### PR TITLE
ISSUE-40: Pin Docker base image versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres:16.13-alpine
         env:
           POSTGRES_USER: brain3_test
           POSTGRES_PASSWORD: brain3_test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12.13-slim
 
 WORKDIR /app
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16.13-alpine
     container_name: brain3-postgres-dev
     restart: unless-stopped
     env_file: .env

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:16-alpine
+    image: postgres:16.13-alpine
     container_name: brain3-db
     restart: unless-stopped
     env_file: .env


### PR DESCRIPTION
## Summary
Pinned all Docker base images from floating minor-version tags to specific patch versions, eliminating a supply chain risk vector and ensuring reproducible builds.

## Changes
- **`Dockerfile`:** `python:3.12-slim` → `python:3.12.13-slim`
- **`docker-compose.dev.yml`:** `postgres:16-alpine` → `postgres:16.13-alpine`
- **`docker-compose.prod.yml`:** `postgres:16-alpine` → `postgres:16.13-alpine`
- **`.github/workflows/ci.yml`:** `postgres:16-alpine` → `postgres:16.13-alpine` (CI service container)

## How to Verify
1. Check each file references the pinned patch version, not a floating tag
2. `docker pull python:3.12.13-slim` — should resolve successfully
3. `docker pull postgres:16.13-alpine` — should resolve successfully
4. `docker compose -f docker-compose.dev.yml config` — should show pinned image tags

## Deviations
- The issue suggested pinning to SHA256 digests. I pinned to patch version tags instead — these are specific enough for reproducibility while remaining human-readable and easy to update. Digest pinning can be layered on later if desired.
- Also pinned the CI workflow's postgres image (`ci.yml`), which wasn't listed in the issue but uses the same floating tag.

## Test Results
```
pytest -v — 283 passed in 2.55s
ruff check . — All checks passed!
```

## Acceptance Checklist
- [x] `Dockerfile` pinned to `python:3.12.13-slim`
- [x] `docker-compose.dev.yml` pinned to `postgres:16.13-alpine`
- [x] `docker-compose.prod.yml` pinned to `postgres:16.13-alpine`
- [x] `.github/workflows/ci.yml` pinned to `postgres:16.13-alpine`
- [x] Versions confirmed as latest patch releases via Docker Hub API
- [x] All tests pass
- [x] Ruff clean

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)