### PR TITLE
ISSUE-26: Add Pydantic Literal validation to all enum-like string fields

### DIFF
--- a/app/schemas/activity.py
+++ b/app/schemas/activity.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+ActionType = Literal[
+    "completed", "skipped", "deferred", "started", "reflected", "checked_in"
+]
 
 
 class ActivityLogCreate(BaseModel):
@@ -14,7 +19,7 @@ class ActivityLogCreate(BaseModel):
     task_id: UUID | None = None
     routine_id: UUID | None = None
     checkin_id: UUID | None = None
-    action_type: str
+    action_type: ActionType
     notes: str | None = None
     energy_before: int | None = None
     energy_after: int | None = None
@@ -45,7 +50,7 @@ class ActivityLogUpdate(BaseModel):
     task_id: UUID | None = None
     routine_id: UUID | None = None
     checkin_id: UUID | None = None
-    action_type: str | None = None
+    action_type: ActionType | None = None
     notes: str | None = None
     energy_before: int | None = None
     energy_after: int | None = None
@@ -71,7 +76,7 @@ class ActivityLogResponse(BaseModel):
     task_id: UUID | None = None
     routine_id: UUID | None = None
     checkin_id: UUID | None = None
-    action_type: str
+    action_type: ActionType
     notes: str | None = None
     energy_before: int | None = None
     energy_after: int | None = None

--- a/app/schemas/checkins.py
+++ b/app/schemas/checkins.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, field_validator
+
+CheckinType = Literal["morning", "midday", "evening", "micro", "freeform"]
 
 
 class CheckinCreate(BaseModel):
     """Fields required to log a check-in. Only checkin_type is mandatory."""
 
-    checkin_type: str
+    checkin_type: CheckinType
     energy_level: int | None = None
     mood: int | None = None
     focus_level: int | None = None
@@ -30,7 +33,7 @@ class CheckinCreate(BaseModel):
 class CheckinUpdate(BaseModel):
     """All fields optional — supports partial PATCH updates."""
 
-    checkin_type: str | None = None
+    checkin_type: CheckinType | None = None
     energy_level: int | None = None
     mood: int | None = None
     focus_level: int | None = None
@@ -52,7 +55,7 @@ class CheckinResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: UUID
-    checkin_type: str
+    checkin_type: CheckinType
     energy_level: int | None = None
     mood: int | None = None
     focus_level: int | None = None

--- a/app/schemas/goals.py
+++ b/app/schemas/goals.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
+
+GoalStatus = Literal["active", "paused", "achieved", "abandoned"]
 
 
 class GoalCreate(BaseModel):
@@ -14,7 +17,7 @@ class GoalCreate(BaseModel):
     domain_id: UUID
     title: str
     description: str | None = None
-    status: str = "active"
+    status: GoalStatus = "active"
 
 
 class GoalUpdate(BaseModel):
@@ -23,7 +26,7 @@ class GoalUpdate(BaseModel):
     domain_id: UUID | None = None
     title: str | None = None
     description: str | None = None
-    status: str | None = None
+    status: GoalStatus | None = None
 
 
 class GoalResponse(BaseModel):
@@ -35,7 +38,7 @@ class GoalResponse(BaseModel):
     domain_id: UUID
     title: str
     description: str | None = None
-    status: str
+    status: GoalStatus
     created_at: datetime
     updated_at: datetime
 

--- a/app/schemas/projects.py
+++ b/app/schemas/projects.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from datetime import date, datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
+
+ProjectStatus = Literal["not_started", "active", "blocked", "completed", "abandoned"]
 
 
 class ProjectCreate(BaseModel):
@@ -14,7 +17,7 @@ class ProjectCreate(BaseModel):
     goal_id: UUID
     title: str
     description: str | None = None
-    status: str = "not_started"
+    status: ProjectStatus = "not_started"
     deadline: date | None = None
 
 
@@ -24,7 +27,7 @@ class ProjectUpdate(BaseModel):
     goal_id: UUID | None = None
     title: str | None = None
     description: str | None = None
-    status: str | None = None
+    status: ProjectStatus | None = None
     deadline: date | None = None
 
 
@@ -37,7 +40,7 @@ class ProjectResponse(BaseModel):
     goal_id: UUID
     title: str
     description: str | None = None
-    status: str
+    status: ProjectStatus
     deadline: date | None = None
     progress_pct: int
     created_at: datetime

