### PR TITLE
TICKET-69: Compute progress_pct dynamically from task completion ratio

### DIFF
--- a/app/routers/projects.py
+++ b/app/routers/projects.py
@@ -18,6 +18,16 @@ from app.schemas.projects import (
 router = APIRouter()
 
 
+def _compute_progress(project: Project) -> None:
+    """Set progress_pct from the ratio of completed tasks to total tasks."""
+    tasks = project.tasks
+    if not tasks:
+        project.progress_pct = 0
+    else:
+        completed = sum(1 for t in tasks if t.status == "completed")
+        project.progress_pct = round(completed * 100 / len(tasks))
+
+
 @router.post("/", response_model=ProjectResponse, status_code=status.HTTP_201_CREATED)
 def create_project(payload: ProjectCreate, db: Session = Depends(get_db)) -> Project:
     """Create a new project. Validates that goal_id references an existing goal."""
@@ -41,7 +51,7 @@ def list_projects(
     db: Session = Depends(get_db),
 ) -> list[Project]:
     """List projects with optional filters."""
-    query = db.query(Project)
+    query = db.query(Project).options(joinedload(Project.tasks))
 
     if goal_id is not None:
         query = query.filter(Project.goal_id == goal_id)
@@ -55,7 +65,10 @@ def list_projects(
             Project.status.notin_(["completed", "abandoned"]),
         )
 
-    return query.order_by(Project.created_at).all()
+    projects = query.order_by(Project.created_at).all()
+    for project in projects:
+        _compute_progress(project)
+    return projects
 
 
 @router.get("/{project_id}", response_model=ProjectDetailResponse)
@@ -69,6 +82,7 @@ def get_project(project_id: UUID, db: Session = Depends(get_db)) -> Project:
     )
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
+    _compute_progress(project)
     return project
 
 
@@ -86,6 +100,7 @@ def update_project(
 
     db.commit()
     db.refresh(project)
+    _compute_progress(project)
     return project
 
 

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -263,3 +263,60 @@ class TestDeleteProject:
     def test_delete_project_not_found(self, client):
         resp = client.delete(f"/api/projects/{FAKE_UUID}")
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# progress_pct dynamic computation (#69)
+# ---------------------------------------------------------------------------
+
+class TestProgressPct:
+
+    def test_progress_zero_tasks(self, client):
+        """Project with no tasks returns 0%."""
+        domain = make_domain(client)
+        goal = make_goal(client, domain["id"])
+        project = make_project(client, goal["id"])
+        resp = client.get(f"/api/projects/{project['id']}")
+        assert resp.json()["progress_pct"] == 0
+
+    def test_progress_half_completed(self, client):
+        """Project with 1/2 completed tasks returns 50%."""
+        domain = make_domain(client)
+        goal = make_goal(client, domain["id"])
+        project = make_project(client, goal["id"])
+        make_task(client, project_id=project["id"], title="Done", status="completed")
+        make_task(client, project_id=project["id"], title="Pending")
+        resp = client.get(f"/api/projects/{project['id']}")
+        assert resp.json()["progress_pct"] == 50
+
+    def test_progress_all_completed(self, client):
+        """Project with 2/2 completed tasks returns 100%."""
+        domain = make_domain(client)
+        goal = make_goal(client, domain["id"])
+        project = make_project(client, goal["id"])
+        make_task(client, project_id=project["id"], title="A", status="completed")
+        make_task(client, project_id=project["id"], title="B", status="completed")
+        resp = client.get(f"/api/projects/{project['id']}")
+        assert resp.json()["progress_pct"] == 100
+
+    def test_progress_all_pending(self, client):
+        """Project with all pending tasks returns 0%."""
+        domain = make_domain(client)
+        goal = make_goal(client, domain["id"])
+        project = make_project(client, goal["id"])
+        make_task(client, project_id=project["id"], title="A")
+        make_task(client, project_id=project["id"], title="B")
+        resp = client.get(f"/api/projects/{project['id']}")
+        assert resp.json()["progress_pct"] == 0
+
+    def test_progress_on_list_endpoint(self, client):
+        """list_projects also returns computed progress_pct."""
+        domain = make_domain(client)
+        goal = make_goal(client, domain["id"])
+        project = make_project(client, goal["id"])
+        make_task(client, project_id=project["id"], title="Done", status="completed")
+        make_task(client, project_id=project["id"], title="Pending")
+        resp = client.get("/api/projects")
+        projects = resp.json()
+        assert len(projects) == 1
+        assert projects[0]["progress_pct"] == 50


### PR DESCRIPTION
## Summary
`progress_pct` on projects now reflects the actual ratio of completed tasks to total tasks, computed dynamically at query time. Previously it was a static column defaulting to 0 that never got updated.

## Changes
- **app/routers/projects.py** — Added `_compute_progress()` helper that calculates `completed / total * 100`. Applied to `get_project`, `list_projects`, and `update_project` endpoints. Added `joinedload(Project.tasks)` to `list_projects` so tasks are available for the computation.
- **tests/test_projects.py** — Added `TestProgressPct` class with 5 tests: zero tasks (0%), half completed (50%), all completed (100%), all pending (0%), and list endpoint returns computed value.

## How to Verify
1. Create a project with 2 tasks
2. Mark one task as completed
3. `GET /api/projects/{id}` — `progress_pct` should be 50
4. `GET /api/projects` — same project should show 50
5. Mark the second task as completed — should show 100

## Deviations
None

## Test Results
```
298 passed in 2.96s
ruff: All checks passed!
```

## Acceptance Checklist
- [x] `progress_pct` dynamically computed from task completion ratio
- [x] Returns 0 when no tasks exist
- [x] Works on both `get_project` and `list_projects`
- [x] Tests cover 0 tasks, partial, full, and all-pending scenarios

Closes #69