### PR TITLE
TICKET-10: Reporting and aggregation endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,17 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import text
 
 from app.database import SessionLocal
-from app.routers import activity, checkins, domains, goals, projects, routines, tags, tasks
+from app.routers import (
+    activity,
+    checkins,
+    domains,
+    goals,
+    projects,
+    reports,
+    routines,
+    tags,
+    tasks,
+)
 
 app = FastAPI(
     title="BRAIN 3.0",
@@ -48,4 +58,5 @@ app.include_router(tags.router, prefix="/api/tags", tags=["Tags"])
 app.include_router(routines.router, prefix="/api/routines", tags=["Routines"])
 app.include_router(checkins.router, prefix="/api/checkins", tags=["Check-ins"])
 app.include_router(activity.router, prefix="/api/activity", tags=["Activity Log"])
+app.include_router(reports.router, prefix="/api/reports", tags=["Reports"])
 app.include_router(tags.task_tags_router, prefix="/api/tasks", tags=["Task Tags"])

--- a/app/routers/reports.py
+++ b/app/routers/reports.py
@@ -1,0 +1,391 @@
+"""Read-only aggregation and pattern-recognition endpoints."""
+
+from __future__ import annotations
+
+import math
+from datetime import date, datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import (
+    ActivityLog,
+    Domain,
+    Goal,
+    Project,
+    Routine,
+    RoutineSchedule,
+    Task,
+)
+from app.schemas.reports import (
+    ActivitySummaryResponse,
+    DomainBalanceResponse,
+    FrictionAnalysisResponse,
+    RoutineAdherenceResponse,
+)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# 1. Activity Summary
+# ---------------------------------------------------------------------------
+
+
+@router.get("/activity-summary", response_model=ActivitySummaryResponse)
+def activity_summary(
+    after: datetime = Query(...),
+    before: datetime = Query(...),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Aggregated activity stats for a date range."""
+    base = db.query(ActivityLog).filter(
+        ActivityLog.logged_at >= after,
+        ActivityLog.logged_at <= before,
+    )
+
+    entries_count = base.count()
+
+    total_completed = base.filter(ActivityLog.action_type == "completed").count()
+    total_skipped = base.filter(ActivityLog.action_type == "skipped").count()
+    total_deferred = base.filter(ActivityLog.action_type == "deferred").count()
+
+    duration_sum = base.with_entities(
+        func.coalesce(func.sum(ActivityLog.duration_minutes), 0),
+    ).scalar()
+
+    # Average energy delta where both before and after are present
+    energy_delta = base.filter(
+        ActivityLog.energy_before.isnot(None),
+        ActivityLog.energy_after.isnot(None),
+    ).with_entities(
+        func.avg(ActivityLog.energy_after - ActivityLog.energy_before),
+    ).scalar()
+
+    avg_mood = base.filter(
+        ActivityLog.mood_rating.isnot(None),
+    ).with_entities(
+        func.avg(ActivityLog.mood_rating),
+    ).scalar()
+
+    return {
+        "period_start": after,
+        "period_end": before,
+        "total_completed": total_completed,
+        "total_skipped": total_skipped,
+        "total_deferred": total_deferred,
+        "total_duration_minutes": duration_sum or 0,
+        "avg_energy_delta": round(float(energy_delta), 2) if energy_delta is not None else None,
+        "avg_mood": round(float(avg_mood), 2) if avg_mood is not None else None,
+        "entries_count": entries_count,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2. Domain Balance
+# ---------------------------------------------------------------------------
+
+
+@router.get("/domain-balance", response_model=list[DomainBalanceResponse])
+def domain_balance(db: Session = Depends(get_db)) -> list[dict]:
+    """Per-domain counts of active items and recency."""
+    domains = db.query(Domain).order_by(Domain.sort_order, Domain.name).all()
+    today = date.today()
+    results = []
+
+    for domain in domains:
+        # Active goals
+        active_goals = (
+            db.query(func.count(Goal.id))
+            .filter(Goal.domain_id == domain.id, Goal.status == "active")
+            .scalar()
+        )
+
+        # Active projects under this domain's goals
+        active_projects = (
+            db.query(func.count(Project.id))
+            .join(Goal, Project.goal_id == Goal.id)
+            .filter(Goal.domain_id == domain.id, Project.status == "active")
+            .scalar()
+        )
+
+        # Pending tasks under this domain's goals → projects
+        pending_tasks = (
+            db.query(func.count(Task.id))
+            .join(Project, Task.project_id == Project.id)
+            .join(Goal, Project.goal_id == Goal.id)
+            .filter(Goal.domain_id == domain.id, Task.status == "pending")
+            .scalar()
+        )
+
+        # Overdue tasks
+        overdue_tasks = (
+            db.query(func.count(Task.id))
+            .join(Project, Task.project_id == Project.id)
+            .join(Goal, Project.goal_id == Goal.id)
+            .filter(
+                Goal.domain_id == domain.id,
+                Task.due_date < today,
+                Task.status.notin_(["completed", "skipped", "abandoned"]),
+            )
+            .scalar()
+        )
+
+        # Days since last activity — via tasks or routines in this domain
+        last_task_activity = (
+            db.query(func.max(ActivityLog.logged_at))
+            .join(Task, ActivityLog.task_id == Task.id)
+            .join(Project, Task.project_id == Project.id)
+            .join(Goal, Project.goal_id == Goal.id)
+            .filter(Goal.domain_id == domain.id)
+            .scalar()
+        )
+        last_routine_activity = (
+            db.query(func.max(ActivityLog.logged_at))
+            .join(Routine, ActivityLog.routine_id == Routine.id)
+            .filter(Routine.domain_id == domain.id)
+            .scalar()
+        )
+
+        last_activity = None
+        for ts in [last_task_activity, last_routine_activity]:
+            if ts is not None:
+                if last_activity is None or ts > last_activity:
+                    last_activity = ts
+
+        days_since = None
+        if last_activity is not None:
+            if hasattr(last_activity, "date"):
+                days_since = (today - last_activity.date()).days
+            else:
+                days_since = (today - last_activity).days
+
+        results.append({
+            "domain_id": domain.id,
+            "domain_name": domain.name,
+            "active_goals": active_goals,
+            "active_projects": active_projects,
+            "pending_tasks": pending_tasks,
+            "overdue_tasks": overdue_tasks,
+            "days_since_last_activity": days_since,
+        })
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# 3. Routine Adherence
+# ---------------------------------------------------------------------------
+
+
+def _count_expected(
+    frequency: str,
+    start: datetime,
+    end: datetime,
+    schedules: list[RoutineSchedule] | None = None,
+) -> int:
+    """Calculate expected completions for a routine in a date range."""
+    # Work with dates
+    start_date = start.date() if hasattr(start, "date") else start
+    end_date = end.date() if hasattr(end, "date") else end
+    total_days = (end_date - start_date).days + 1
+    if total_days <= 0:
+        return 0
+
+    if frequency == "daily":
+        return total_days
+    elif frequency == "weekdays":
+        count = 0
+        for i in range(total_days):
+            if (start_date + timedelta(days=i)).weekday() < 5:
+                count += 1
+        return count
+    elif frequency == "weekends":
+        count = 0
+        for i in range(total_days):
+            if (start_date + timedelta(days=i)).weekday() >= 5:
+                count += 1
+        return count
+    elif frequency == "weekly":
+        return math.ceil(total_days / 7)
+    elif frequency == "custom":
+        if not schedules:
+            return math.ceil(total_days / 7)
+        day_map = {
+            "monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3,
+            "friday": 4, "saturday": 5, "sunday": 6,
+        }
+        scheduled_days = {
+            day_map[s.day_of_week.lower()]
+            for s in schedules
+            if s.day_of_week and s.day_of_week.lower() in day_map
+        }
+        if not scheduled_days:
+            return math.ceil(total_days / 7)
+        count = 0
+        for i in range(total_days):
+            if (start_date + timedelta(days=i)).weekday() in scheduled_days:
+                count += 1
+        return count
+    return total_days
+
+
+@router.get("/routine-adherence", response_model=list[RoutineAdherenceResponse])
+def routine_adherence(
+    after: datetime = Query(...),
+    before: datetime = Query(...),
+    db: Session = Depends(get_db),
+) -> list[dict]:
+    """Per-routine completion rates and streak health."""
+    routines = (
+        db.query(Routine)
+        .filter(Routine.status.in_(["active", "paused"]))
+        .all()
+    )
+    results = []
+
+    for routine in routines:
+        completions = (
+            db.query(func.count(ActivityLog.id))
+            .filter(
+                ActivityLog.routine_id == routine.id,
+                ActivityLog.action_type == "completed",
+                ActivityLog.logged_at >= after,
+                ActivityLog.logged_at <= before,
+            )
+            .scalar()
+        )
+
+        schedules = (
+            db.query(RoutineSchedule)
+            .filter(RoutineSchedule.routine_id == routine.id)
+            .all()
+        )
+
+        expected = _count_expected(routine.frequency, after, before, schedules)
+        adherence = min(completions / expected * 100, 100.0) if expected > 0 else 0.0
+
+        # Get domain name
+        domain = db.query(Domain).filter(Domain.id == routine.domain_id).first()
+
+        results.append({
+            "routine_id": routine.id,
+            "routine_title": routine.title,
+            "domain_name": domain.name if domain else "Unknown",
+            "frequency": routine.frequency,
+            "completions_in_period": completions,
+            "expected_in_period": expected,
+            "adherence_pct": round(adherence, 1),
+            "current_streak": routine.current_streak,
+            "best_streak": routine.best_streak,
+            "streak_is_broken": routine.current_streak == 0 and routine.status == "active",
+        })
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# 4. Friction Analysis
+# ---------------------------------------------------------------------------
+
+
+@router.get("/friction-analysis", response_model=list[FrictionAnalysisResponse])
+def friction_analysis(
+    after: datetime | None = Query(None),
+    before: datetime | None = Query(None),
+    db: Session = Depends(get_db),
+) -> list[dict]:
+    """Predicted vs actual friction by cognitive type."""
+    if after is None:
+        after = datetime.now(tz=timezone.utc) - timedelta(days=30)
+    if before is None:
+        before = datetime.now(tz=timezone.utc)
+
+    # Base query: activity log entries joined to tasks with cognitive_type
+    base = (
+        db.query(
+            Task.cognitive_type,
+            ActivityLog.action_type,
+            Task.activation_friction,
+            ActivityLog.friction_actual,
+            Task.energy_cost,
+            ActivityLog.energy_before,
+            ActivityLog.energy_after,
+        )
+        .join(Task, ActivityLog.task_id == Task.id)
+        .filter(
+            ActivityLog.logged_at >= after,
+            ActivityLog.logged_at <= before,
+            Task.cognitive_type.isnot(None),
+        )
+        .all()
+    )
+
+    # Group by cognitive_type
+    groups: dict[str, list] = {}
+    for row in base:
+        ct = row[0]  # cognitive_type
+        if ct not in groups:
+            groups[ct] = []
+        groups[ct].append(row)
+
+    results = []
+    for cognitive_type, rows in sorted(groups.items()):
+        friction_predicted = []
+        friction_actual = []
+        energy_costs = []
+        energy_deltas = []
+        completed = 0
+        skipped = 0
+        deferred = 0
+
+        for row in rows:
+            action_type = row[1]
+            pred_friction = row[2]
+            act_friction = row[3]
+            energy_cost = row[4]
+            energy_before = row[5]
+            energy_after = row[6]
+
+            if action_type == "completed":
+                completed += 1
+            elif action_type == "skipped":
+                skipped += 1
+            elif action_type == "deferred":
+                deferred += 1
+
+            if pred_friction is not None and act_friction is not None:
+                friction_predicted.append(pred_friction)
+                friction_actual.append(act_friction)
+
+            if energy_cost is not None:
+                energy_costs.append(energy_cost)
+
+            if energy_before is not None and energy_after is not None:
+                energy_deltas.append(energy_after - energy_before)
+
+        task_count = len(rows)
+        total_actions = completed + skipped + deferred
+        completion_rate = (completed / total_actions * 100) if total_actions > 0 else 0.0
+
+        avg_pred = sum(friction_predicted) / len(friction_predicted) if friction_predicted else 0.0
+        avg_act = sum(friction_actual) / len(friction_actual) if friction_actual else 0.0
+
+        results.append({
+            "cognitive_type": cognitive_type,
+            "task_count": task_count,
+            "avg_predicted_friction": round(avg_pred, 2),
+            "avg_actual_friction": round(avg_act, 2),
+            "friction_gap": round(avg_pred - avg_act, 2),
+            "completion_rate": round(completion_rate, 1),
+            "avg_energy_cost": (
+                round(sum(energy_costs) / len(energy_costs), 2) if energy_costs else 0.0
+            ),
+            "avg_energy_delta": (
+                round(sum(energy_deltas) / len(energy_deltas), 2) if energy_deltas else None
+            ),
+        })
+
+    return results

--- a/app/schemas/reports.py
+++ b/app/schemas/reports.py
@@ -1,0 +1,62 @@
+"""Pydantic response schemas for reporting and aggregation endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class ActivitySummaryResponse(BaseModel):
+    """Aggregated activity stats for a date range."""
+
+    period_start: datetime
+    period_end: datetime
+    total_completed: int
+    total_skipped: int
+    total_deferred: int
+    total_duration_minutes: int
+    avg_energy_delta: float | None
+    avg_mood: float | None
+    entries_count: int
+
+
+class DomainBalanceResponse(BaseModel):
+    """Per-domain counts of active items and recency."""
+
+    domain_id: UUID
+    domain_name: str
+    active_goals: int
+    active_projects: int
+    pending_tasks: int
+    overdue_tasks: int
+    days_since_last_activity: int | None
+
+
+class RoutineAdherenceResponse(BaseModel):
+    """Per-routine completion rates and streak health."""
+
+    routine_id: UUID
+    routine_title: str
+    domain_name: str
+    frequency: str
+    completions_in_period: int
+    expected_in_period: int
+    adherence_pct: float
+    current_streak: int
+    best_streak: int
+    streak_is_broken: bool
+
+
+class FrictionAnalysisResponse(BaseModel):
+    """Predicted vs actual friction by cognitive type."""
+
+    cognitive_type: str
+    task_count: int
+    avg_predicted_friction: float
+    avg_actual_friction: float
+    friction_gap: float
+    completion_rate: float
+    avg_energy_cost: float
+    avg_energy_delta: float | None

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,355 @@
+"""Tests for reporting and aggregation endpoints."""
+
+import uuid as _uuid
+from datetime import date, datetime, timedelta, timezone
+
+from app.models import ActivityLog
+from tests.conftest import make_domain, make_goal, make_project, make_routine, make_task
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _setup_domain_hierarchy(client):
+    """Create domain → goal → project → task chain and return all IDs."""
+    domain = make_domain(client, name="Health")
+    goal = make_goal(client, domain["id"], title="Exercise more")
+    project = make_project(client, goal["id"], title="Gym plan")
+    task = make_task(client, project_id=project["id"], title="Go to gym")
+    return domain, goal, project, task
+
+
+def _log_activity(db, **kwargs):
+    """Insert an activity log entry directly via ORM."""
+    # Convert string UUIDs to proper UUID objects for SQLite compatibility
+    for key in ("task_id", "routine_id", "checkin_id"):
+        if key in kwargs and isinstance(kwargs[key], str):
+            kwargs[key] = _uuid.UUID(kwargs[key])
+    entry = ActivityLog(**kwargs)
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# GET /api/reports/activity-summary
+# ---------------------------------------------------------------------------
+
+class TestActivitySummary:
+
+    def test_empty_range(self, client):
+        resp = client.get(
+            "/api/reports/activity-summary"
+            "?after=2026-03-01T00:00:00&before=2026-03-07T23:59:59"
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["entries_count"] == 0
+        assert body["total_completed"] == 0
+        assert body["total_skipped"] == 0
+        assert body["total_deferred"] == 0
+        assert body["total_duration_minutes"] == 0
+        assert body["avg_energy_delta"] is None
+        assert body["avg_mood"] is None
+
+    def test_aggregations(self, client, db):
+        _log_activity(
+            db, action_type="completed", duration_minutes=30,
+            energy_before=2, energy_after=4, mood_rating=4,
+            logged_at=datetime(2026, 3, 5, 10, 0, tzinfo=timezone.utc),
+        )
+        _log_activity(
+            db, action_type="completed", duration_minutes=15,
+            energy_before=3, energy_after=2, mood_rating=3,
+            logged_at=datetime(2026, 3, 5, 14, 0, tzinfo=timezone.utc),
+        )
+        _log_activity(
+            db, action_type="skipped",
+            logged_at=datetime(2026, 3, 5, 16, 0, tzinfo=timezone.utc),
+        )
+        _log_activity(
+            db, action_type="deferred",
+            logged_at=datetime(2026, 3, 6, 10, 0, tzinfo=timezone.utc),
+        )
+
+        resp = client.get(
+            "/api/reports/activity-summary"
+            "?after=2026-03-01T00:00:00&before=2026-03-07T23:59:59"
+        )
+        body = resp.json()
+        assert body["entries_count"] == 4
+        assert body["total_completed"] == 2
+        assert body["total_skipped"] == 1
+        assert body["total_deferred"] == 1
+        assert body["total_duration_minutes"] == 45
+        # avg energy delta: (4-2 + 2-3) / 2 = (2 + -1) / 2 = 0.5
+        assert body["avg_energy_delta"] == 0.5
+        # avg mood: (4 + 3) / 2 = 3.5
+        assert body["avg_mood"] == 3.5
+
+    def test_date_range_exclusion(self, client, db):
+        _log_activity(
+            db, action_type="completed",
+            logged_at=datetime(2026, 3, 5, 10, 0, tzinfo=timezone.utc),
+        )
+        _log_activity(
+            db, action_type="completed",
+            logged_at=datetime(2026, 4, 5, 10, 0, tzinfo=timezone.utc),
+        )
+        resp = client.get(
+            "/api/reports/activity-summary"
+            "?after=2026-03-01T00:00:00&before=2026-03-31T23:59:59"
+        )
+        assert resp.json()["entries_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /api/reports/domain-balance
+# ---------------------------------------------------------------------------
+
+class TestDomainBalance:
+
+    def test_empty_domains(self, client):
+        make_domain(client, name="Empty")
+        resp = client.get("/api/reports/domain-balance")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 1
+        assert body[0]["domain_name"] == "Empty"
+        assert body[0]["active_goals"] == 0
+        assert body[0]["active_projects"] == 0
+        assert body[0]["pending_tasks"] == 0
+        assert body[0]["overdue_tasks"] == 0
+        assert body[0]["days_since_last_activity"] is None
+
+    def test_counts(self, client):
+        domain = make_domain(client, name="Health")
+        goal = make_goal(client, domain["id"], title="Exercise")
+        # paused goal shouldn't count
+        make_goal(client, domain["id"], title="Paused", status="paused")
+        project = make_project(client, goal["id"], title="Gym")
+        # Activate the project
+        client.patch(f"/api/projects/{project['id']}", json={"status": "active"})
+        make_task(client, project_id=project["id"], title="Task 1")
+        make_task(client, project_id=project["id"], title="Task 2")
+
+        resp = client.get("/api/reports/domain-balance")
+        body = resp.json()
+        d = body[0]
+        assert d["active_goals"] == 1
+        assert d["active_projects"] == 1
+        assert d["pending_tasks"] == 2
+
+    def test_overdue_tasks(self, client):
+        domain, goal, project, task = _setup_domain_hierarchy(client)
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        make_task(
+            client, project_id=project["id"], title="Overdue",
+            due_date=yesterday, status="pending",
+        )
+        resp = client.get("/api/reports/domain-balance")
+        assert resp.json()[0]["overdue_tasks"] == 1
+
+    def test_days_since_activity(self, client, db):
+        domain, goal, project, task = _setup_domain_hierarchy(client)
+        _log_activity(
+            db, task_id=task["id"], action_type="completed",
+            logged_at=datetime(2026, 3, 20, 10, 0, tzinfo=timezone.utc),
+        )
+        resp = client.get("/api/reports/domain-balance")
+        d = resp.json()[0]
+        assert d["days_since_last_activity"] is not None
+        assert d["days_since_last_activity"] >= 0
+
+    def test_days_since_routine_activity(self, client, db):
+        domain = make_domain(client, name="Health")
+        routine = make_routine(client, domain["id"], title="Walk")
+        _log_activity(
+            db, routine_id=routine["id"], action_type="completed",
+            logged_at=datetime(2026, 3, 20, 10, 0, tzinfo=timezone.utc),
+        )
+        resp = client.get("/api/reports/domain-balance")
+        d = resp.json()[0]
+        assert d["days_since_last_activity"] is not None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/reports/routine-adherence
+# ---------------------------------------------------------------------------
+
+class TestRoutineAdherence:
+
+    def test_empty(self, client):
+        resp = client.get(
+            "/api/reports/routine-adherence"
+            "?after=2026-03-01T00:00:00&before=2026-03-07T23:59:59"
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_daily_routine(self, client, db):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"], title="Meditate", frequency="daily")
+        # Log 5 completions in a 7-day period
+        for day in range(1, 6):
+            _log_activity(
+                db, routine_id=routine["id"], action_type="completed",
+                logged_at=datetime(2026, 3, day, 8, 0, tzinfo=timezone.utc),
+            )
+        resp = client.get(
+            "/api/reports/routine-adherence"
+            "?after=2026-03-01T00:00:00&before=2026-03-07T23:59:59"
+        )
+        body = resp.json()
+        assert len(body) == 1
+        r = body[0]
+        assert r["routine_title"] == "Meditate"
+        assert r["completions_in_period"] == 5
+        assert r["expected_in_period"] == 7
+        assert r["adherence_pct"] == 71.4
+
+    def test_weekly_routine(self, client, db):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"], title="Review", frequency="weekly")
+        _log_activity(
+            db, routine_id=routine["id"], action_type="completed",
+            logged_at=datetime(2026, 3, 3, 10, 0, tzinfo=timezone.utc),
+        )
+        # 14 days = 2 weeks expected
+        resp = client.get(
+            "/api/reports/routine-adherence"
+            "?after=2026-03-01T00:00:00&before=2026-03-14T23:59:59"
+        )
+        r = resp.json()[0]
+        assert r["expected_in_period"] == 2
+        assert r["completions_in_period"] == 1
+        assert r["adherence_pct"] == 50.0
+
+    def test_adherence_capped_at_100(self, client, db):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"], title="Walk", frequency="weekly")
+        # Log 3 completions in a 7-day period (expected=1)
+        for day in [1, 3, 5]:
+            _log_activity(
+                db, routine_id=routine["id"], action_type="completed",
+                logged_at=datetime(2026, 3, day, 8, 0, tzinfo=timezone.utc),
+            )
+        resp = client.get(
+            "/api/reports/routine-adherence"
+            "?after=2026-03-01T00:00:00&before=2026-03-07T23:59:59"
+        )
+        assert resp.json()[0]["adherence_pct"] == 100.0
+
+    def test_streak_is_broken(self, client):
+        domain = make_domain(client)
+        make_routine(client, domain["id"], title="Broken", frequency="daily")
+        resp = client.get(
+            "/api/reports/routine-adherence"
+            "?after=2026-03-01T00:00:00&before=2026-03-07T23:59:59"
+        )
+        r = resp.json()[0]
+        assert r["current_streak"] == 0
+        assert r["streak_is_broken"] is True
+
+    def test_weekday_expected(self, client, db):
+        domain = make_domain(client)
+        make_routine(client, domain["id"], title="Work", frequency="weekdays")
+        # 2026-03-02 is Monday, 2026-03-08 is Sunday — 5 weekdays
+        resp = client.get(
+            "/api/reports/routine-adherence"
+            "?after=2026-03-02T00:00:00&before=2026-03-08T23:59:59"
+        )
+        assert resp.json()[0]["expected_in_period"] == 5
+
+
+# ---------------------------------------------------------------------------
+# GET /api/reports/friction-analysis
+# ---------------------------------------------------------------------------
+
+class TestFrictionAnalysis:
+
+    def test_empty(self, client):
+        resp = client.get(
+            "/api/reports/friction-analysis"
+            "?after=2026-03-01T00:00:00&before=2026-03-31T23:59:59"
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_friction_grouping(self, client, db):
+        # Create tasks with cognitive types
+        t1 = make_task(
+            client, title="Phone call",
+            cognitive_type="communication", activation_friction=4, energy_cost=3,
+        )
+        t2 = make_task(
+            client, title="Email",
+            cognitive_type="communication", activation_friction=3, energy_cost=2,
+        )
+        t3 = make_task(
+            client, title="Deep work",
+            cognitive_type="focus_work", activation_friction=5, energy_cost=5,
+        )
+
+        # Log activities
+        _log_activity(
+            db, task_id=t1["id"], action_type="completed",
+            friction_actual=2, energy_before=3, energy_after=2,
+            logged_at=datetime(2026, 3, 5, 10, 0, tzinfo=timezone.utc),
+        )
+        _log_activity(
+            db, task_id=t2["id"], action_type="skipped",
+            friction_actual=3,
+            logged_at=datetime(2026, 3, 5, 14, 0, tzinfo=timezone.utc),
+        )
+        _log_activity(
+            db, task_id=t3["id"], action_type="completed",
+            friction_actual=3, energy_before=4, energy_after=1,
+            logged_at=datetime(2026, 3, 5, 16, 0, tzinfo=timezone.utc),
+        )
+
+        resp = client.get(
+            "/api/reports/friction-analysis"
+            "?after=2026-03-01T00:00:00&before=2026-03-31T23:59:59"
+        )
+        body = resp.json()
+        assert len(body) == 2
+
+        comm = next(r for r in body if r["cognitive_type"] == "communication")
+        assert comm["task_count"] == 2
+        # avg predicted: (4+3)/2 = 3.5, avg actual: (2+3)/2 = 2.5
+        assert comm["avg_predicted_friction"] == 3.5
+        assert comm["avg_actual_friction"] == 2.5
+        assert comm["friction_gap"] == 1.0  # overestimates
+        assert comm["completion_rate"] == 50.0  # 1 completed, 1 skipped
+
+        focus = next(r for r in body if r["cognitive_type"] == "focus_work")
+        assert focus["task_count"] == 1
+        assert focus["avg_energy_delta"] == -3.0  # 1 - 4
+
+    def test_defaults_to_30_days(self, client, db):
+        task = make_task(
+            client, title="Recent",
+            cognitive_type="errand", activation_friction=2, energy_cost=1,
+        )
+        _log_activity(
+            db, task_id=task["id"], action_type="completed",
+            friction_actual=1,
+            logged_at=datetime.now(tz=timezone.utc) - timedelta(days=5),
+        )
+        resp = client.get("/api/reports/friction-analysis")
+        assert len(resp.json()) == 1
+
+    def test_excludes_no_cognitive_type(self, client, db):
+        task = make_task(client, title="No type")
+        _log_activity(
+            db, task_id=task["id"], action_type="completed",
+            friction_actual=1,
+            logged_at=datetime(2026, 3, 5, 10, 0, tzinfo=timezone.utc),
+        )
+        resp = client.get(
+            "/api/reports/friction-analysis"
+            "?after=2026-03-01T00:00:00&before=2026-03-31T23:59:59"
+        )
+        assert resp.json() == []


### PR DESCRIPTION
## Summary

Implements four read-only aggregation endpoints that power Claude's reasoning as a partner. These are the queries that let Claude move beyond "what tasks do you have?" to "how are you actually doing?" — weekly summaries, domain balance monitoring, routine health, and friction pattern analysis.

## Changes

- **`app/schemas/reports.py`** (new) — Pydantic response schemas for all four reports: `ActivitySummaryResponse`, `DomainBalanceResponse`, `RoutineAdherenceResponse`, `FrictionAnalysisResponse`.
- **`app/routers/reports.py`** (new) — Four GET endpoints:
  - `/activity-summary?after=&before=` — aggregated counts, duration, energy delta, mood
  - `/domain-balance` — per-domain active items, overdue tasks, days since last activity (joins domain→goals→projects→tasks→activity_log + domain→routines→activity_log)
  - `/routine-adherence?after=&before=` — per-routine completion rates with frequency-aware expected counts and streak health
  - `/friction-analysis?after=&before=` — predicted vs actual friction grouped by cognitive type, with completion rates and energy deltas
- **`app/main.py`** (modified) — Registered reports router under `/api/reports`.
- **`tests/test_reports.py`** (new) — 18 tests covering all four endpoints including edge cases (empty data, date range exclusion, overdue detection, adherence capping, friction grouping).

## How to Verify

1. Start the dev environment: `docker compose -f docker-compose.dev.yml up -d`
2. Run the API: `uvicorn app.main:app --reload`
3. Visit `http://localhost:8000/docs` — verify Reports section appears with all four endpoints
4. Run tests: `pytest -v` — all 243 tests should pass (18 new + 225 existing)
5. Manual smoke test:
   - Create some domains, goals, projects, tasks, routines, and activity log entries
   - `GET /api/reports/activity-summary?after=2026-03-01T00:00:00&before=2026-03-31T23:59:59`
   - `GET /api/reports/domain-balance` → per-domain health overview
   - `GET /api/reports/routine-adherence?after=2026-03-01T00:00:00&before=2026-03-07T23:59:59`
   - `GET /api/reports/friction-analysis` → grouped by cognitive type

## Deviations

None — implementation fully aligns with the ticket spec.

## Test Results

```
pytest -v
243 passed in 2.28s

ruff check .
All checks passed!
```

18 new tests alongside 225 existing tests with zero regressions.

## Acceptance Checklist

- [x] Pydantic response schemas defined for all four reports
- [x] Activity summary endpoint returns correct aggregations for a date range
- [x] Activity summary handles empty date ranges gracefully (returns zeros)
- [x] Domain balance returns all domains with accurate counts
- [x] Domain balance correctly calculates days_since_last_activity across the domain hierarchy (domain → goals → projects → tasks → activity log)
- [x] Domain balance returns null for days_since_last_activity when no activity exists for a domain
- [x] Routine adherence calculates expected completions correctly for each frequency type (daily, weekdays, weekends, weekly)
- [x] Routine adherence caps adherence_pct at 100 (completing extra doesn't exceed 100%)
- [x] Friction analysis groups by cognitive_type and calculates averages correctly
- [x] Friction analysis only includes cognitive types that have activity log entries in the period
- [x] All endpoints return well-structured JSON matching the defined schemas
- [x] All endpoints handle edge cases: no data in period, no activity log entries, routines with no completions
- [x] Date range parameters use consistent datetime format across all endpoints
- [x] All endpoints visible and testable at `/docs`

Closes #10