--- a/app/schemas/routines.py
+++ b/app/schemas/routines.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from datetime import date, datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, field_validator
+
+RoutineFrequency = Literal["daily", "weekdays", "weekends", "weekly", "custom"]
+RoutineStatus = Literal["active", "paused", "retired"]
 
 # ---------------------------------------------------------------------------
 # Routine schemas
@@ -18,8 +22,8 @@ class RoutineCreate(BaseModel):
     domain_id: UUID
     title: str
     description: str | None = None
-    frequency: str
-    status: str = "active"
+    frequency: RoutineFrequency
+    status: RoutineStatus = "active"
     energy_cost: int | None = None
     activation_friction: int | None = None
 
@@ -38,8 +42,8 @@ class RoutineUpdate(BaseModel):
     domain_id: UUID | None = None
     title: str | None = None
     description: str | None = None
-    frequency: str | None = None
-    status: str | None = None
+    frequency: RoutineFrequency | None = None
+    status: RoutineStatus | None = None
     energy_cost: int | None = None
     activation_friction: int | None = None
 
@@ -61,8 +65,8 @@ class RoutineResponse(BaseModel):
     domain_id: UUID
     title: str
     description: str | None = None
-    frequency: str
-    status: str
+    frequency: RoutineFrequency
+    status: RoutineStatus
     energy_cost: int | None = None
     activation_friction: int | None = None
     current_streak: int

--- a/app/schemas/tasks.py
+++ b/app/schemas/tasks.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 from datetime import date, datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, field_validator
+
+TaskStatus = Literal["pending", "active", "completed", "skipped", "deferred"]
+CognitiveType = Literal[
+    "hands_on", "communication", "decision", "errand", "admin", "focus_work"
+]
 
 
 class TaskCreate(BaseModel):
@@ -14,8 +20,8 @@ class TaskCreate(BaseModel):
     project_id: UUID | None = None
     title: str
     description: str | None = None
-    status: str = "pending"
-    cognitive_type: str | None = None
+    status: TaskStatus = "pending"
+    cognitive_type: CognitiveType | None = None
     energy_cost: int | None = None
     activation_friction: int | None = None
     context_required: str | None = None
@@ -37,8 +43,8 @@ class TaskUpdate(BaseModel):
     project_id: UUID | None = None
     title: str | None = None
     description: str | None = None
-    status: str | None = None
-    cognitive_type: str | None = None
+    status: TaskStatus | None = None
+    cognitive_type: CognitiveType | None = None
     energy_cost: int | None = None
     activation_friction: int | None = None
     context_required: str | None = None
@@ -63,8 +69,8 @@ class TaskResponse(BaseModel):
     project_id: UUID | None = None
     title: str
     description: str | None = None
-    status: str
-    cognitive_type: str | None = None
+    status: TaskStatus
+    cognitive_type: CognitiveType | None = None
     energy_cost: int | None = None
     activation_friction: int | None = None
     context_required: str | None = None

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -121,6 +121,13 @@ class TestCreateActivity:
         )
         assert resp.status_code == 422
 
+    def test_create_invalid_action_type(self, client):
+        resp = client.post(
+            "/api/activity",
+            json={"action_type": "INVALID"},
+        )
+        assert resp.status_code == 422
+
 
 # ---------------------------------------------------------------------------
 # GET /api/activity
@@ -293,6 +300,13 @@ class TestUpdateActivity:
         entry = make_activity(client)
         resp = client.patch(
             f"/api/activity/{entry['id']}", json={"friction_actual": 10},
+        )
+        assert resp.status_code == 422
+
+    def test_patch_invalid_action_type(self, client):
+        entry = make_activity(client)
+        resp = client.patch(
+            f"/api/activity/{entry['id']}", json={"action_type": "INVALID"},
         )
         assert resp.status_code == 422
 

--- a/tests/test_checkins.py
+++ b/tests/test_checkins.py
@@ -70,6 +70,12 @@ class TestCreateCheckin:
         )
         assert resp.status_code == 422
 
+    def test_create_invalid_checkin_type(self, client):
+        resp = client.post(
+            "/api/checkins", json={"checkin_type": "INVALID"},
+        )
+        assert resp.status_code == 422
+
 
 # ---------------------------------------------------------------------------
 # GET /api/checkins
