### PR TITLE
ISSUE-38: Add non-root user to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Create non-root user
+RUN addgroup --system brain3 && adduser --system --ingroup brain3 brain3
+
 # Copy migration config and scripts
 COPY alembic.ini .
 COPY alembic/ alembic/
@@ -16,6 +19,9 @@ COPY app/ app/
 # Copy and prepare entrypoint
 COPY scripts/entrypoint.sh scripts/entrypoint.sh
 RUN chmod +x scripts/entrypoint.sh
+
+# Switch to non-root user
+USER brain3
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary

Added a non-root system user (`brain3`) to the Dockerfile and switched to it before the application runs. The uvicorn process no longer runs as root inside the container, reducing the blast radius of any potential container escape.

Closes #38

## Changes

**File modified:**
- `Dockerfile` — Added `addgroup`/`adduser` to create a `brain3` system user after dependency installation, and added `USER brain3` directive before `EXPOSE` and `ENTRYPOINT`.

**Build order (layer caching preserved):**
1. Install pip dependencies (as root — required for system-level pip install)
2. Create `brain3` system user and group
3. Copy application files (alembic, app code, entrypoint)
4. `USER brain3` — switch to non-root
5. `EXPOSE 8000` and `ENTRYPOINT`

**Why no `chown` needed:**
- The copied files are read-only from the app's perspective — uvicorn serves them, doesn't write to them
- Alembic migrations write to the database (network), not the filesystem
- No temp file directories are used by the application

## How to Verify

1. Rebuild the container:
   ```bash
   docker compose -f docker-compose.prod.yml build
   ```

2. Start and check the running user:
   ```bash
   docker compose -f docker-compose.prod.yml up -d
   docker exec brain3-api whoami
   # Expected: brain3 (not root)
   ```

3. Confirm the API still works:
   ```bash
   curl http://localhost:8000/health
   # Expected: healthy response
   ```

4. Confirm migrations still run (check container logs):
   ```bash
   docker logs brain3-api
   # Expected: "Running database migrations..." followed by "Starting BRAIN 3.0 API..."
   ```

## Deviations

None. Implementation follows the suggested remediation from the issue exactly.

## Test Results

```
============================= 273 passed in 2.67s =============================
ruff check . → All checks passed!
```

No new application tests — this is a Dockerfile-only change. Verification is via container inspection as described above.

## Acceptance Checklist

- [x] Non-root user (`brain3`) created in Dockerfile
- [x] `USER brain3` directive set before ENTRYPOINT
- [x] Dependencies installed as root (required for pip)
- [x] User switch happens after all root-required operations
- [x] entrypoint.sh and uvicorn do not require root
- [x] alembic migrations do not require root (DB access only)
- [x] No regressions — all 273 tests pass
- [x] Lint clean — ruff check passes