### PR TITLE
ISSUE-30: Auto-populate task completed_at on status transitions

### DIFF
--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -1,6 +1,6 @@
 """CRUD endpoints for Tasks."""
 
-from datetime import date
+from datetime import date, datetime, timezone
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -108,6 +108,12 @@ def update_task(
 
     for field, value in payload.model_dump(exclude_unset=True).items():
         setattr(task, field, value)
+
+    # Auto-manage completed_at based on status transitions
+    if task.status == "completed" and task.completed_at is None:
+        task.completed_at = datetime.now(tz=timezone.utc)
+    elif task.status != "completed" and task.completed_at is not None:
+        task.completed_at = None
 
     db.commit()
     db.refresh(task)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -312,6 +312,40 @@ class TestUpdateTask:
         )
         assert resp.status_code == 422
 
+    def test_patch_task_completed_at_auto_set(self, client):
+        task = make_task(client)
+        assert task["completed_at"] is None
+        resp = client.patch(
+            f"/api/tasks/{task['id']}", json={"status": "completed"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "completed"
+        assert body["completed_at"] is not None
+
+    def test_patch_task_completed_at_cleared_on_revert(self, client):
+        task = make_task(client)
+        client.patch(f"/api/tasks/{task['id']}", json={"status": "completed"})
+        resp = client.patch(
+            f"/api/tasks/{task['id']}", json={"status": "active"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "active"
+        assert body["completed_at"] is None
+
+    def test_patch_task_completed_at_preserved(self, client):
+        task = make_task(client)
+        completed = client.patch(
+            f"/api/tasks/{task['id']}", json={"status": "completed"},
+        ).json()
+        resp = client.patch(
+            f"/api/tasks/{task['id']}", json={"title": "Updated"},
+        )
+        body = resp.json()
+        assert body["title"] == "Updated"
+        assert body["completed_at"] == completed["completed_at"]
+
 
 # ---------------------------------------------------------------------------
 # DELETE /api/tasks/{id}


### PR DESCRIPTION
## Summary

The `completed_at` field on tasks was always NULL — the model and response schema exposed it, but no code path ever set it. Now, when a task's status transitions to `"completed"` via PATCH, `completed_at` is automatically set to `datetime.now(tz=timezone.utc)`. When status moves away from `"completed"`, it is cleared back to `null`. The field is not user-settable through the schema — it is managed entirely by transition logic in the PATCH endpoint.

Closes #30

## Changes

- `app/routers/tasks.py` — Added `datetime`/`timezone` imports; added post-update logic in `update_task` to auto-set `completed_at` when status becomes `"completed"` and clear it when status reverts
- `tests/test_tasks.py` — Added 3 tests:
  - `test_patch_task_completed_at_auto_set` — status → completed sets completed_at
  - `test_patch_task_completed_at_cleared_on_revert` — status away from completed clears it
  - `test_patch_task_completed_at_preserved` — non-status updates preserve existing completed_at

## How to Verify

```bash
# Create a task
curl -s -X POST http://localhost:8000/api/tasks \
  -H "Content-Type: application/json" \
  -d '{"title": "Test completion"}' | jq '.completed_at'
# → null

# Complete it
curl -s -X PATCH http://localhost:8000/api/tasks/<id> \
  -H "Content-Type: application/json" \
  -d '{"status": "completed"}' | jq '.completed_at'
# → "2026-03-28T..."

# Revert to active
curl -s -X PATCH http://localhost:8000/api/tasks/<id> \
  -H "Content-Type: application/json" \
  -d '{"status": "active"}' | jq '.completed_at'
# → null
```

## Deviations

None. Implements Option A (auto-set) per L's design decision — `completed_at` is not added to `TaskUpdate` schema. The field is fully managed by the router based on status transitions.

## Test Results

```
============================= 276 passed in 2.47s =============================
ruff check . → All checks passed!
```

## Acceptance Checklist

- [x] `completed_at` auto-set to UTC now when status → "completed"
- [x] `completed_at` cleared to null when status moves away from "completed"
- [x] `completed_at` preserved when non-status fields are updated
- [x] `completed_at` NOT added to TaskUpdate schema (not user-settable)
- [x] Idempotent: re-patching with status="completed" does not overwrite existing timestamp
- [x] No regressions — all 276 tests pass
- [x] Lint clean — ruff check passes