@@ -196,6 +202,13 @@ class TestUpdateCheckin:
         checkin = make_checkin(client)
         resp = client.patch(
             f"/api/checkins/{checkin['id']}", json={"focus_level": 10},
+        )
+        assert resp.status_code == 422
+
+    def test_patch_checkin_invalid_type(self, client):
+        checkin = make_checkin(client)
+        resp = client.patch(
+            f"/api/checkins/{checkin['id']}", json={"checkin_type": "INVALID"},
         )
         assert resp.status_code == 422
 

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -43,6 +43,14 @@ class TestCreateGoal:
         )
         assert resp.status_code == 422
 
+    def test_create_goal_invalid_status(self, client):
+        domain = make_domain(client)
+        resp = client.post(
+            "/api/goals",
+            json={"domain_id": domain["id"], "title": "Bad", "status": "INVALID"},
+        )
+        assert resp.status_code == 422
+
     def test_create_goal_invalid_domain(self, client):
         resp = client.post(
             "/api/goals",
@@ -140,6 +148,14 @@ class TestUpdateGoal:
         body = resp.json()
         assert body["title"] == "Keep"
         assert body["status"] == "paused"
+
+    def test_patch_goal_invalid_status(self, client):
+        domain = make_domain(client)
+        goal = make_goal(client, domain["id"])
+        resp = client.patch(
+            f"/api/goals/{goal['id']}", json={"status": "INVALID"},
+        )
+        assert resp.status_code == 422
 
     def test_patch_goal_not_found(self, client):
         resp = client.patch(f"/api/goals/{FAKE_UUID}", json={"title": "X"})

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -49,6 +49,15 @@ class TestCreateProject:
         resp = client.post("/api/projects", json={"goal_id": goal["id"]})
         assert resp.status_code == 422
 
+    def test_create_project_invalid_status(self, client):
+        domain = make_domain(client)
+        goal = make_goal(client, domain["id"])
+        resp = client.post(
+            "/api/projects",
+            json={"goal_id": goal["id"], "title": "Bad", "status": "INVALID"},
+        )
+        assert resp.status_code == 422
+
     def test_create_project_invalid_goal(self, client):
         resp = client.post(
             "/api/projects",
@@ -182,6 +191,15 @@ class TestUpdateProject:
         body = resp.json()
         assert body["title"] == "Keep"
         assert body["status"] == "blocked"
+
+    def test_patch_project_invalid_status(self, client):
+        domain = make_domain(client)
+        goal = make_goal(client, domain["id"])
+        project = make_project(client, goal["id"])
+        resp = client.patch(
+            f"/api/projects/{project['id']}", json={"status": "INVALID"},
+        )
+        assert resp.status_code == 422
 
     def test_patch_project_not_found(self, client):
         resp = client.patch(f"/api/projects/{FAKE_UUID}", json={"title": "X"})

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -81,6 +81,25 @@ class TestCreateRoutine:
         )
         assert resp.status_code == 422
 
+    def test_create_routine_invalid_frequency(self, client):
+        domain = make_domain(client)
+        resp = client.post(
+            "/api/routines",
+            json={"domain_id": domain["id"], "title": "Bad", "frequency": "INVALID"},
+        )
+        assert resp.status_code == 422
+
+    def test_create_routine_invalid_status(self, client):
+        domain = make_domain(client)
+        resp = client.post(
+            "/api/routines",
+            json={
+                "domain_id": domain["id"], "title": "Bad", "frequency": "daily",
+                "status": "INVALID",
+            },
+        )
+        assert resp.status_code == 422
+
 
 # ---------------------------------------------------------------------------
 # GET /api/routines
@@ -209,6 +228,22 @@ class TestUpdateRoutine:
         routine = make_routine(client, domain["id"])
         resp = client.patch(
             f"/api/routines/{routine['id']}", json={"energy_cost": 7},
+        )
+        assert resp.status_code == 422
+
+    def test_patch_routine_invalid_frequency(self, client):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        resp = client.patch(
+            f"/api/routines/{routine['id']}", json={"frequency": "INVALID"},
+        )
+        assert resp.status_code == 422
+
+    def test_patch_routine_invalid_status(self, client):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        resp = client.patch(
+            f"/api/routines/{routine['id']}", json={"status": "INVALID"},
         )
         assert resp.status_code == 422
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -76,6 +76,18 @@ class TestCreateTask:
         )
         assert resp.status_code == 422
 
+    def test_create_task_invalid_status(self, client):
+        resp = client.post(
+            "/api/tasks", json={"title": "Bad", "status": "INVALID"},
+        )
+        assert resp.status_code == 422
+
+    def test_create_task_invalid_cognitive_type(self, client):
+        resp = client.post(
+            "/api/tasks", json={"title": "Bad", "cognitive_type": "INVALID"},
+        )
+        assert resp.status_code == 422
+
 
 # ---------------------------------------------------------------------------
 # GET /api/tasks — composable filters
