### PR TITLE
ISSUE-34: Add max_length constraints to all string fields

### DIFF
--- a/app/schemas/activity.py
+++ b/app/schemas/activity.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 ActionType = Literal[
     "completed", "skipped", "deferred", "started", "reflected", "checked_in"
@@ -20,7 +20,7 @@ class ActivityLogCreate(BaseModel):
     routine_id: UUID | None = None
     checkin_id: UUID | None = None
     action_type: ActionType
-    notes: str | None = None
+    notes: str | None = Field(default=None, max_length=5000)
     energy_before: int | None = None
     energy_after: int | None = None
     mood_rating: int | None = None
@@ -51,7 +51,7 @@ class ActivityLogUpdate(BaseModel):
     routine_id: UUID | None = None
     checkin_id: UUID | None = None
     action_type: ActionType | None = None
-    notes: str | None = None
+    notes: str | None = Field(default=None, max_length=5000)
     energy_before: int | None = None
     energy_after: int | None = None
     mood_rating: int | None = None

--- a/app/schemas/checkins.py
+++ b/app/schemas/checkins.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 CheckinType = Literal["morning", "midday", "evening", "micro", "freeform"]
 
@@ -18,8 +18,8 @@ class CheckinCreate(BaseModel):
     energy_level: int | None = None
     mood: int | None = None
     focus_level: int | None = None
-    freeform_note: str | None = None
-    context: str | None = None
+    freeform_note: str | None = Field(default=None, max_length=5000)
+    context: str | None = Field(default=None, max_length=100)
 
     @field_validator("energy_level", "mood", "focus_level")
     @classmethod
@@ -37,8 +37,8 @@ class CheckinUpdate(BaseModel):
     energy_level: int | None = None
     mood: int | None = None
     focus_level: int | None = None
-    freeform_note: str | None = None
-    context: str | None = None
+    freeform_note: str | None = Field(default=None, max_length=5000)
+    context: str | None = Field(default=None, max_length=100)
 
     @field_validator("energy_level", "mood", "focus_level")
     @classmethod

--- a/app/schemas/domains.py
+++ b/app/schemas/domains.py
@@ -5,24 +5,24 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class DomainCreate(BaseModel):
     """Fields required to create a domain."""
 
-    name: str
-    description: str | None = None
-    color: str | None = None
+    name: str = Field(max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
+    color: str | None = Field(default=None, max_length=7)
     sort_order: int = 0
 
 
 class DomainUpdate(BaseModel):
     """All fields optional — supports partial PATCH updates."""
 
-    name: str | None = None
-    description: str | None = None
-    color: str | None = None
+    name: str | None = Field(default=None, max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
+    color: str | None = Field(default=None, max_length=7)
     sort_order: int | None = None
 
 

--- a/app/schemas/goals.py
+++ b/app/schemas/goals.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 GoalStatus = Literal["active", "paused", "achieved", "abandoned"]
 
@@ -15,8 +15,8 @@ class GoalCreate(BaseModel):
     """Fields required to create a goal."""
 
     domain_id: UUID
-    title: str
-    description: str | None = None
+    title: str = Field(max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
     status: GoalStatus = "active"
 
 
@@ -24,8 +24,8 @@ class GoalUpdate(BaseModel):
     """All fields optional — supports partial PATCH updates."""
 
     domain_id: UUID | None = None
-    title: str | None = None
-    description: str | None = None
+    title: str | None = Field(default=None, max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
     status: GoalStatus | None = None
 
 

--- a/app/schemas/projects.py
+++ b/app/schemas/projects.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 ProjectStatus = Literal["not_started", "active", "blocked", "completed", "abandoned"]
 
@@ -15,8 +15,8 @@ class ProjectCreate(BaseModel):
     """Fields required to create a project."""
 
     goal_id: UUID
-    title: str
-    description: str | None = None
+    title: str = Field(max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
     status: ProjectStatus = "not_started"
     deadline: date | None = None
 
@@ -25,8 +25,8 @@ class ProjectUpdate(BaseModel):
     """All fields optional — supports partial PATCH updates."""
 
     goal_id: UUID | None = None
-    title: str | None = None
-    description: str | None = None
+    title: str | None = Field(default=None, max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
     status: ProjectStatus | None = None
     deadline: date | None = None
 

--- a/app/schemas/routines.py
+++ b/app/schemas/routines.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 RoutineFrequency = Literal["daily", "weekdays", "weekends", "weekly", "custom"]
 RoutineStatus = Literal["active", "paused", "retired"]
@@ -20,8 +20,8 @@ class RoutineCreate(BaseModel):
     """Fields required to create a routine."""
 
     domain_id: UUID
-    title: str
-    description: str | None = None
+    title: str = Field(max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
     frequency: RoutineFrequency
     status: RoutineStatus = "active"
     energy_cost: int | None = None
@@ -40,8 +40,8 @@ class RoutineUpdate(BaseModel):
     """All fields optional — supports partial PATCH updates."""
 
     domain_id: UUID | None = None
-    title: str | None = None
-    description: str | None = None
+    title: str | None = Field(default=None, max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
     frequency: RoutineFrequency | None = None
     status: RoutineStatus | None = None
     energy_cost: int | None = None
@@ -90,9 +90,9 @@ class RoutineDetailResponse(RoutineResponse):
 class RoutineScheduleCreate(BaseModel):
     """Fields required to add a schedule entry to a routine."""
 
-    day_of_week: str
-    time_of_day: str
-    preferred_window: str | None = None
+    day_of_week: str = Field(max_length=50)
+    time_of_day: str = Field(max_length=50)
+    preferred_window: str | None = Field(default=None, max_length=50)
 
 
 class RoutineScheduleResponse(BaseModel):

--- a/app/schemas/tags.py
+++ b/app/schemas/tags.py
@@ -2,21 +2,21 @@
 
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class TagCreate(BaseModel):
     """Fields required to create a tag."""
 
-    name: str
-    color: str | None = None
+    name: str = Field(max_length=100)
+    color: str | None = Field(default=None, max_length=7)
 
 
 class TagUpdate(BaseModel):
     """All fields optional — supports partial PATCH updates."""
 
-    name: str | None = None
-    color: str | None = None
+    name: str | None = Field(default=None, max_length=100)
+    color: str | None = Field(default=None, max_length=7)
 
 
 class TagResponse(BaseModel):

--- a/app/schemas/tasks.py
+++ b/app/schemas/tasks.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 TaskStatus = Literal["pending", "active", "completed", "skipped", "deferred"]
 CognitiveType = Literal[
@@ -18,15 +18,15 @@ class TaskCreate(BaseModel):
     """Fields required to create a task."""
 
     project_id: UUID | None = None
-    title: str
-    description: str | None = None
+    title: str = Field(max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
     status: TaskStatus = "pending"
     cognitive_type: CognitiveType | None = None
     energy_cost: int | None = None
     activation_friction: int | None = None
-    context_required: str | None = None
+    context_required: str | None = Field(default=None, max_length=100)
     due_date: date | None = None
-    recurrence_rule: str | None = None
+    recurrence_rule: str | None = Field(default=None, max_length=500)
 
     @field_validator("energy_cost", "activation_friction")
     @classmethod
@@ -41,15 +41,15 @@ class TaskUpdate(BaseModel):
     """All fields optional — supports partial PATCH updates."""
 
     project_id: UUID | None = None
-    title: str | None = None
-    description: str | None = None
+    title: str | None = Field(default=None, max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
     status: TaskStatus | None = None
     cognitive_type: CognitiveType | None = None
     energy_cost: int | None = None
     activation_friction: int | None = None
-    context_required: str | None = None
+    context_required: str | None = Field(default=None, max_length=100)
     due_date: date | None = None
-    recurrence_rule: str | None = None
+    recurrence_rule: str | None = Field(default=None, max_length=500)
 
     @field_validator("energy_cost", "activation_friction")
     @classmethod

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -121,6 +121,13 @@ class TestCreateActivity:
         )
         assert resp.status_code == 422
 
+    def test_create_notes_too_long(self, client):
+        resp = client.post(
+            "/api/activity",
+            json={"action_type": "reflected", "notes": "x" * 5001},
+        )
+        assert resp.status_code == 422
+
     def test_create_invalid_action_type(self, client):
         resp = client.post(
             "/api/activity",

--- a/tests/test_checkins.py
+++ b/tests/test_checkins.py
@@ -70,6 +70,20 @@ class TestCreateCheckin:
         )
         assert resp.status_code == 422
 
+    def test_create_freeform_note_too_long(self, client):
+        resp = client.post(
+            "/api/checkins",
+            json={"checkin_type": "freeform", "freeform_note": "x" * 5001},
+        )
+        assert resp.status_code == 422
+
+    def test_create_context_too_long(self, client):
+        resp = client.post(
+            "/api/checkins",
+            json={"checkin_type": "morning", "context": "x" * 101},
+        )
+        assert resp.status_code == 422
+
     def test_create_invalid_checkin_type(self, client):
         resp = client.post(
             "/api/checkins", json={"checkin_type": "INVALID"},

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -32,6 +32,22 @@ class TestCreateDomain:
         assert body["color"] == "#00FF00"
         assert body["sort_order"] == 5
 
+    def test_create_domain_name_too_long(self, client):
+        resp = client.post("/api/domains", json={"name": "x" * 201})
+        assert resp.status_code == 422
+
+    def test_create_domain_color_too_long(self, client):
+        resp = client.post(
+            "/api/domains", json={"name": "Valid", "color": "#FF00FF00"},
+        )
+        assert resp.status_code == 422
+
+    def test_create_domain_description_too_long(self, client):
+        resp = client.post(
+            "/api/domains", json={"name": "Valid", "description": "x" * 5001},
+        )
+        assert resp.status_code == 422
+
     def test_create_domain_missing_name(self, client):
         resp = client.post("/api/domains", json={})
         assert resp.status_code == 422
@@ -107,6 +123,13 @@ class TestUpdateDomain:
         body = resp.json()
         assert body["name"] == "Keep"
         assert body["color"] == "#0000FF"
+
+    def test_patch_domain_name_too_long(self, client):
+        domain = make_domain(client)
+        resp = client.patch(
+            f"/api/domains/{domain['id']}", json={"name": "x" * 201},
+        )
+        assert resp.status_code == 422
 
     def test_patch_domain_not_found(self, client):
         resp = client.patch(f"/api/domains/{FAKE_UUID}", json={"name": "X"})

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -43,6 +43,14 @@ class TestCreateGoal:
         )
         assert resp.status_code == 422
 
+    def test_create_goal_title_too_long(self, client):
+        domain = make_domain(client)
+        resp = client.post(
+            "/api/goals",
+            json={"domain_id": domain["id"], "title": "x" * 201},
+        )
+        assert resp.status_code == 422
+
     def test_create_goal_invalid_status(self, client):
         domain = make_domain(client)
         resp = client.post(

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -49,6 +49,15 @@ class TestCreateProject:
         resp = client.post("/api/projects", json={"goal_id": goal["id"]})
         assert resp.status_code == 422
 
+    def test_create_project_title_too_long(self, client):
+        domain = make_domain(client)
+        goal = make_goal(client, domain["id"])
+        resp = client.post(
+            "/api/projects",
+            json={"goal_id": goal["id"], "title": "x" * 201},
+        )
+        assert resp.status_code == 422
+
     def test_create_project_invalid_status(self, client):
         domain = make_domain(client)
         goal = make_goal(client, domain["id"])

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -81,6 +81,14 @@ class TestCreateRoutine:
         )
         assert resp.status_code == 422
 
+    def test_create_routine_title_too_long(self, client):
+        domain = make_domain(client)
+        resp = client.post(
+            "/api/routines",
+            json={"domain_id": domain["id"], "title": "x" * 201, "frequency": "daily"},
+        )
+        assert resp.status_code == 422
+
     def test_create_routine_invalid_frequency(self, client):
         domain = make_domain(client)
         resp = client.post(

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -33,6 +33,14 @@ class TestCreateTag:
         assert second.status_code == 200
         assert second.json()["id"] == first.json()["id"]
 
+    def test_create_tag_name_too_long(self, client):
+        resp = client.post("/api/tags", json={"name": "x" * 101})
+        assert resp.status_code == 422
+
+    def test_create_tag_color_too_long(self, client):
+        resp = client.post("/api/tags", json={"name": "valid", "color": "#FF00FF00"})
+        assert resp.status_code == 422
+
     def test_create_tag_missing_name(self, client):
         resp = client.post("/api/tags", json={})
         assert resp.status_code == 422

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -76,6 +76,18 @@ class TestCreateTask:
         )
         assert resp.status_code == 422
 
+    def test_create_task_title_too_long(self, client):
+        resp = client.post(
+            "/api/tasks", json={"title": "x" * 201},
+        )
+        assert resp.status_code == 422
+
+    def test_create_task_context_too_long(self, client):
+        resp = client.post(
+            "/api/tasks", json={"title": "Valid", "context_required": "x" * 101},
+        )
+        assert resp.status_code == 422
+
     def test_create_task_invalid_status(self, client):
         resp = client.post(
             "/api/tasks", json={"title": "Bad", "status": "INVALID"},


### PR DESCRIPTION
## Summary

Added `Field(max_length=...)` constraints to every unbounded string field across all Pydantic Create and Update schemas. Oversized strings are now rejected at the Pydantic layer with a 422 response before reaching the database, preventing resource exhaustion from arbitrarily large payloads.

Closes #34

## Changes

**Schemas modified (8 files):**
- `app/schemas/domains.py` — `name` (200), `description` (5000), `color` (7) on Create and Update
- `app/schemas/goals.py` — `title` (200), `description` (5000) on Create and Update
- `app/schemas/projects.py` — `title` (200), `description` (5000) on Create and Update
- `app/schemas/tasks.py` — `title` (200), `description` (5000), `context_required` (100), `recurrence_rule` (500) on Create and Update
- `app/schemas/routines.py` — `title` (200), `description` (5000) on Create and Update; `day_of_week` (50), `time_of_day` (50), `preferred_window` (50) on RoutineScheduleCreate
- `app/schemas/checkins.py` — `freeform_note` (5000), `context` (100) on Create and Update
- `app/schemas/activity.py` — `notes` (5000) on Create and Update
- `app/schemas/tags.py` — `name` (100), `color` (7) on Create and Update

**Limits rationale (from Seraphina's recommendations in #34):**
| Field type | Limit | Reasoning |
|---|---|---|
| `name`, `title` | 200 | Generous for display names, prevents abuse |
| `description`, `notes`, `freeform_note` | 5,000 | Ample for detailed text, blocks megabyte payloads |
| `context`, `context_required` | 100 | Short categorical labels |
| `color` | 7 | Hex format `#RRGGBB` |
| `recurrence_rule` | 500 | RRULE strings are typically under 200 chars |
| `day_of_week`, `time_of_day`, `preferred_window` | 50 | Short scheduling labels |
| Tag `name` | 100 | Tag names should be concise |

**Tests added (8 files, 14 new tests):**
- `tests/test_domains.py` — `test_create_domain_name_too_long`, `test_create_domain_color_too_long`, `test_create_domain_description_too_long`, `test_patch_domain_name_too_long`
- `tests/test_goals.py` — `test_create_goal_title_too_long`
- `tests/test_projects.py` — `test_create_project_title_too_long`
- `tests/test_tasks.py` — `test_create_task_title_too_long`, `test_create_task_context_too_long`
- `tests/test_routines.py` — `test_create_routine_title_too_long`
- `tests/test_checkins.py` — `test_create_freeform_note_too_long`, `test_create_context_too_long`
- `tests/test_activity.py` — `test_create_notes_too_long`
- `tests/test_tags.py` — `test_create_tag_name_too_long`, `test_create_tag_color_too_long`

## How to Verify

1. Start the dev stack and API
2. Send an oversized string:
   ```bash
   curl -X POST http://localhost:8000/api/domains \
     -H "Content-Type: application/json" \
     -d "{\"name\": \"$(python -c "print('x' * 201)")\"}"
   ```
3. Confirm: 422 response with Pydantic validation error about max_length
4. Run tests: `pytest -v` — all 273 tests pass
5. Run lint: `ruff check .` — all checks pass

## Deviations

None. Limits follow Seraphina's recommendations from #34 exactly. Only applied to Create/Update schemas (input validation), not Response schemas (which reflect stored data).

## Test Results

```
============================= 273 passed in 2.64s =============================
ruff check . → All checks passed!
```

## Acceptance Checklist

- [x] All string fields in Create schemas have max_length constraints
- [x] All string fields in Update schemas have max_length constraints
- [x] Oversized strings return 422 (not accepted silently)
- [x] Normal-length strings still accepted (existing happy-path tests pass)
- [x] Tests cover representative fields across all entities
- [x] No regressions — all 273 tests pass
- [x] Lint clean — ruff check passes