### PR TITLE
TICKET-13: GitHub Actions CI workflow with test and lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: brain3_test
+          POSTGRES_PASSWORD: brain3_test
+          POSTGRES_DB: brain3_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U brain3_test"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      POSTGRES_USER: brain3_test
+      POSTGRES_PASSWORD: brain3_test
+      POSTGRES_DB: brain3_test
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: 5432
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run Alembic migrations
+        run: |
+          if [ -d alembic ]; then
+            alembic upgrade head
+          else
+            echo "No alembic directory found — skipping migrations"
+          fi
+
+      - name: Run tests
+        run: pytest -v || [ $? -eq 5 ]
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Run Ruff
+        run: ruff check .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,5 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Developer setup guide with start/stop/reset procedures (#1)
 - FastAPI application scaffold with config, database layer, and health check (#2)
 - Requirements.txt with pinned Phase 1 dependencies (#2)
+- GitHub Actions CI workflow with test and lint jobs (#13)
+- Ruff linter configuration with project standards (#13)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+"alembic/*" = ["E", "F", "W", "I"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# BRAIN 3.0 — Development Dependencies
+-r requirements.txt
+ruff==0.11.6
+pytest==8.3.5


### PR DESCRIPTION
## Summary
Added a GitHub Actions CI workflow that automatically runs tests and linting on every PR to `develop`. This gives the reviewer an automated green/red signal before reviewing code.

## Changes
- **`.github/workflows/ci.yml`** — CI workflow with two jobs: **test** (PostgreSQL 16 service container, pip install, Alembic migrations if present, pytest) and **lint** (Ruff check). Triggers on PRs to `develop` and pushes to `develop`. Uses pip caching for faster runs.
- **`pyproject.toml`** — Ruff configuration: line-length 100 (matches project standard), Python 3.12 target, E/F/W/I rule selection, alembic directory excluded. Also includes pytest config pointing to `tests/` directory.
- **`requirements-dev.txt`** — Dev-only dependencies (ruff, pytest) inheriting from `requirements.txt`.
- **`CHANGELOG.md`** — Added TICKET-13 entries.

## How to Verify
**Locally:**
```bash
pip install -r requirements-dev.txt
ruff check .          # Should pass with "All checks passed!"
pytest -v             # 0 tests collected (expected — tests come in TICKET-03)
```

**On GitHub:**
1. Check the Actions tab on this PR — both Test and Lint jobs should show green
2. Alembic migration step should print "No alembic directory found — skipping migrations"
3. Pytest should pass with 0 tests collected (exit code 5 handled gracefully)

## Deviations
- Added `requirements-dev.txt` for dev-only deps — ticket mentioned this as an option vs adding ruff to `requirements.txt`
- Used `pyproject.toml` for Ruff config — ticket allowed either `pyproject.toml` or `ruff.toml`
- Pytest exit code 5 (no tests collected) is treated as a pass until TICKET-03 adds tests

## Test Results
```
$ ruff check .
All checks passed!

$ pytest -v
collected 0 items
```

## Acceptance Checklist
- [x] `.github/workflows/ci.yml` exists and is valid
- [x] Workflow triggers on PRs to `develop` and pushes to `develop`
- [x] Test job spins up PostgreSQL 16 service container
- [x] Test job installs Python 3.12 and project dependencies
- [x] Test job runs `pytest -v` and reports pass/fail
- [x] Lint job runs Ruff and reports pass/fail
- [x] Both jobs must pass for the workflow to show green
- [x] Workflow runs successfully on the current codebase
- [x] Ruff configuration added in `pyproject.toml` with line length 100

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)