@@ -271,6 +283,20 @@ class TestUpdateTask:
         task = make_task(client)
         resp = client.patch(
             f"/api/tasks/{task['id']}", json={"energy_cost": 7}
+        )
+        assert resp.status_code == 422
+
+    def test_patch_task_invalid_status(self, client):
+        task = make_task(client)
+        resp = client.patch(
+            f"/api/tasks/{task['id']}", json={"status": "INVALID"},
+        )
+        assert resp.status_code == 422
+
+    def test_patch_task_invalid_cognitive_type(self, client):
+        task = make_task(client)
+        resp = client.patch(
+            f"/api/tasks/{task['id']}", json={"cognitive_type": "INVALID"},
         )
         assert resp.status_code == 422
 


### PR DESCRIPTION
## Summary

Added `Literal` type constraints to all 8 enum-like string fields across Pydantic Create, Update, and Response schemas. Invalid enum values are now rejected at the Pydantic validation layer with a 422 response, instead of passing through to PostgreSQL CHECK constraints and returning a 500 with leaked database internals.

Closes #26
Closes #36

## Changes

**Schemas modified (6 files):**
- `app/schemas/goals.py` — `status` field now uses `GoalStatus = Literal["active", "paused", "achieved", "abandoned"]`
- `app/schemas/projects.py` — `status` field now uses `ProjectStatus = Literal["not_started", "active", "blocked", "completed", "abandoned"]`
- `app/schemas/tasks.py` — `status` uses `TaskStatus` Literal; `cognitive_type` uses `CognitiveType` Literal
- `app/schemas/routines.py` — `frequency` uses `RoutineFrequency` Literal; `status` uses `RoutineStatus` Literal
- `app/schemas/checkins.py` — `checkin_type` uses `CheckinType` Literal
- `app/schemas/activity.py` — `action_type` uses `ActionType` Literal

Literal type aliases are applied consistently to Create, Update, and Response schemas for each entity.

**Tests added (6 files, 16 new tests):**
- `tests/test_goals.py` — `test_create_goal_invalid_status`, `test_patch_goal_invalid_status`
- `tests/test_projects.py` — `test_create_project_invalid_status`, `test_patch_project_invalid_status`
- `tests/test_tasks.py` — `test_create_task_invalid_status`, `test_create_task_invalid_cognitive_type`, `test_patch_task_invalid_status`, `test_patch_task_invalid_cognitive_type`
- `tests/test_routines.py` — `test_create_routine_invalid_frequency`, `test_create_routine_invalid_status`, `test_patch_routine_invalid_frequency`, `test_patch_routine_invalid_status`
- `tests/test_checkins.py` — `test_create_invalid_checkin_type`, `test_patch_checkin_invalid_type`
- `tests/test_activity.py` — `test_create_invalid_action_type`, `test_patch_invalid_action_type`

## How to Verify

1. Start the dev stack: `docker compose -f docker-compose.dev.yml up -d` and `uvicorn app.main:app --reload`
2. Send an invalid enum value:
   ```bash
   curl -X POST http://localhost:8000/api/goals \
     -H "Content-Type: application/json" \
     -d '{"domain_id": "<valid-uuid>", "title": "test", "status": "INVALID"}'
   ```
3. Confirm: response is 422 with a clear Pydantic validation error (not a 500 with DB internals)
4. Repeat for any affected field (action_type, checkin_type, cognitive_type, frequency, status on any entity)
5. Run tests: `pytest -v` — all 259 tests pass
6. Run lint: `ruff check .` — all checks pass

## Deviations

None. Implementation follows the suggested fix from the issue (Literal types on Create and Update schemas). Also applied Literal types to Response schemas for consistency — the DB constraints guarantee valid data, but typed responses improve client-side type safety.

## Test Results

```
============================= 259 passed in 2.44s =============================
ruff check . → All checks passed!
```

## Acceptance Checklist

- [x] All 8 enum-like string fields validated at Pydantic layer
- [x] Invalid values return 422 (not 500)
- [x] Error responses no longer leak DB constraint names or SQL fragments (#36)
- [x] Valid enum values still accepted (existing happy-path tests pass)
- [x] Tests cover both create and update paths for all affected fields
- [x] No regressions — all 259 tests pass
- [x] Lint clean — ruff check passes