### PR TITLE
TICKET-01: Docker + PostgreSQL dev environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# BRAIN 3.0 — Development Environment Variables
+# Copy this file to .env and adjust values as needed:
+#   cp .env.example .env
+
+# PostgreSQL
+POSTGRES_USER=brain3
+POSTGRES_PASSWORD=brain3_dev
+POSTGRES_DB=brain3_dev
+POSTGRES_PORT=5432

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,5 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - System design document — seven-pillar data model, full schema, architecture, ADHD design principles, phased delivery plan, and resolved design decisions
 - Project repository with README and documentation structure
+- Docker Compose dev environment with PostgreSQL 16-alpine (#1)
+- Developer setup guide with start/stop/reset procedures (#1)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,18 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: brain3-postgres-dev
+    restart: unless-stopped
+    env_file: .env
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - brain3_dev_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-brain3}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  brain3_dev_data:

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,78 @@
+# Developer Setup Guide
+
+## Prerequisites
+
+- **Docker Desktop** — [Install](https://docs.docker.com/desktop/install/windows-install/) and ensure it is running.
+- **Git** — For cloning the repository.
+- **Python 3.12+** — For running the FastAPI app locally (later tickets).
+
+## Initial Setup
+
+1. Clone the repository:
+
+   ```bash
+   git clone <repo-url> brain3
+   cd brain3
+   ```
+
+2. Create your local environment file:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Edit `.env` if you need to change the default values (port, credentials, etc.).
+
+## Database — Start / Stop / Reset
+
+### Start
+
+```bash
+docker compose -f docker-compose.dev.yml up -d
+```
+
+### Verify
+
+```bash
+docker compose -f docker-compose.dev.yml exec postgres pg_isready -U brain3
+```
+
+You should see: `/var/run/postgresql:5432 - accepting connections`
+
+### Stop (preserves data)
+
+```bash
+docker compose -f docker-compose.dev.yml down
+```
+
+### Reset (wipe all data)
+
+```bash
+docker compose -f docker-compose.dev.yml down -v
+```
+
+The `-v` flag removes the `brain3_dev_data` volume, deleting all database contents.
+
+## Connecting to the Database
+
+| Setting  | Value           |
+|----------|-----------------|
+| Host     | `localhost`     |
+| Port     | `5432`          |
+| Database | `brain3_dev`    |
+| User     | `brain3`        |
+| Password | `brain3_dev`    |
+
+### psql (from inside the container)
+
+```bash
+docker compose -f docker-compose.dev.yml exec postgres psql -U brain3 -d brain3_dev
+```
+
+### Connection string
+
+```
+postgresql://brain3:brain3_dev@localhost:5432/brain3_dev
+```
+
+Use this in `.env` for the FastAPI app (added in a later ticket).


### PR DESCRIPTION
## Summary
Set up the local development environment with PostgreSQL 16 running in Docker Desktop. This provides the database foundation that all subsequent Phase 1 tickets build on.

## Changes
- **`.env.example`** — Environment variable template with dev credentials (`brain3`/`brain3_dev`) for PostgreSQL user, password, database name, and port.
- **`docker-compose.dev.yml`** — Dev-only Compose file defining a PostgreSQL 16-alpine service with a named volume (`brain3_dev_data`), `pg_isready` health check, and configurable port mapping via `.env`.
- **`docs/dev-setup.md`** — Developer setup guide covering prerequisites, initial setup, start/stop/reset commands, and database connection info.
- **`CHANGELOG.md`** — Added entries for the Docker environment and setup guide.

## How to Verify
1. Copy env template: `cp .env.example .env`
2. Start the database: `docker compose -f docker-compose.dev.yml up -d`
3. Check health: `docker compose -f docker-compose.dev.yml ps` (should show "healthy")
4. Verify connectivity: `docker compose -f docker-compose.dev.yml exec postgres pg_isready -U brain3`
5. Test psql: `docker compose -f docker-compose.dev.yml exec postgres psql -U brain3 -d brain3_dev -c "SELECT 1;"`
6. Clean up: `docker compose -f docker-compose.dev.yml down`

## Deviations
None — fully aligned with ticket spec.

## Test Results
Docker Compose starts successfully, container reaches healthy state, and PostgreSQL accepts connections. Verified locally on Windows with Docker Desktop.

## Acceptance Checklist
- [x] `docker-compose.dev.yml` defines a PostgreSQL 16-alpine service
- [x] Named volume `brain3_dev_data` for persistent database storage across container restarts
- [x] Health check configured on the Postgres container (`pg_isready`)
- [x] Container exposes port 5432 to localhost (configurable via .env)
- [x] `.env.example` includes: `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_PORT`
- [x] `docs/dev-setup.md` covers: prerequisites, setup steps, start/stop/reset, client connection
- [x] Verification: `docker compose -f docker-compose.dev.yml up -d` starts Postgres and `pg_isready` returns success

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)