### PR TITLE
ISSUE-39: Restrict backup dump file permissions

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -28,6 +28,9 @@ log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
 }
 
+# Restrict file creation to owner-only (mode 600 for files, 700 for directories)
+umask 077
+
 # Ensure backup directory exists
 mkdir -p "$BACKUP_PATH"
 


### PR DESCRIPTION
## Summary
Database backup dumps were created with default umask (typically 644 — world-readable). Added `umask 077` before any file creation so dumps and logs are owner-only (600/700).

## Changes
- **`scripts/backup.sh`:** Added `umask 077` after variable declarations and before `mkdir -p`. This ensures the backup directory (700), dump files (600), and log file (600) are all restricted to the owner.

## How to Verify
1. Review `scripts/backup.sh` — `umask 077` should appear before `mkdir -p "$BACKUP_PATH"`
2. Run the script on a test system and verify:
   - `stat -c '%a' "$BACKUP_PATH"` → `700`
   - `stat -c '%a' "$BACKUP_PATH/brain3_*.sql.gz"` → `600`
   - `stat -c '%a' "$BACKUP_PATH/backup.log"` → `600`

## Deviations
None.

## Test Results
```
bash -n scripts/backup.sh — Syntax OK
pytest -v — 283 passed in 2.58s
ruff check . — All checks passed!
```

## Acceptance Checklist
- [x] `umask 077` added before any file creation
- [x] Backup dumps will be created with mode 600
- [x] Backup directory will be created with mode 700
- [x] Log file will be created with mode 600
- [x] Script syntax validated
- [x] All tests pass
- [x] Ruff clean

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)