### PR TITLE
Wiki Pages & Routine Adherence Contract (#31)

### DIFF
--- a/docs/wiki/API-Overview.md
+++ b/docs/wiki/API-Overview.md
@@ -1,0 +1,128 @@
+# API Overview
+
+BRAIN 3.0 exposes a RESTful API via FastAPI. All endpoints are under the `/api` prefix, with a standalone `/health` endpoint at the root. The full interactive documentation (Swagger UI) is available at `/docs` when the API is running.
+
+This page orients you to what's available. For endpoint-level detail — request/response schemas, status codes, and parameter types — use the `/docs` page.
+
+---
+
+## Health Check
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/health` | Returns API status and database connectivity |
+
+Returns `{"status": "healthy", "database": "connected"}` when everything is working, or a 503 with `"unhealthy"` if the database is unreachable.
+
+---
+
+## Entity CRUD
+
+Standard create, read, update, delete operations for all seven pillar entities. Each entity follows the same pattern:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/api/{entity}` | Create |
+| `GET` | `/api/{entity}` | List (with filters) |
+| `GET` | `/api/{entity}/{id}` | Get by ID (detail view with nested children) |
+| `PATCH` | `/api/{entity}/{id}` | Partial update |
+| `DELETE` | `/api/{entity}/{id}` | Delete |
+
+### Domains — `/api/domains`
+
+Life areas. CRUD only — domains are a simple organizational layer.
+
+### Goals — `/api/goals`
+
+Enduring outcomes nested under domains.
+
+**List filters:** `domain_id`, `status` (active, paused, achieved, abandoned)
+
+### Projects — `/api/projects`
+
+Bounded efforts nested under goals.
+
+**List filters:** `goal_id`, `status` (not_started, active, blocked, completed, abandoned)
+
+### Tasks — `/api/tasks`
+
+Atoms of action with ADHD-aware metadata. Tasks have the richest filtering of any entity — all filters are composable (combine any subset in a single request):
+
+| Filter | Type | What It Does |
+|--------|------|-------------|
+| `project_id` | UUID | Tasks in a specific project |
+| `standalone` | bool | Tasks with no project (`true`) or with a project (`false`) |
+| `status` | string | Filter by status (pending, active, completed, skipped, deferred) |
+| `cognitive_type` | string | Filter by cognitive type |
+| `energy_cost_min` / `energy_cost_max` | int | Energy cost range (1-5) |
+| `friction_min` / `friction_max` | int | Activation friction range (1-5) |
+| `context_required` | string | Filter by context (at_home, at_computer, etc.) |
+| `due_before` / `due_after` | date | Due date range |
+| `overdue` | bool | Tasks past due date and not completed/skipped |
+
+These filters are how Claude matches tasks to your current capacity — filtering by energy, friction, cognitive type, and context to surface what makes sense right now.
+
+### Tags — `/api/tags`
+
+Cross-cutting labels for tasks. Tags have globally unique names (case-insensitive) with get-or-create behavior on POST.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/api/tags` | Create or retrieve an existing tag |
+| `GET` | `/api/tags` | List all tags |
+| `GET` | `/api/tags/{id}` | Get a tag |
+| `PATCH` | `/api/tags/{id}` | Update a tag |
+| `DELETE` | `/api/tags/{id}` | Delete a tag |
+| `GET` | `/api/tags/{id}/tasks` | List all tasks with this tag |
+
+**Task-tag associations:**
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/tasks/{task_id}/tags` | List tags on a task |
+| `POST` | `/api/tasks/{task_id}/tags/{tag_id}` | Attach a tag to a task |
+| `DELETE` | `/api/tasks/{task_id}/tags/{tag_id}` | Detach a tag from a task |
+
+### Routines — `/api/routines`
+
+Behavioral patterns with streak tracking. Routines have additional endpoints beyond standard CRUD:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/api/routines/{id}/complete` | Mark a routine as completed (updates streak counters) |
+| `POST` | `/api/routines/{id}/schedules` | Add a schedule entry (day, time, preferred window) |
+| `GET` | `/api/routines/{id}/schedules` | List schedule entries |
+| `DELETE` | `/api/routines/{id}/schedules/{schedule_id}` | Remove a schedule entry |
+
+**List filters:** `domain_id`, `status` (active, paused, retired), `frequency`
+
+> **Note:** Completing a routine via `/complete` updates the streak counter but does **not** create an activity log entry. See [Architecture — Explicit Activity Logging](Architecture.md#explicit-activity-logging) for why this is intentional and what it means for reporting.
+
+### Check-ins — `/api/checkins`
+
+State snapshots (energy, mood, focus). CRUD with list filtering.
+
+**List filters:** `checkin_type` (morning, midday, evening, micro, freeform), `after`, `before` (date range)
+
+### Activity Log — `/api/activity`
+
+Record of what happened and how it felt. Each entry can reference a task, routine, and/or check-in.
+
+**List filters:** `task_id`, `routine_id`, `checkin_id`, `action_type`, `after`, `before` (date range)
+
+---
+
+## Reports
+
+Four read-only aggregation endpoints that power pattern recognition. All are under `/api/reports`.
+
+| Endpoint | What It Answers |
+|----------|----------------|
+| `GET /api/reports/activity-summary` | How productive was this period? Total completions, skips, deferrals, duration, average energy delta, average mood. |
+| `GET /api/reports/domain-balance` | Which life areas are getting attention and which are being neglected? Active goals, projects, pending tasks, overdue tasks, and days since last activity per domain. |
+| `GET /api/reports/routine-adherence` | How consistently am I maintaining my routines? Completions vs. expected, adherence percentage, streak health, broken streak flags. |
+| `GET /api/reports/friction-analysis` | Am I overestimating or underestimating friction? Predicted vs. actual friction by cognitive type, completion rates, energy impact. |
+
+**Activity summary** and **routine adherence** require `after` and `before` query parameters (datetime range). **Friction analysis** defaults to the last 30 days if no range is specified. **Domain balance** has no parameters — it reports current state.
+
+These endpoints are designed for Claude to consume and interpret conversationally. Claude reads the numbers; you get the insight in plain language.

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,0 +1,157 @@
+# Architecture
+
+BRAIN 3.0's data model is organized around **seven pillars** — core concepts that together give the system a complete picture of what matters in your life, what needs doing, how you're maintaining your patterns, how you're feeling, and what actually happened.
+
+For the full schema-level detail and technology rationale, see the [System Design Document](../BRAIN_3_0_Design_Document.md).
+
+---
+
+## The Seven Pillars
+
+### 1. Domains
+
+Life areas that cut across the entire system. Examples: House, Health, Finances, Network.
+
+Domains are a **filtering and reporting layer** — every goal and routine belongs to a domain, and everything beneath them inherits that categorization. They're intentionally broad and stable; you might have 4-8 of them and they rarely change. The [domain balance report](API-Overview.md#reports) uses domains to show which areas of life are getting attention and which are being neglected.
+
+### 2. Goals
+
+Enduring outcomes that give everything else meaning. Goals answer the question: *why does this matter?*
+
+Goals sit at the top of the hierarchy under domains. They rarely change. Examples: maintain the house, achieve financial stability, keep the network secure. When Claude acts as a partner, goals are the layer it uses to reason about priorities and notice neglected areas of life.
+
+### 3. Projects
+
+Bounded efforts with a beginning and an end, nested under goals. Projects have deadlines, progress tracking, and status. They represent the chunks of work that move a goal forward. Examples: remodel the bathroom, file 2026 taxes, segment VLANs.
+
+A project's progress is tracked as a percentage, calculated from the completion state of its tasks.
+
+### 4. Tasks
+
+The atoms of action — and where BRAIN 3.0 diverges most from a generic task manager. Every task carries **ADHD-aware metadata**:
+
+| Field | What It Captures | Scale |
+|-------|-----------------|-------|
+| `energy_cost` | How draining the task is, independent of time | 1-5 |
+| `cognitive_type` | What kind of thinking it requires | hands_on, communication, decision, errand, admin, focus_work |
+| `activation_friction` | How hard it is to *start*, regardless of how easy it is once going | 1-5 |
+| `context_required` | Where you need to be or what you need | at_home, at_computer, at_store, needs_tools, etc. |
+
+These fields let Claude match tasks to your current capacity. Low energy? Surface low-friction tasks. At the hardware store? Show everything tagged for that context across all projects. In a focus window? Offer the decision and admin tasks that benefit from that state.
+
+Tasks can be standalone or belong to a project. They support recurrence via RRULE strings (iCalendar standard), and can be tagged for cross-cutting connections.
+
+### 5. Routines
+
+Behavioral patterns the user is actively building or maintaining — modeled as a **first-class concept separate from recurring tasks**.
+
+A routine is not just a task that repeats. It's a commitment to a pattern of behavior. The system tracks streaks (current and best), monitors for pattern breaks, and responds differently when a routine is missed (encouragement, redesign suggestions) versus when a one-off task is overdue (simple rescheduling).
+
+Routines have their own schedule system: each routine can have multiple schedule entries specifying day of week, time of day, and preferred time windows. This supports complex patterns like "weekday mornings and Saturday afternoons."
+
+**Frequency options:** daily, weekdays, weekends, weekly, custom (with explicit schedule entries).
+
+### 6. Check-ins (Mindfulness & State)
+
+A continuous, low-friction layer for capturing internal state. Check-ins record:
+
+- **Energy level** (1-5)
+- **Mood** (1-5)
+- **Focus level** (1-5)
+- **Context** (work_day, day_off, chaotic, travel, etc.)
+- **Freeform notes** for open-ended mindfulness observations
+
+**Check-in types:** morning, midday, evening, micro (quick capture), freeform.
+
+This data serves two purposes: it lets Claude match tasks to current capacity in real time, and it feeds the reporting layer so you can see correlations between internal state and productivity over time.
+
+### 7. Activity Log
+
+The record of what actually happened. Every task completion, routine execution, and state change generates a log entry. The log captures not just *what* was done but *how it felt*:
+
+- Energy before and after
+- Actual friction experienced (vs. predicted)
+- Mood rating
+- Duration
+- Freeform notes
+
+This is what makes BRAIN a learning system. Claude uses the log to recognize patterns — you avoid phone calls, you're most productive Saturday mornings, you overestimate evening capacity. You use it through reporting to build self-awareness and identify recurring friction points.
+
+---
+
+## How the Pillars Relate
+
+```
+Domains
+  └── Goals
+        └── Projects
+              └── Tasks ←→ Tags (cross-cutting)
+  └── Routines
+        └── Routine Schedules
+
+Check-ins (standalone — capture state at any time)
+
+Activity Log (references tasks, routines, and/or check-ins)
+```
+
+Domains contain goals and routines. Goals contain projects. Projects contain tasks. Tasks can be tagged for connections that cut across the hierarchy (e.g., "home-depot" tags tasks in multiple projects).
+
+Check-ins are standalone — they capture how you're feeling without being tied to a specific action.
+
+The activity log ties everything together. Each entry can reference a task, a routine, and/or a check-in, recording what happened and how it felt. The four reporting endpoints aggregate this data to surface patterns.
+
+---
+
+## ADHD-Specific Design Principles
+
+These aren't afterthought features. They're the reason the system exists.
+
+### Friction Awareness
+
+Every task carries explicit activation friction and energy cost. The system matches tasks to current capacity rather than presenting a flat list ordered by due date. When energy is low, BRAIN surfaces low-friction tasks. When momentum is high, it offers the harder items that benefit from that window.
+
+### Context Batching
+
+Tags and context requirements enable intelligent batching. Already at the hardware store? BRAIN knows what else you need from there across all projects. At your computer in a focus window? It surfaces the admin and decision tasks that require that context.
+
+### Routine Scaffolding
+
+Routines are modeled as behavioral commitments, not recurring tasks. The system distinguishes between a missed routine (a pattern to address) and a missed one-off task (something to reschedule). This reflects how ADHD brains relate to habits — routines are scaffolding that either holds or collapses, and the response to each is different.
+
+### Pattern Visibility
+
+Reporting surfaces recurring friction points, avoidance patterns, energy cycles, and routine adherence trends. This makes the invisible patterns of ADHD visible and concrete — not as judgment, but as self-knowledge that enables better decisions.
+
+### Proactive Initiative (Phase 2+)
+
+The system is designed to reach out rather than wait to be checked. The ADHD brain struggles with object permanence — if the system isn't visible, it ceases to exist. Phase 2 adds a scheduler and Home Assistant integration to deliver morning briefings, accountability nudges, and timely reminders through push notifications and voice.
+
+---
+
+## Design Decisions
+
+Key architectural decisions that inform how the system works. These have been resolved and should not be revisited without discussion.
+
+### Explicit Activity Logging
+
+Activity log entries are created explicitly — there are no automatic side effects. When a routine is completed (via `POST /api/routines/{id}/complete`), the streak counter is updated, but **no activity log entry is created automatically**. The caller is responsible for creating a separate activity log entry (`POST /api/activity`) to record the completion with contextual data (energy, mood, friction, notes).
+
+This is by design. The activity log captures *how it felt*, not just *that it happened*. Automatic logging would produce entries without the subjective metadata that makes the log valuable for pattern recognition. The MCP partner layer is responsible for pairing these calls — completing the routine and logging the activity together — so that the routine adherence report has the data it needs.
+
+**Why this matters for reporting:** The [routine adherence report](API-Overview.md#reports) counts activity log entries with `action_type: "completed"` and a matching `routine_id` to calculate adherence percentages. If activity log entries aren't created alongside routine completions, the adherence report will show 0% even though the routine's streak counter is advancing.
+
+### Recurrence via RRULE
+
+Task recurrence uses RRULE strings (iCalendar standard) via the python-dateutil library. This handles all edge cases — month boundaries, leap years, complex schedules — through a well-tested standard. Claude generates and interprets the strings on behalf of the user; the user never touches the syntax directly.
+
+### No Authentication (Phase 1)
+
+BRAIN 3.0 is a single-user system running on a home network behind a firewall. The API runs with no authentication in Phase 1. The architecture uses a middleware pattern so that adding auth in Phase 3 (when the web UI exposes the system beyond localhost) is a single-layer addition.
+
+### Tags Are Global
+
+Tags have globally unique names (case-insensitive) and use a get-or-create pattern on POST. This means tagging a task with "home-depot" will reuse the existing tag rather than creating a duplicate. Tags connect tasks across projects and goals for cross-cutting queries.
+
+### PostgreSQL Over SQLite
+
+PostgreSQL was chosen for concurrent access support, LISTEN/NOTIFY (for future real-time UI), JSON columns, and full-text search. It runs in Docker on TrueNAS with nightly pg_dump backups and 30-day retention.

--- a/docs/wiki/Development-Guide.md
+++ b/docs/wiki/Development-Guide.md
@@ -1,0 +1,123 @@
+# Development Guide
+
+A summary of how development works on BRAIN 3.0. This page covers the workflow, conventions, and key references. For the full developer setup (from clone to running API), see [docs/dev-setup.md](../dev-setup.md). For the authoritative coding standards and project structure, see [CLAUDE.md](../../CLAUDE.md).
+
+---
+
+## Git Workflow
+
+### Branching Strategy
+
+```
+main          ← production deploys only
+  └── develop ← integration branch, all features merge here
+        └── feature/TICKET-XX-short-description
+```
+
+- Never commit directly to `main` or `develop`
+- One branch per ticket, branched from `develop`
+- PRs target `develop`
+- `main` is updated from `develop` only for deployment milestones
+
+### Branch Naming
+
+- Features: `feature/TICKET-XX-short-description`
+- Documentation: `docs/short-description`
+
+### Commit Messages
+
+[Conventional Commits](https://www.conventionalcommits.org/) with ticket reference:
+
+```
+type(scope): description (#XX)
+```
+
+**Types:** `feat`, `fix`, `docs`, `test`, `chore`, `refactor`
+
+**Examples:**
+```
+feat(api): add domain CRUD endpoints (#4)
+fix(db): correct cascade delete on projects (#5)
+docs: rewrite README with architecture overview
+test(api): add composable filter tests for tasks (#5)
+```
+
+Commits should be atomic — one logical change per commit.
+
+---
+
+## Pull Request Process
+
+1. Ensure all tests pass (`pytest -v`) and lint is clean (`ruff check .`)
+2. Push your feature branch and open a PR targeting `develop`
+3. Title format: `TICKET-XX: Short description`
+4. Fill out **every section** of the PR template:
+
+| Section | What Goes There |
+|---------|----------------|
+| **Summary** | What was built, in plain language |
+| **Changes** | Files created/modified and why |
+| **How to Verify** | Step-by-step verification instructions |
+| **Deviations** | Anything that differs from the ticket spec (or "None") |
+| **Test Results** | Confirmation that tests pass, with output |
+| **Acceptance Checklist** | Criteria from the ticket, checked off |
+
+The **Deviations** section matters. If you deviated from the spec — even for good reasons — document it. Undocumented deviations create confusion during review.
+
+---
+
+## Ticket Workflow
+
+Work is organized through GitHub issues with detailed ticket specs in `docs/tickets/`.
+
+1. Read the ticket spec before starting work
+2. Create a feature branch from `develop`
+3. If anything in the ticket is ambiguous, ask — don't guess
+4. If you find a bug or issue outside the current ticket's scope, **file a GitHub issue** rather than fixing it inline
+5. Open a PR when complete, linking to the issue with `Closes #XX`
+
+---
+
+## Testing
+
+Tests use an in-memory SQLite database — no external dependencies needed.
+
+```bash
+pytest -v              # Full suite
+pytest tests/test_tasks.py -v   # Single file
+ruff check .           # Lint
+```
+
+**CI runs both** on every push and PR to `develop`. Both must pass.
+
+### Testing Standards
+
+- Every API endpoint gets: happy path, validation, not found (404), and filter tests
+- Tests must be independent — each creates its own data
+- Use the helper fixtures in `tests/conftest.py` (`make_domain`, `make_goal`, `make_task`, etc.)
+
+---
+
+## Code Standards
+
+| Standard | Rule |
+|----------|------|
+| Style | PEP 8 |
+| Type hints | Required on all function signatures |
+| Line length | 100 characters max |
+| Strings | f-strings over `.format()` or `%` |
+| Paths | `pathlib` over `os.path` |
+| ORM style | SQLAlchemy 2.0 (`DeclarativeBase`, `Mapped`, `mapped_column`) |
+| Schemas | Pydantic 2.x with `model_config = {"from_attributes": True}` |
+
+---
+
+## Key References
+
+| Resource | What It Covers |
+|----------|---------------|
+| [CLAUDE.md](../../CLAUDE.md) | Full developer guide — project structure, conventions, design decisions |
+| [docs/dev-setup.md](../dev-setup.md) | Prerequisites, clone, configure, start, test, troubleshoot |
+| [docs/deployment.md](../deployment.md) | Production deployment on TrueNAS |
+| [docs/environment-variables.md](../environment-variables.md) | Every env var documented |
+| [System Design Document](../BRAIN_3_0_Design_Document.md) | Architecture, data model, schema, design philosophy |

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,45 @@
+# BRAIN 3.0 Wiki
+
+**AI-Powered Personal Operating System for ADHD**
+
+BRAIN 3.0 is a personal life management system designed to work with how an ADHD brain actually functions. It pairs a structured data model — organized around seven pillars that capture what matters, what needs doing, and how you're doing — with Claude as an AI partner that has full context to reason about priorities, spot avoidance patterns, and match work to your current capacity.
+
+This is not a task manager. It's a system that has initiative, not just memory.
+
+**Version:** 1.0.0 (Phase 1 complete)
+**Status:** Core data loop — database, API, and MCP integration — is stable and deployed. 283+ tests passing, CI green, production running on TrueNAS.
+
+---
+
+## Wiki Pages
+
+| Page | What's There |
+|------|-------------|
+| [Architecture](Architecture.md) | The seven pillars, how they relate, ADHD-specific design principles, and key design decisions |
+| [API Overview](API-Overview.md) | Endpoint groups, what each covers, query filters, reporting endpoints |
+| [MCP Setup](MCP-Setup.md) | How to connect Claude to BRAIN 3.0 via the Model Context Protocol |
+| [Development Guide](Development-Guide.md) | Developer workflow, git conventions, PR process, testing |
+| [Roadmap](Roadmap.md) | Phase 1 (complete) through Phase 4+ (vision) — what's built, what's planned, what's speculative |
+
+## Key Resources
+
+| Resource | Location |
+|----------|----------|
+| [System Design Document](../BRAIN_3_0_Design_Document.md) | Full architecture, data model, schema, and design rationale |
+| [Developer Setup Guide](../dev-setup.md) | From clone to running API |
+| [Deployment Guide](../deployment.md) | Production deployment on TrueNAS or any Docker host |
+| [Environment Variables](../environment-variables.md) | Every env var documented |
+| [CLAUDE.md](../../CLAUDE.md) | Developer standards and conventions |
+| [README](../../README.md) | Project overview and quick start |
+
+## What's Not Here Yet
+
+Phase 1 delivers the core data loop: Claude can manage your goals, tasks, routines, and patterns through conversation. What's **not** in v1.0.0:
+
+- No web UI (Phase 3)
+- No authentication — single-user system behind a firewall (Phase 3)
+- No scheduler or push notifications (Phase 2)
+- No Home Assistant integration (Phase 2)
+- No calendar sync (Phase 4+)
+
+See the [Roadmap](Roadmap.md) for what's coming and when.

--- a/docs/wiki/MCP-Setup.md
+++ b/docs/wiki/MCP-Setup.md
@@ -1,0 +1,100 @@
+# MCP Setup
+
+BRAIN 3.0's primary interface is Claude, connected through the **Model Context Protocol (MCP)**. The MCP gives Claude full read/write access to the BRAIN 3.0 API — every CRUD operation, every filter, every report. This is where the partner relationship lives.
+
+---
+
+## How It Works
+
+The MCP server is a separate application ([brain3-mcp](https://github.com/WilliM233/brain3-mcp)) that runs as a Claude subprocess on your local machine. It translates Claude's tool calls into HTTP requests against the BRAIN 3.0 API.
+
+```
+Claude Desktop  →  brain3-mcp (local subprocess)  →  BRAIN 3.0 API (localhost or TrueNAS)
+```
+
+The MCP server does not store data — it's a translation layer. All state lives in the BRAIN 3.0 database, accessed through the API.
+
+## What Claude Can Do
+
+With the MCP connected, Claude has access to:
+
+- **Full CRUD** on all seven pillar entities — create, read, update, delete domains, goals, projects, tasks, routines, check-ins, and activity log entries
+- **Filtered queries** — find tasks by energy level, cognitive type, context, due date, and more
+- **Tag management** — create tags, attach/detach them from tasks, query tasks by tag
+- **Routine management** — complete routines, manage schedules, track streaks
+- **Reporting** — activity summaries, domain balance, routine adherence, friction analysis
+- **Health check** — verify the API and database are connected
+
+This gives Claude enough context to act as a partner: reasoning about priorities, noticing neglected areas, matching tasks to current capacity, and surfacing patterns from the activity log.
+
+---
+
+## Setup
+
+### Prerequisites
+
+- BRAIN 3.0 API running and accessible (see [Deployment Guide](../deployment.md) or [Dev Setup](../dev-setup.md))
+- Python 3.12+ on your local machine
+- Claude Desktop (or Claude Code)
+
+### 1. Clone the MCP server
+
+```bash
+git clone https://github.com/WilliM233/brain3-mcp.git
+cd brain3-mcp
+```
+
+### 2. Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 3. Configure Claude Desktop
+
+Add the MCP server to your Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "brain3": {
+      "command": "python",
+      "args": ["/path/to/brain3-mcp/mcp/server.py"],
+      "env": {
+        "BRAIN3_API_URL": "http://localhost:8000"
+      }
+    }
+  }
+}
+```
+
+If your API is running on TrueNAS or another server, replace `localhost:8000` with the server's IP and port:
+
+```json
+"BRAIN3_API_URL": "http://192.168.1.100:8000"
+```
+
+### 4. Verify
+
+Restart Claude Desktop, then ask Claude to run the `health_check` tool. If it reports healthy, the connection is working.
+
+---
+
+## Troubleshooting
+
+**Claude doesn't see the BRAIN 3.0 tools:**
+- Is the MCP server configured in Claude Desktop's settings? Check the config file path.
+- Did you restart Claude Desktop after adding the configuration?
+
+**Health check fails:**
+- Is the BRAIN 3.0 API running? `curl http://localhost:8000/health`
+- Is `BRAIN3_API_URL` set correctly? It must include the protocol (`http://`) and port.
+- If the API is on another machine, is port 8000 open and reachable from your local network?
+
+**MCP server crashes on startup:**
+- Check that Python 3.12+ is installed and the dependencies are installed.
+- Check the path to `server.py` in your configuration.
+
+---
+
+For full MCP server documentation, see the [brain3-mcp repository](https://github.com/WilliM233/brain3-mcp).

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -1,0 +1,106 @@
+# Roadmap
+
+BRAIN 3.0 is built in phases. Each phase adds a capability layer to the system without requiring changes to previous phases.
+
+---
+
+## Phase 1 — The Core Loop ✓
+
+**Status: Complete** (v1.0.0, March 2026)
+
+The data foundation and conversational interface. Claude has full read/write access to all seven pillar entities through the MCP.
+
+### What's Delivered
+
+- **PostgreSQL database** on Docker with all seven pillar tables and relationships
+- **FastAPI REST API** with full CRUD, composable query filters, and four reporting endpoints
+- **Claude MCP integration** via [brain3-mcp](https://github.com/WilliM233/brain3-mcp) — 50+ tools covering all entities
+- **ADHD-aware task metadata** — energy cost, cognitive type, activation friction, context requirements
+- **Routine system** with streak tracking, flexible scheduling, and pattern break detection
+- **Activity logging** with subjective metadata (energy before/after, actual friction, mood)
+- **Reporting** — activity summaries, domain balance, routine adherence, friction analysis
+- **Production deployment** on TrueNAS with Docker Compose, automated migrations, nightly backups
+- **CI pipeline** — 283+ tests, Ruff lint, GitHub Actions
+- **Documentation** — README, developer setup, deployment guide, environment reference, wiki
+
+### What's Not Here
+
+- No web UI — interaction is through Claude conversation only
+- No authentication — single-user system behind a firewall
+- No scheduler — the system responds but doesn't initiate
+- No push notifications or voice interface
+- No Home Assistant integration
+
+---
+
+## Phase 2 — The System Gets Proactive
+
+**Status: Planned**
+
+The system transitions from responsive to proactive. Claude reaches out rather than waiting to be asked.
+
+### Planned Capabilities
+
+- **Internal scheduler** (APScheduler or cron-based) for time-triggered behaviors
+- **Home Assistant integration** — push notifications via the companion app, voice interface via Assist
+- **Morning briefings** — daily summary of what's on deck, routine status, and relevant context
+- **Accountability nudges** — missed routine alerts, deadline warnings, neglected domain flags
+- **MCP composite tools** — higher-level operations that combine multiple API calls (e.g., "complete routine + log activity + check in" as a single tool)
+- **Modular MCP refactoring** — splitting the monolithic `server.py` into per-entity tool modules as composite tools justify the structure
+
+### What This Changes
+
+Phase 1 BRAIN waits to be asked. Phase 2 BRAIN notices things and reaches out — a missed routine, an approaching deadline, an area of life that hasn't gotten attention in weeks. The ADHD brain struggles with object permanence; Phase 2 addresses this by making the system visible through the channels you already check.
+
+---
+
+## Phase 3 — Browse and Manage Directly
+
+**Status: Planned**
+
+A lightweight web UI for when you want to see your world at a glance without having a conversation.
+
+### Planned Capabilities
+
+- **Mobile-first web dashboard** — goals, projects, tasks, routines at a glance
+- **Quick entry** — add tasks and log activities without a full conversation
+- **Visual reporting** — charts and trend lines for pattern recognition (energy cycles, routine adherence, friction analysis)
+- **Authentication** — API key, OAuth, or basic auth middleware (required once the UI exposes the system beyond localhost)
+
+### What This Changes
+
+Phase 3 adds a visual layer that complements the conversational interface. Claude remains the richer interface for reasoning and pattern interpretation; the UI provides at-a-glance awareness and low-friction data entry.
+
+---
+
+## Phase 4+ — Expand and Integrate
+
+**Status: Vision**
+
+Everything beyond Phase 3 is speculative. These are directions, not commitments.
+
+### Possible Directions
+
+- **New life domains** — finances (budget tracking, bill management), health (medication, exercise, sleep)
+- **Voice interface** — deeper Home Assistant Assist integration for hands-free interaction
+- **Calendar integration** — sync with external calendars for deadline awareness and scheduling
+- **Ambient reminders** — Home Assistant automations (lights, display panels) for non-intrusive nudges
+- **Multi-device sync** — consistent experience across devices
+- **Pattern learning** — the system improves its friction and energy predictions over time based on activity log history
+
+### What's Speculative Here
+
+All of it. Phase 4+ items are ideas that emerged from the design process and represent where the system *could* go. They will be scoped and prioritized based on what actually matters once Phases 1-3 are stable and in daily use.
+
+---
+
+## How Phases Build on Each Other
+
+```
+Phase 1:  Data + API + Claude conversation
+Phase 2:  + Scheduler + Notifications + Home Assistant
+Phase 3:  + Web UI + Auth + Visual reporting
+Phase 4+: + New domains + Voice + Calendar + Ambient
+```
+
+Each phase adds a capability layer without modifying the previous one. The API and data model from Phase 1 serve all future phases. The MCP contract from Phase 1 extends in Phase 2 with composite tools. The reporting from Phase 1 gets a visual representation in Phase 3.


### PR DESCRIPTION
## Summary

Pass 3 (Part A + B.1) of the technical writing phase. Six wiki-ready markdown pages in `docs/wiki/` covering architecture, API, MCP setup, development workflow, and roadmap. Also documents the routine adherence / activity log contract from brain3#31 in the Architecture page.

## Changes

**docs/wiki/Home.md** — Wiki landing page. Project description, links to all wiki pages, key resource table, and honest list of what's not in v1.0.0.

**docs/wiki/Architecture.md** — The seven pillars explained with their relationships and ADHD-specific design principles. Includes a Design Decisions section covering: explicit activity logging (the #31 contract), RRULE recurrence, no-auth in Phase 1, global tags, and PostgreSQL rationale.

**docs/wiki/API-Overview.md** — All endpoint groups with purpose, filters, and special endpoints. Full task filter table (12 composable filters). All four reporting endpoints with what questions they answer. Notes the routine completion / activity log separation with a cross-link to Architecture.

**docs/wiki/MCP-Setup.md** — What the MCP is, how it works (architecture diagram), what Claude can do with it, setup steps, and troubleshooting. Points to brain3-mcp for full documentation.

**docs/wiki/Development-Guide.md** — Git workflow, branching, commit conventions, PR process with template section descriptions, ticket workflow, testing standards, code standards table. Links to CLAUDE.md and dev-setup.md for detail.

**docs/wiki/Roadmap.md** — Phase 1 (complete, detailed deliverables list), Phase 2 (planned, specific capabilities), Phase 3 (planned, specific capabilities), Phase 4+ (vision, explicitly speculative). Includes a "how phases build on each other" summary.

## How to Verify

1. Read each wiki page. Does it stand alone? Can you understand the page without reading the others first?
2. Follow cross-links between wiki pages — they should all resolve to real files.
3. Follow links from wiki pages to other docs (dev-setup.md, deployment.md, CLAUDE.md, design document) — they should all resolve.
4. Read the "Explicit Activity Logging" section in Architecture.md — does it clearly explain why routine completions don't auto-create activity log entries and what the caller must do?
5. Check API-Overview.md against `/docs` on a running instance — endpoint groups, paths, and filter parameters should match.

## Deviations

- The brief suggests the routine adherence contract (#31) could go in the deployment guide, wiki architecture page, or a dedicated Design Decisions section. Placed it in Architecture.md under "Design Decisions" since it's an architectural decision about data flow, not a deployment concern. Also added a cross-reference note in API-Overview.md under the Routines section.
- Added a relationship diagram (text-based) to Architecture.md showing how the seven pillars connect. Not in the brief but essential for orienting new readers.

## Test Results

No application code changed.

```
pytest -v → 283 passed
ruff check . → All checks passed!
```

## Acceptance Checklist

### Wiki Pages
- [x] Home.md — project overview, wiki index, project status
- [x] Architecture.md — seven pillars, relationships, ADHD principles
- [x] API-Overview.md — endpoint groups, filters, reporting
- [x] MCP-Setup.md — connection setup, points to brain3-mcp
- [x] Development-Guide.md — workflow summary, links to CLAUDE.md and dev-setup.md
- [x] Roadmap.md — Phase 1 complete, Phase 2-3 planned, Phase 4+ speculative

### brain3#31 — Routine Adherence Contract
- [x] Documented that routine completion does not auto-create activity log entries
- [x] Explained why (explicit logging principle — captures subjective metadata)
- [x] Noted that MCP partner layer is responsible for pairing the calls
- [x] Explained impact on routine adherence reporting

---

*Pass 3 (Part A) of 3 — Wilhelmina Prose, Technical Writing Phase*