### PR TITLE
ISSUE-61: Correct wiki API filter parameters for activity log and check-ins

### DIFF
--- a/docs/wiki/API-Overview.md
+++ b/docs/wiki/API-Overview.md
@@ -102,13 +102,13 @@ Behavioral patterns with streak tracking. Routines have additional endpoints bey
 
 State snapshots (energy, mood, focus). CRUD with list filtering.
 
-**List filters:** `checkin_type` (morning, midday, evening, micro, freeform), `after`, `before` (date range)
+**List filters:** `checkin_type` (morning, midday, evening, micro, freeform), `context`, `logged_after`, `logged_before` (date range)
 
 ### Activity Log — `/api/activity`
 
 Record of what happened and how it felt. Each entry can reference a task, routine, and/or check-in.
 
-**List filters:** `task_id`, `routine_id`, `checkin_id`, `action_type`, `after`, `before` (date range)
+**List filters:** `action_type`, `task_id`, `routine_id`, `logged_after`, `logged_before` (date range), `has_task`, `has_routine`
 
 ---
 


### PR DESCRIPTION
## Summary

Corrected incorrect filter parameter names and missing filters in the wiki API Overview page for the activity log and check-in list endpoints.

## Changes

**`docs/wiki/API-Overview.md`** — Two sections corrected:

1. **Activity log filters (line 111):** Removed nonexistent `checkin_id` parameter, renamed `after`/`before` to `logged_after`/`logged_before` to match router code, added missing `has_task` and `has_routine` boolean filters.

2. **Check-in filters (line 105):** Renamed `after`/`before` to `logged_after`/`logged_before` to match router code, added missing `context` filter.

## How to Verify

Compare the corrected filter lists against the actual router signatures:
- `app/routers/activity.py` → `list_activity()` parameters
- `app/routers/checkins.py` → `list_checkins()` parameters

## Deviations

None.

## Test Results

```
pytest -v: 293 passed
ruff check .: All checks passed!
```

(Docs-only change — no functional impact.)

## Acceptance Checklist

- [x] Activity log filters match `app/routers/activity.py` — `action_type`, `task_id`, `routine_id`, `logged_after`, `logged_before`, `has_task`, `has_routine`
- [x] Check-in filters match `app/routers/checkins.py` — `checkin_type`, `context`, `logged_after`, `logged_before`
- [x] Removed nonexistent `checkin_id` filter from activity log
- [x] All date range filters use correct `logged_after`/`logged_before` names

Closes #61