### PR TITLE
ISSUE-29: Add test coverage for cascades, reparenting, and reference integrity

### DIFF
--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -391,3 +391,48 @@ class TestDeleteActivity:
     def test_delete_not_found(self, client):
         resp = client.delete(f"/api/activity/{FAKE_UUID}")
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Reference integrity — FK SET NULL on parent deletion
+# ---------------------------------------------------------------------------
+
+class TestActivityReferenceIntegrity:
+
+    def test_task_deletion_nullifies_activity_reference(self, client):
+        """Deleting a task sets activity_log.task_id to NULL, not cascading."""
+        task = make_task(client)
+        entry = make_activity(client, task_id=task["id"])
+
+        client.delete(f"/api/tasks/{task['id']}")
+
+        resp = client.get(f"/api/activity/{entry['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["task_id"] is None
+
+    def test_routine_deletion_nullifies_activity_reference(self, client):
+        """Deleting a routine sets activity_log.routine_id to NULL."""
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        entry = make_activity(
+            client, routine_id=routine["id"], action_type="completed",
+        )
+
+        client.delete(f"/api/routines/{routine['id']}")
+
+        resp = client.get(f"/api/activity/{entry['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["routine_id"] is None
+
+    def test_checkin_deletion_nullifies_activity_reference(self, client):
+        """Deleting a check-in sets activity_log.checkin_id to NULL."""
+        checkin = make_checkin(client)
+        entry = make_activity(
+            client, checkin_id=checkin["id"], action_type="checked_in",
+        )
+
+        client.delete(f"/api/checkins/{checkin['id']}")
+
+        resp = client.get(f"/api/activity/{entry['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["checkin_id"] is None

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -1,6 +1,13 @@
 """Tests for Domain CRUD endpoints."""
 
-from tests.conftest import FAKE_UUID, make_domain, make_goal
+from tests.conftest import (
+    FAKE_UUID,
+    make_domain,
+    make_goal,
+    make_project,
+    make_tag,
+    make_task,
+)
 
 # ---------------------------------------------------------------------------
 # POST /api/domains
@@ -158,6 +165,26 @@ class TestDeleteDomain:
 
         resp = client.get(f"/api/goals/{goal['id']}")
         assert resp.status_code == 404
+
+    def test_delete_domain_cascades_full_chain(self, client):
+        """Delete a domain and verify the full chain is removed:
+        domain → goals → projects → tasks → task-tags."""
+        domain = make_domain(client)
+        goal = make_goal(client, domain["id"])
+        project = make_project(client, goal["id"])
+        task = make_task(client, project_id=project["id"])
+        tag = make_tag(client, name="cascade-test")
+        client.post(f"/api/tasks/{task['id']}/tags/{tag['id']}")
+
+        client.delete(f"/api/domains/{domain['id']}")
+
+        assert client.get(f"/api/goals/{goal['id']}").status_code == 404
+        assert client.get(f"/api/projects/{project['id']}").status_code == 404
+        assert client.get(f"/api/tasks/{task['id']}").status_code == 404
+        # Tag itself survives, but the task-tag association is gone
+        assert client.get(f"/api/tags/{tag['id']}").status_code == 200
+        tagged_tasks = client.get(f"/api/tags/{tag['id']}/tasks").json()
+        assert len(tagged_tasks) == 0
 
     def test_delete_domain_not_found(self, client):
         resp = client.delete(f"/api/domains/{FAKE_UUID}")

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -1,6 +1,6 @@
 """Tests for Goal CRUD endpoints."""
 
-from tests.conftest import FAKE_UUID, make_domain, make_goal
+from tests.conftest import FAKE_UUID, make_domain, make_goal, make_project, make_task
 
 # ---------------------------------------------------------------------------
 # POST /api/goals
@@ -165,6 +165,23 @@ class TestUpdateGoal:
         )
         assert resp.status_code == 422
 
+    def test_patch_goal_reparent_to_different_domain(self, client):
+        """Move a goal from one domain to another via PATCH."""
+        domain_a = make_domain(client, name="Domain A")
+        domain_b = make_domain(client, name="Domain B")
+        goal = make_goal(client, domain_a["id"])
+
+        resp = client.patch(
+            f"/api/goals/{goal['id']}", json={"domain_id": domain_b["id"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["domain_id"] == domain_b["id"]
+
+        # Verify it shows under domain B's detail
+        detail = client.get(f"/api/domains/{domain_b['id']}").json()
+        goal_ids = [g["id"] for g in detail["goals"]]
+        assert goal["id"] in goal_ids
+
     def test_patch_goal_not_found(self, client):
         resp = client.patch(f"/api/goals/{FAKE_UUID}", json={"title": "X"})
         assert resp.status_code == 404
@@ -184,6 +201,18 @@ class TestDeleteGoal:
 
         resp = client.get(f"/api/goals/{goal['id']}")
         assert resp.status_code == 404
+
+    def test_delete_goal_cascades_projects_and_tasks(self, client):
+        """Delete a goal and verify child projects and tasks are removed."""
+        domain = make_domain(client)
+        goal = make_goal(client, domain["id"])
+        project = make_project(client, goal["id"])
+        task = make_task(client, project_id=project["id"])
+
+        client.delete(f"/api/goals/{goal['id']}")
+
+        assert client.get(f"/api/projects/{project['id']}").status_code == 404
+        assert client.get(f"/api/tasks/{task['id']}").status_code == 404
 
     def test_delete_goal_not_found(self, client):
         resp = client.delete(f"/api/goals/{FAKE_UUID}")

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -210,6 +210,24 @@ class TestUpdateProject:
         )
         assert resp.status_code == 422
 
+    def test_patch_project_reparent_to_different_goal(self, client):
+        """Move a project from one goal to another via PATCH."""
+        domain = make_domain(client)
+        goal_a = make_goal(client, domain["id"], title="Goal A")
+        goal_b = make_goal(client, domain["id"], title="Goal B")
+        project = make_project(client, goal_a["id"])
+
+        resp = client.patch(
+            f"/api/projects/{project['id']}", json={"goal_id": goal_b["id"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["goal_id"] == goal_b["id"]
+
+        # Verify it shows under goal B's detail
+        detail = client.get(f"/api/goals/{goal_b['id']}").json()
+        project_ids = [p["id"] for p in detail["projects"]]
+        assert project["id"] in project_ids
+
     def test_patch_project_not_found(self, client):
         resp = client.patch(f"/api/projects/{FAKE_UUID}", json={"title": "X"})
         assert resp.status_code == 404

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -227,6 +227,19 @@ class TestUpdateRoutine:
         assert body["title"] == "Keep"
         assert body["energy_cost"] == 1
 
+    def test_patch_routine_reparent_to_different_domain(self, client):
+        """Move a routine from one domain to another via PATCH."""
+        domain_a = make_domain(client, name="Domain A")
+        domain_b = make_domain(client, name="Domain B")
+        routine = make_routine(client, domain_a["id"])
+
+        resp = client.patch(
+            f"/api/routines/{routine['id']}",
+            json={"domain_id": domain_b["id"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["domain_id"] == domain_b["id"]
+
     def test_patch_routine_not_found(self, client):
         resp = client.patch(f"/api/routines/{FAKE_UUID}", json={"title": "X"})
         assert resp.status_code == 404

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -299,6 +299,33 @@ class TestUpdateTask:
         assert body["title"] == "Keep"
         assert body["energy_cost"] == 1
 
+    def test_patch_task_reparent_to_different_project(self, client):
+        """Move a task from one project to another via PATCH."""
+        domain = make_domain(client)
+        goal = make_goal(client, domain["id"])
+        project_a = make_project(client, goal["id"], title="Project A")
+        project_b = make_project(client, goal["id"], title="Project B")
+        task = make_task(client, project_id=project_a["id"])
+
+        resp = client.patch(
+            f"/api/tasks/{task['id']}", json={"project_id": project_b["id"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["project_id"] == project_b["id"]
+
+    def test_patch_task_make_standalone(self, client):
+        """Detach a task from its project to make it standalone."""
+        domain = make_domain(client)
+        goal = make_goal(client, domain["id"])
+        project = make_project(client, goal["id"])
+        task = make_task(client, project_id=project["id"])
+
+        resp = client.patch(
+            f"/api/tasks/{task['id']}", json={"project_id": None},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["project_id"] is None
+
     def test_patch_task_not_found(self, client):
         resp = client.patch(f"/api/tasks/{FAKE_UUID}", json={"title": "X"})
         assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Fills test coverage gaps identified by QA: full cascade chain deletion, entity reparenting via PATCH, and activity log reference integrity when parent entities are deleted.

## Changes
- **`tests/test_domains.py`:** Added `test_delete_domain_cascades_full_chain` — deletes a domain and verifies the entire chain (goals → projects → tasks → task-tag associations) is removed while the tag itself survives.
- **`tests/test_goals.py`:** Added `test_delete_goal_cascades_projects_and_tasks` (goal deletion removes child projects and tasks) and `test_patch_goal_reparent_to_different_domain` (move a goal between domains via PATCH).
- **`tests/test_projects.py`:** Added `test_patch_project_reparent_to_different_goal` (move a project between goals via PATCH).
- **`tests/test_tasks.py`:** Added `test_patch_task_reparent_to_different_project` and `test_patch_task_make_standalone` (move task between projects or detach from project).
- **`tests/test_routines.py`:** Added `test_patch_routine_reparent_to_different_domain` (move routine between domains).
- **`tests/test_activity.py`:** Added `TestActivityReferenceIntegrity` class with three tests confirming FK SET NULL behavior when a referenced task, routine, or check-in is deleted.

## How to Verify
1. Run `pytest -v` — all 293 tests pass (10 new)
2. Verify each new test is independent (no shared state, no ordering dependencies)
3. Review test names match the coverage gaps from issue #29

## Deviations
- Enum validation edge cases (category 3 in the issue) were already covered by existing tests across all entity types. No new enum tests were needed — confirmed existing coverage for invalid status, cognitive_type, checkin_type, action_type, and frequency on both create and update endpoints.

## Test Results
```
pytest -v — 293 passed in 2.77s
ruff check . — All checks passed!
```

## Acceptance Checklist
- [x] Full cascade chain: domain → goals → projects → tasks → task-tags
- [x] Goal → projects + tasks cascade
- [x] Goal reparenting (PATCH domain_id)
- [x] Project reparenting (PATCH goal_id)
- [x] Task reparenting (PATCH project_id) and standalone detachment
- [x] Routine reparenting (PATCH domain_id)
- [x] Activity log SET NULL on task deletion
- [x] Activity log SET NULL on routine deletion
- [x] Activity log SET NULL on check-in deletion
- [x] All tests independent — no ordering dependencies
- [x] All 293 tests pass
- [x] Ruff clean

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)