### PR TITLE
ISSUE-27: Enforce at-most-one-reference constraint on activity log PATCH

### DIFF
--- a/app/routers/activity.py
+++ b/app/routers/activity.py
@@ -104,6 +104,14 @@ def update_activity(
     for field, value in payload.model_dump(exclude_unset=True).items():
         setattr(entry, field, value)
 
+    # Enforce at-most-one-reference on the post-merge state
+    refs = sum(v is not None for v in [entry.task_id, entry.routine_id, entry.checkin_id])
+    if refs > 1:
+        raise HTTPException(
+            status_code=422,
+            detail="At most one of task_id, routine_id, or checkin_id may be set",
+        )
+
     db.commit()
     db.refresh(entry)
     return entry

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -317,6 +317,32 @@ class TestUpdateActivity:
         )
         assert resp.status_code == 422
 
+    def test_patch_multiple_refs_rejected(self, client):
+        """Adding a second reference to an entry with an existing one is rejected."""
+        task = make_task(client)
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        entry = make_activity(client, task_id=task["id"])
+        resp = client.patch(
+            f"/api/activity/{entry['id']}", json={"routine_id": routine["id"]},
+        )
+        assert resp.status_code == 422
+
+    def test_patch_replace_ref_allowed(self, client):
+        """Clearing old ref and setting a new one in the same PATCH is allowed."""
+        task = make_task(client)
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        entry = make_activity(client, task_id=task["id"])
+        resp = client.patch(
+            f"/api/activity/{entry['id']}",
+            json={"task_id": None, "routine_id": routine["id"]},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["task_id"] is None
+        assert body["routine_id"] == routine["id"]
+
 
 # ---------------------------------------------------------------------------
 # DELETE /api/activity/{id}


### PR DESCRIPTION
## Summary

The `ActivityLogUpdate` schema (PATCH) was missing the at-most-one-reference constraint that `ActivityLogCreate` (POST) already enforced. A PATCH could add a `routine_id` to an entry that already had a `task_id`, resulting in an entry with two references — violating the business rule.

The fix validates the **post-merge state** of the entry in the router (not the schema), since the schema only sees the incoming fields and can't know what's already on the record. After applying all payload fields, if more than one of `task_id`, `routine_id`, `checkin_id` is non-null, a 422 is returned before committing.

Closes #27

## Changes

- `app/routers/activity.py` — Added post-merge reference count check in `update_activity` before `db.commit()`. Returns 422 if more than one reference is set.
- `tests/test_activity.py` — Added 2 tests:
  - `test_patch_multiple_refs_rejected` — PATCH adding a second ref to an entry with an existing one → 422
  - `test_patch_replace_ref_allowed` — PATCH clearing old ref and setting new one in same request → 200

## How to Verify

```bash
# Create entry with task_id
ENTRY=$(curl -s -X POST http://localhost:8000/api/activity \
  -H "Content-Type: application/json" \
  -d '{"task_id": "<valid>", "action_type": "completed"}')
ID=$(echo $ENTRY | jq -r '.id')

# Try adding routine_id without clearing task_id
curl -s -X PATCH http://localhost:8000/api/activity/$ID \
  -H "Content-Type: application/json" \
  -d '{"routine_id": "<valid>"}'
# → 422: "At most one of task_id, routine_id, or checkin_id may be set"

# Replace ref correctly (clear + set in same PATCH)
curl -s -X PATCH http://localhost:8000/api/activity/$ID \
  -H "Content-Type: application/json" \
  -d '{"task_id": null, "routine_id": "<valid>"}'
# → 200
```

## Deviations

Used Option B from the issue (router-level validation on post-merge state) rather than a schema-level `@model_validator`, because the schema only sees incoming fields and cannot evaluate the resulting state of the record. This is noted in the issue as the more correct approach.

## Test Results

```
============================= 278 passed in 2.60s =============================
ruff check . → All checks passed!
```

## Acceptance Checklist

- [x] PATCH rejects multiple references on post-merge state (422)
- [x] PATCH allows replacing one ref with another (clear old + set new)
- [x] POST constraint unchanged (already worked via `@model_validator`)
- [x] Validation checks post-merge state, not just payload
- [x] No regressions — all 278 tests pass
- [x] Lint clean — ruff check passes