### PR TITLE
ISSUE-60: Fix smoke test failures on hardened API

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -41,11 +41,11 @@ fail_step() {
 cleanup() {
     echo ""
     echo "Cleaning up test entities..."
-    [ -n "$ACTIVITY_ID" ] && curl -s -X DELETE "$BASE_URL/api/activity/$ACTIVITY_ID" > /dev/null 2>&1 && echo "  Deleted activity $ACTIVITY_ID" || true
-    [ -n "$TASK_ID" ] && curl -s -X DELETE "$BASE_URL/api/tasks/$TASK_ID" > /dev/null 2>&1 && echo "  Deleted task $TASK_ID" || true
-    [ -n "$PROJECT_ID" ] && curl -s -X DELETE "$BASE_URL/api/projects/$PROJECT_ID" > /dev/null 2>&1 && echo "  Deleted project $PROJECT_ID" || true
-    [ -n "$GOAL_ID" ] && curl -s -X DELETE "$BASE_URL/api/goals/$GOAL_ID" > /dev/null 2>&1 && echo "  Deleted goal $GOAL_ID" || true
-    [ -n "$DOMAIN_ID" ] && curl -s -X DELETE "$BASE_URL/api/domains/$DOMAIN_ID" > /dev/null 2>&1 && echo "  Deleted domain $DOMAIN_ID" || true
+    [ -n "$ACTIVITY_ID" ] && curl -s -L -X DELETE "$BASE_URL/api/activity/$ACTIVITY_ID" > /dev/null 2>&1 && echo "  Deleted activity $ACTIVITY_ID" || true
+    [ -n "$TASK_ID" ] && curl -s -L -X DELETE "$BASE_URL/api/tasks/$TASK_ID" > /dev/null 2>&1 && echo "  Deleted task $TASK_ID" || true
+    [ -n "$PROJECT_ID" ] && curl -s -L -X DELETE "$BASE_URL/api/projects/$PROJECT_ID" > /dev/null 2>&1 && echo "  Deleted project $PROJECT_ID" || true
+    [ -n "$GOAL_ID" ] && curl -s -L -X DELETE "$BASE_URL/api/goals/$GOAL_ID" > /dev/null 2>&1 && echo "  Deleted goal $GOAL_ID" || true
+    [ -n "$DOMAIN_ID" ] && curl -s -L -X DELETE "$BASE_URL/api/domains/$DOMAIN_ID" > /dev/null 2>&1 && echo "  Deleted domain $DOMAIN_ID" || true
 }
 
 # Helper: make an API call and capture status + body
@@ -55,12 +55,12 @@ api_call() {
     local data="${3:-}"
 
     if [ -n "$data" ]; then
-        RESPONSE=$(curl -s -w "\n%{http_code}" -X "$method" \
+        RESPONSE=$(curl -s -L -w "\n%{http_code}" -X "$method" \
             -H "Content-Type: application/json" \
             -d "$data" \
             "$BASE_URL$path" 2>&1) || RESPONSE=$'error\n000'
     else
-        RESPONSE=$(curl -s -w "\n%{http_code}" -X "$method" \
+        RESPONSE=$(curl -s -L -w "\n%{http_code}" -X "$method" \
             "$BASE_URL$path" 2>&1) || RESPONSE=$'error\n000'
     fi
 
@@ -158,7 +158,7 @@ fi
 # Step 7: Log activity
 # -----------------------------------------------------------------------
 echo "Step 7: Log activity"
-api_call POST /api/activity "{\"action_type\": \"smoke_test\", \"notes\": \"Automated smoke test entry\"}"
+api_call POST /api/activity "{\"action_type\": \"completed\", \"notes\": \"Automated smoke test entry\"}"
 
 if [ "$HTTP_STATUS" = "201" ]; then
     ACTIVITY_ID=$(echo "$BODY" | jq -r '.id')


### PR DESCRIPTION
## Summary

Fixed the smoke test script (`scripts/smoke-test.sh`) which failed against the hardened API due to two issues: missing redirect handling on curl calls, and an invalid `action_type` enum value in the activity log test step.

## Changes

**`scripts/smoke-test.sh`** — Two fixes applied:
1. Added `-L` flag to all curl calls in the `api_call()` helper function so curl follows FastAPI's 307 redirects (e.g., `/api/domains` → `/api/domains/`).
2. Changed the activity log test from `action_type: "smoke_test"` (invalid after Pydantic enum validation from #26) to `action_type: "completed"` (a valid `ActionType` value).
3. Added `-L` to the `cleanup()` function's curl calls to ensure cleanup succeeds even when the test fails mid-run.

## How to Verify

1. Start the dev stack: `docker compose -f docker-compose.dev.yml up -d` + `uvicorn app.main:app --reload`
2. Run: `bash scripts/smoke-test.sh http://localhost:8000`
3. All 13 steps should pass (health check, CRUD cycle, activity log, report query, cleanup)
4. After the test completes, verify no orphaned records exist:
   - `GET /api/domains/` — no "Smoke Test Domain"
   - `GET /api/activity/` — no "Automated smoke test entry"

## Deviations

None. Both fixes align with the issue description.

## Test Results

```
pytest -v: 293 passed
ruff check .: All checks passed!

Smoke test: All 13 tests passed.
Cleanup verification: 0 orphaned domains, 0 orphaned activity logs.
```

## Acceptance Checklist

- [x] Smoke test follows redirects (curl `-L` flag added)
- [x] Activity log test uses valid enum value (`completed`)
- [x] All 13 smoke test steps pass
- [x] Cleanup completes — no leftover test data in database
- [x] pytest passes (293 tests)
- [x] ruff check passes

Closes #60