### PR TITLE
ISSUE-28: Validate referenced entity IDs on activity log PATCH

### DIFF
--- a/app/routers/activity.py
+++ b/app/routers/activity.py
@@ -101,7 +101,19 @@ def update_activity(
     if not entry:
         raise HTTPException(status_code=404, detail="Activity log entry not found")
 
-    for field, value in payload.model_dump(exclude_unset=True).items():
+    # Validate referenced entities exist (only for fields in the payload)
+    updates = payload.model_dump(exclude_unset=True)
+    if updates.get("task_id") is not None:
+        if not db.query(Task).filter(Task.id == updates["task_id"]).first():
+            raise HTTPException(status_code=400, detail="Task not found")
+    if updates.get("routine_id") is not None:
+        if not db.query(Routine).filter(Routine.id == updates["routine_id"]).first():
+            raise HTTPException(status_code=400, detail="Routine not found")
+    if updates.get("checkin_id") is not None:
+        if not db.query(StateCheckin).filter(StateCheckin.id == updates["checkin_id"]).first():
+            raise HTTPException(status_code=400, detail="Check-in not found")
+
+    for field, value in updates.items():
         setattr(entry, field, value)
 
     # Enforce at-most-one-reference on the post-merge state

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -343,6 +343,37 @@ class TestUpdateActivity:
         assert body["task_id"] is None
         assert body["routine_id"] == routine["id"]
 
+    def test_patch_invalid_task_ref(self, client):
+        entry = make_activity(client)
+        resp = client.patch(
+            f"/api/activity/{entry['id']}", json={"task_id": FAKE_UUID},
+        )
+        assert resp.status_code == 400
+
+    def test_patch_invalid_routine_ref(self, client):
+        entry = make_activity(client)
+        resp = client.patch(
+            f"/api/activity/{entry['id']}", json={"routine_id": FAKE_UUID},
+        )
+        assert resp.status_code == 400
+
+    def test_patch_invalid_checkin_ref(self, client):
+        entry = make_activity(client)
+        resp = client.patch(
+            f"/api/activity/{entry['id']}", json={"checkin_id": FAKE_UUID},
+        )
+        assert resp.status_code == 400
+
+    def test_patch_clear_ref_allowed(self, client):
+        """Setting a ref to null should not trigger existence validation."""
+        task = make_task(client)
+        entry = make_activity(client, task_id=task["id"])
+        resp = client.patch(
+            f"/api/activity/{entry['id']}", json={"task_id": None},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["task_id"] is None
+
 
 # ---------------------------------------------------------------------------
 # DELETE /api/activity/{id}


### PR DESCRIPTION
## Summary

The `update_activity` PATCH handler accepted any UUID for `task_id`, `routine_id`, and `checkin_id` without checking whether the referenced entity exists. On PostgreSQL this would hit the FK constraint and return a 500 with leaked database internals; on SQLite tests it would silently create a dangling reference.

Now, the PATCH handler validates that referenced entities exist before applying changes — matching the existing behavior on the POST handler. The validation only runs for fields present in the payload and only when the value is non-null (clearing a ref to `null` is always valid).

The validation order in the handler is now: existence checks → apply fields → reference count check (#27) → commit.

Closes #28

## Changes

- `app/routers/activity.py` — Added existence validation for `task_id`, `routine_id`, `checkin_id` in `update_activity`, before applying fields. Uses `updates = payload.model_dump(exclude_unset=True)` to only check fields in the payload. Returns 400 for invalid references (consistent with POST).
- `tests/test_activity.py` — Added 4 tests:
  - `test_patch_invalid_task_ref` — nonexistent task_id → 400
  - `test_patch_invalid_routine_ref` — nonexistent routine_id → 400
  - `test_patch_invalid_checkin_ref` — nonexistent checkin_id → 400
  - `test_patch_clear_ref_allowed` — setting task_id to null → 200 (no existence check on null)

## How to Verify

```bash
# Create a standalone entry
ENTRY=$(curl -s -X POST http://localhost:8000/api/activity \
  -H "Content-Type: application/json" \
  -d '{"action_type": "reflected"}')
ID=$(echo $ENTRY | jq -r '.id')

# Try setting a nonexistent task reference
curl -s -X PATCH http://localhost:8000/api/activity/$ID \
  -H "Content-Type: application/json" \
  -d '{"task_id": "00000000-0000-0000-0000-000000000000"}'
# → 400: "Task not found"

# Same for routine and checkin references
```

## Deviations

None. Follows the suggested fix from the issue — same FK existence checks as `create_activity`, applied only to fields present in the PATCH payload. Coexists cleanly with the #27 reference count check.

## Test Results

```
============================= 282 passed in 2.59s =============================
ruff check . → All checks passed!
```

## Acceptance Checklist

- [x] Invalid `task_id` on PATCH returns 400
- [x] Invalid `routine_id` on PATCH returns 400
- [x] Invalid `checkin_id` on PATCH returns 400
- [x] Clearing a ref to null does not trigger existence validation
- [x] Existence check runs before field application and count check
- [x] Consistent with POST handler behavior (same error codes, same messages)
- [x] Coexists with #27 reference count check — existence first, count second
- [x] No regressions — all 282 tests pass
- [x] Lint clean — ruff check passes