### PR TITLE
ISSUE-66: Fix CRLF line endings breaking container entrypoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Ensure shell scripts always use LF line endings, even on Windows.
+# Without this, git core.autocrlf=true converts LF → CRLF on checkout,
+# which breaks scripts running inside Linux containers.
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY app/ app/
 
 # Copy and prepare entrypoint
 COPY scripts/entrypoint.sh scripts/entrypoint.sh
-RUN chmod +x scripts/entrypoint.sh
+RUN sed -i 's/\r$//' scripts/entrypoint.sh && chmod +x scripts/entrypoint.sh
 
 # Switch to non-root user
 USER brain3


### PR DESCRIPTION
## Summary

Fixed a blocker where the production Docker container failed to start on Windows builds because shell scripts had CRLF line endings. The `\r` in the shebang line caused Linux to report `exec scripts/entrypoint.sh: no such file or directory`.

## Changes

**`.gitattributes`** (new) — Forces LF line endings for all `*.sh` files on checkout, regardless of `core.autocrlf` setting.

**`Dockerfile`** — Added `sed -i 's/\r$//'` to strip carriage returns from `entrypoint.sh` during build as a safety net for any build environment.

## How to Verify

1. On Windows: `docker compose -f docker-compose.prod.yml up -d --build`
2. `docker logs brain3-api` — should show migration output and uvicorn startup, not "no such file or directory"
3. `curl http://localhost:8000/health` — should return healthy

## Deviations

None — this is a straightforward infrastructure fix discovered during Phase 4 verification.

## Test Results

```
pytest -v: 293 passed
ruff check .: All checks passed!
```

## Acceptance Checklist

- [x] `.gitattributes` enforces LF on `*.sh` files
- [x] Dockerfile strips `\r` from entrypoint as safety net
- [x] Production container starts successfully
- [x] Tests pass, lint clean

Closes #66