### PR TITLE
ISSUE-32: Remove invalid abandoned status from task overdue filter

### DIFF
--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -77,7 +77,7 @@ def list_tasks(
     if overdue is True:
         query = query.filter(
             Task.due_date < date.today(),
-            Task.status.notin_(["completed", "skipped", "abandoned"]),
+            Task.status.notin_(["completed", "skipped"]),
         )
 
     return query.order_by(Task.created_at).all()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -222,6 +222,18 @@ class TestListTasks:
         assert len(tasks) == 1
         assert tasks[0]["title"] == "Overdue"
 
+    def test_filter_overdue_excludes_skipped(self, client):
+        """Overdue filter excludes completed and skipped, but includes deferred."""
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        make_task(client, title="Skipped", due_date=yesterday, status="skipped")
+        make_task(client, title="Deferred", due_date=yesterday, status="deferred")
+
+        resp = client.get("/api/tasks?overdue=true")
+        tasks = resp.json()
+        titles = [t["title"] for t in tasks]
+        assert "Skipped" not in titles
+        assert "Deferred" in titles
+
     def test_composable_filters(self, client):
         make_task(
             client, title="Match",


### PR DESCRIPTION
## Summary
The task overdue filter excluded `"abandoned"` from results, but `abandoned` is not a valid task status — it's a project status. Removed the phantom entry so the exclusion list only references valid task statuses (`completed`, `skipped`).

## Changes
- **`app/routers/tasks.py`:** Changed overdue filter from `notin_(["completed", "skipped", "abandoned"])` to `notin_(["completed", "skipped"])`.
- **`tests/test_tasks.py`:** Added `test_filter_overdue_excludes_skipped` — verifies that `skipped` tasks are excluded from overdue results while `deferred` tasks (past due) are correctly included.

## How to Verify
1. Check `app/routers/tasks.py:80` — exclusion list should be `["completed", "skipped"]`
2. Run `pytest tests/test_tasks.py -v` — all 39 tests pass
3. Confirm the new test creates a skipped and deferred task both past due, and only deferred appears in overdue results

## Deviations
None.

## Test Results
```
pytest tests/test_tasks.py -v — 39 passed in 0.47s
ruff check . — All checks passed!
```

## Acceptance Checklist
- [x] `"abandoned"` removed from task overdue filter exclusion list
- [x] Overdue filter only excludes valid task statuses (completed, skipped)
- [x] New test confirms skipped excluded, deferred included
- [x] All existing tests still pass
- [x] Ruff clean

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)