### PR TITLE
ISSUE-35: Replace CORS wildcard with configurable origin allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ POSTGRES_PORT=5432
 # API
 API_HOST=0.0.0.0
 API_PORT=8000
+
+# CORS — comma-separated list of allowed origins
+CORS_ORIGINS=http://localhost:3000,http://localhost:8000

--- a/.env.production.example
+++ b/.env.production.example
@@ -13,6 +13,9 @@ POSTGRES_PORT=5432
 API_HOST=0.0.0.0
 API_PORT=8000
 
+# CORS — comma-separated list of allowed origins (set to your TrueNAS IP/hostname)
+CORS_ORIGINS=http://TRUENAS_IP:8000
+
 # Backup
 BACKUP_PATH=/mnt/pool/backups/brain3
 BACKUP_RETENTION_DAYS=30

--- a/app/config.py
+++ b/app/config.py
@@ -15,6 +15,8 @@ class Settings(BaseSettings):
     API_HOST: str = "0.0.0.0"
     API_PORT: int = 8000
 
+    CORS_ORIGINS: str = "http://localhost:3000,http://localhost:8000"
+
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
     @property

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy import text
 
+from app.config import settings
 from app.database import SessionLocal
 from app.routers import (
     activity,
@@ -26,7 +27,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[o.strip() for o in settings.CORS_ORIGINS.split(",")],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary

Replaced the hardcoded `allow_origins=["*"]` CORS wildcard with a configurable `CORS_ORIGINS` environment variable. Origins are now loaded from settings, defaulting to `http://localhost:3000,http://localhost:8000` for local development. Production deployments set the variable to the specific TrueNAS host origin.

Closes #35

## Changes

- `app/config.py` — Added `CORS_ORIGINS: str` field with localhost default
- `app/main.py` — Imported `settings`, split `CORS_ORIGINS` into a list for the middleware
- `.env.example` — Added `CORS_ORIGINS` with dev values
- `.env.production.example` — Added `CORS_ORIGINS` with placeholder for TrueNAS IP

## How to Verify

1. Start the API and confirm CORS headers are restricted:
   ```bash
   curl -s -I -H "Origin: http://localhost:8000" http://localhost:8000/health | grep -i access-control
   # Expected: Access-Control-Allow-Origin: http://localhost:8000

   curl -s -I -H "Origin: http://evil.example.com" http://localhost:8000/health | grep -i access-control
   # Expected: No Access-Control-Allow-Origin header (origin rejected)
   ```

2. Override via env var:
   ```bash
   CORS_ORIGINS="http://192.168.1.100:8000" uvicorn app.main:app
   ```

3. Run tests: `pytest -v` — all 273 pass

## Deviations

None. Follows the suggested remediation from the issue exactly, including the comma-separated env var pattern and localhost defaults.

## Test Results

```
============================= 273 passed in 2.49s =============================
ruff check . → All checks passed!
```

No new application tests — CORS behavior is a browser enforcement mechanism tested via header inspection, not API response codes. Verification steps above confirm correct behavior.

## Acceptance Checklist

- [x] `allow_origins=["*"]` replaced with configurable allowlist
- [x] Origins loaded from `CORS_ORIGINS` env var via Pydantic Settings
- [x] Safe default: `http://localhost:3000,http://localhost:8000`
- [x] `.env.example` updated with dev value
- [x] `.env.production.example` updated with production placeholder
- [x] `allow_credentials`, `allow_methods`, `allow_headers` unchanged
- [x] No regressions — all 273 tests pass
- [x] Lint clean — ruff check passes