### PR TITLE
ISSUE-37: Remove default database credentials from config.py

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -6,9 +6,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """BRAIN 3.0 application settings, loaded from environment variables / .env file."""
 
-    POSTGRES_USER: str = "brain3"
-    POSTGRES_PASSWORD: str = "brain3_dev"
-    POSTGRES_DB: str = "brain3_dev"
+    POSTGRES_USER: str
+    POSTGRES_PASSWORD: str
+    POSTGRES_DB: str
     POSTGRES_HOST: str = "localhost"
     POSTGRES_PORT: int = 5432
 


### PR DESCRIPTION
## Summary

Removed hardcoded fallback default values for database credentials (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`) from Pydantic Settings. If `.env` is missing or incomplete, the application now fails immediately at startup with a clear validation error instead of silently connecting with weak dev credentials.

Closes #37

## Changes

**File modified:**
- `app/config.py` — Removed default values from `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` fields. These are now required fields that must be provided via environment variables or `.env` file.

**What stays the same:**
- `POSTGRES_HOST` keeps its `"localhost"` default (reasonable for local dev)
- `POSTGRES_PORT` keeps its `5432` default (standard Postgres port)
- `API_HOST` and `API_PORT` keep their defaults
- `.env.example` still provides dev values (`brain3`/`brain3_dev`) for local setup
- `.env.production.example` still documents `CHANGE_ME_TO_A_STRONG_PASSWORD`

## How to Verify

1. Confirm local dev still works (`.env` provides the values):
   ```bash
   uvicorn app.main:app --reload
   # Should start normally
   ```

2. Confirm missing `.env` fails loudly:
   ```bash
   mv .env .env.bak
   python -c "from app.config import settings"
   # Should raise pydantic ValidationError for missing required fields
   mv .env.bak .env
   ```

3. Run tests: `pytest -v` — all 273 pass (tests use SQLite, but config is still loaded during import)

## Deviations

None. Implemented Option A from the issue (remove defaults, force explicit configuration), which was the recommended approach.

## Test Results

```
============================= 273 passed in 2.63s =============================
ruff check . → All checks passed!
```

No new tests added — the fix changes startup behavior when `.env` is absent, which is an operational concern rather than an API behavior testable via TestClient. The 273 existing tests confirm no regressions.

## Acceptance Checklist

- [x] `POSTGRES_USER` has no default — must be set via env/`.env`
- [x] `POSTGRES_PASSWORD` has no default — must be set via env/`.env`
- [x] `POSTGRES_DB` has no default — must be set via env/`.env`
- [x] Missing `.env` causes clear startup error (not silent fallback)
- [x] `.env.example` still provides dev values for local setup
- [x] No regressions — all 273 tests pass
- [x] Lint clean — ruff check passes