### PR TITLE
TICKET-14: Activity tags — attach, detach, filter, reverse lookup

### DIFF
--- a/alembic/versions/002_activity_tags.py
+++ b/alembic/versions/002_activity_tags.py
@@ -1,0 +1,54 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""add activity_tags association table
+
+Revision ID: a1b2c3d4e5f6
+Revises: 5ccf2b58d02a
+Create Date: 2026-04-02 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "5ccf2b58d02a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "activity_tags",
+        sa.Column("activity_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tag_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["activity_id"], ["activity_log.id"], ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tag_id"], ["tags.id"], ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("activity_id", "tag_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("activity_tags")

--- a/app/main.py
+++ b/app/main.py
@@ -77,3 +77,6 @@ app.include_router(checkins.router, prefix="/api/checkins", tags=["Check-ins"])
 app.include_router(activity.router, prefix="/api/activity", tags=["Activity Log"])
 app.include_router(reports.router, prefix="/api/reports", tags=["Reports"])
 app.include_router(tags.task_tags_router, prefix="/api/tasks", tags=["Task Tags"])
+app.include_router(
+    activity.activity_tags_router, prefix="/api/activity", tags=["Activity Tags"],
+)

--- a/app/models.py
+++ b/app/models.py
@@ -53,6 +53,19 @@ class TaskTag(Base):
     )
 
 
+class ActivityTag(Base):
+    """Many-to-many link between activity log entries and tags."""
+
+    __tablename__ = "activity_tags"
+
+    activity_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("activity_log.id", ondelete="CASCADE"), primary_key=True,
+    )
+    tag_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Pillar 1: Domains
 # ---------------------------------------------------------------------------
@@ -249,6 +262,9 @@ class Tag(Base):
     tasks: Mapped[list["Task"]] = relationship(
         secondary="task_tags", back_populates="tags",
     )
+    activity_logs: Mapped[list["ActivityLog"]] = relationship(
+        secondary="activity_tags", back_populates="tags",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -436,3 +452,6 @@ class ActivityLog(Base):
     task: Mapped["Task | None"] = relationship(back_populates="activity_logs")
     routine: Mapped["Routine | None"] = relationship(back_populates="activity_logs")
     checkin: Mapped["StateCheckin | None"] = relationship(back_populates="activity_logs")
+    tags: Mapped[list["Tag"]] = relationship(
+        secondary="activity_tags", back_populates="activity_logs",
+    )

--- a/app/routers/activity.py
+++ b/app/routers/activity.py
@@ -23,15 +23,17 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session, joinedload
 
 from app.database import get_db
-from app.models import ActivityLog, Routine, StateCheckin, Task
+from app.models import ActivityLog, ActivityTag, Routine, StateCheckin, Tag, Task
 from app.schemas.activity import (
     ActivityLogCreate,
     ActivityLogDetailResponse,
     ActivityLogResponse,
     ActivityLogUpdate,
 )
+from app.schemas.tags import TagResponse
 
 router = APIRouter()
+activity_tags_router = APIRouter()
 
 
 @router.post("/", response_model=ActivityLogResponse, status_code=status.HTTP_201_CREATED)
@@ -47,8 +49,22 @@ def create_activity(payload: ActivityLogCreate, db: Session = Depends(get_db)) -
         if not db.query(StateCheckin).filter(StateCheckin.id == payload.checkin_id).first():
             raise HTTPException(status_code=400, detail="Check-in not found")
 
-    entry = ActivityLog(**payload.model_dump())
+    # Validate tag_ids if provided
+    tags = []
+    if payload.tag_ids:
+        for tid in payload.tag_ids:
+            tag = db.query(Tag).filter(Tag.id == tid).first()
+            if not tag:
+                raise HTTPException(status_code=400, detail=f"Tag {tid} not found")
+            tags.append(tag)
+
+    entry = ActivityLog(**payload.model_dump(exclude={"tag_ids"}))
     db.add(entry)
+    db.flush()
+
+    for tag in tags:
+        db.add(ActivityTag(activity_id=entry.id, tag_id=tag.id))
+
     db.commit()
     db.refresh(entry)
     return entry
@@ -63,6 +79,7 @@ def list_activity(
     logged_before: datetime | None = Query(None),
     has_task: bool | None = Query(None),
     has_routine: bool | None = Query(None),
+    tag: str | None = Query(None, description="Comma-separated tag names (AND logic)"),
     db: Session = Depends(get_db),
 ) -> list[ActivityLog]:
     """List activity log entries with optional filters. Descending by logged_at."""
@@ -86,6 +103,12 @@ def list_activity(
         query = query.filter(ActivityLog.routine_id.isnot(None))
     elif has_routine is False:
         query = query.filter(ActivityLog.routine_id.is_(None))
+    if tag is not None:
+        tag_names = [t.strip().lower() for t in tag.split(",") if t.strip()]
+        for tag_name in tag_names:
+            query = query.filter(
+                ActivityLog.tags.any(Tag.name == tag_name)
+            )
 
     return query.order_by(ActivityLog.logged_at.desc()).all()
 
@@ -99,6 +122,7 @@ def get_activity(entry_id: UUID, db: Session = Depends(get_db)) -> ActivityLog:
             joinedload(ActivityLog.task),
             joinedload(ActivityLog.routine),
             joinedload(ActivityLog.checkin),
+            joinedload(ActivityLog.tags),
         )
         .filter(ActivityLog.id == entry_id)
         .first()
@@ -152,4 +176,71 @@ def delete_activity(entry_id: UUID, db: Session = Depends(get_db)) -> None:
     if not entry:
         raise HTTPException(status_code=404, detail="Activity log entry not found")
     db.delete(entry)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Activity-Tag attachment — /api/activity/{activity_id}/tags
+# ---------------------------------------------------------------------------
+
+
+@activity_tags_router.get("/{activity_id}/tags", response_model=list[TagResponse])
+def list_tags_on_activity(
+    activity_id: UUID, db: Session = Depends(get_db)
+) -> list[Tag]:
+    """List all tags attached to an activity log entry."""
+    entry = db.query(ActivityLog).filter(ActivityLog.id == activity_id).first()
+    if not entry:
+        raise HTTPException(status_code=404, detail="Activity log entry not found")
+    return entry.tags
+
+
+@activity_tags_router.post(
+    "/{activity_id}/tags/{tag_id}", response_model=TagResponse,
+)
+def attach_tag_to_activity(
+    activity_id: UUID, tag_id: UUID, db: Session = Depends(get_db)
+) -> Tag:
+    """Attach a tag to an activity log entry. Idempotent."""
+    entry = db.query(ActivityLog).filter(ActivityLog.id == activity_id).first()
+    if not entry:
+        raise HTTPException(status_code=404, detail="Activity log entry not found")
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    existing = (
+        db.query(ActivityTag)
+        .filter(ActivityTag.activity_id == activity_id, ActivityTag.tag_id == tag_id)
+        .first()
+    )
+    if not existing:
+        db.add(ActivityTag(activity_id=activity_id, tag_id=tag_id))
+        db.commit()
+
+    return tag
+
+
+@activity_tags_router.delete(
+    "/{activity_id}/tags/{tag_id}", status_code=status.HTTP_204_NO_CONTENT,
+)
+def detach_tag_from_activity(
+    activity_id: UUID, tag_id: UUID, db: Session = Depends(get_db)
+) -> None:
+    """Remove a tag from an activity log entry."""
+    entry = db.query(ActivityLog).filter(ActivityLog.id == activity_id).first()
+    if not entry:
+        raise HTTPException(status_code=404, detail="Activity log entry not found")
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    link = (
+        db.query(ActivityTag)
+        .filter(ActivityTag.activity_id == activity_id, ActivityTag.tag_id == tag_id)
+        .first()
+    )
+    if not link:
+        raise HTTPException(status_code=404, detail="Tag is not attached to this activity")
+    db.delete(link)
     db.commit()

--- a/app/routers/tags.py
+++ b/app/routers/tags.py
@@ -22,7 +22,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.models import Tag, Task, TaskTag
+from app.models import ActivityLog, Tag, Task, TaskTag
+from app.schemas.activity import ActivityLogResponse
 from app.schemas.tags import TagCreate, TagResponse, TagUpdate
 from app.schemas.tasks import TaskResponse
 
@@ -117,6 +118,22 @@ def list_tasks_for_tag(tag_id: UUID, db: Session = Depends(get_db)) -> list[Task
     if not tag:
         raise HTTPException(status_code=404, detail="Tag not found")
     return tag.tasks
+
+
+# ---------------------------------------------------------------------------
+# Reverse lookup — /api/tags/{tag_id}/activities
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{tag_id}/activities", response_model=list[ActivityLogResponse])
+def list_activities_for_tag(
+    tag_id: UUID, db: Session = Depends(get_db)
+) -> list[ActivityLog]:
+    """List all activity log entries that have a given tag."""
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    return tag.activity_logs
 
 
 # ---------------------------------------------------------------------------

--- a/app/schemas/activity.py
+++ b/app/schemas/activity.py
@@ -42,6 +42,7 @@ class ActivityLogCreate(BaseModel):
     mood_rating: int | None = None
     friction_actual: int | None = None
     duration_minutes: int | None = None
+    tag_ids: list[UUID] | None = None
 
     @field_validator("energy_before", "energy_after", "mood_rating", "friction_actual")
     @classmethod
@@ -100,6 +101,7 @@ class ActivityLogResponse(BaseModel):
     friction_actual: int | None = None
     duration_minutes: int | None = None
     logged_at: datetime
+    tags: list["TagResponse"] = []
 
 
 class ActivityLogDetailResponse(ActivityLogResponse):
@@ -112,6 +114,8 @@ class ActivityLogDetailResponse(ActivityLogResponse):
 
 from app.schemas.checkins import CheckinResponse  # noqa: E402
 from app.schemas.routines import RoutineResponse  # noqa: E402
+from app.schemas.tags import TagResponse  # noqa: E402
 from app.schemas.tasks import TaskResponse  # noqa: E402
 
+ActivityLogResponse.model_rebuild()
 ActivityLogDetailResponse.model_rebuild()

--- a/tests/test_activity_tags.py
+++ b/tests/test_activity_tags.py
@@ -1,0 +1,289 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for activity-tag attachment, reverse lookup, tag filter, and tag-at-create."""
+
+from tests.conftest import FAKE_UUID, make_activity, make_tag
+
+# ---------------------------------------------------------------------------
+# POST /api/activity/{activity_id}/tags/{tag_id}  — attach
+# ---------------------------------------------------------------------------
+
+class TestAttachTagToActivity:
+
+    def test_attach_tag(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        resp = client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == tag["id"]
+
+    def test_attach_idempotent(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        resp = client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        assert resp.status_code == 200
+        tags_resp = client.get(f"/api/activity/{entry['id']}/tags")
+        assert len(tags_resp.json()) == 1
+
+    def test_attach_invalid_activity(self, client):
+        tag = make_tag(client, name="test")
+        resp = client.post(f"/api/activity/{FAKE_UUID}/tags/{tag['id']}")
+        assert resp.status_code == 404
+
+    def test_attach_invalid_tag(self, client):
+        entry = make_activity(client)
+        resp = client.post(f"/api/activity/{entry['id']}/tags/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/activity/{activity_id}/tags/{tag_id}  — detach
+# ---------------------------------------------------------------------------
+
+class TestDetachTagFromActivity:
+
+    def test_detach_tag(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        resp = client.delete(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        assert resp.status_code == 204
+
+    def test_detach_invalid_activity(self, client):
+        tag = make_tag(client, name="test")
+        resp = client.delete(f"/api/activity/{FAKE_UUID}/tags/{tag['id']}")
+        assert resp.status_code == 404
+
+    def test_detach_invalid_tag(self, client):
+        entry = make_activity(client)
+        resp = client.delete(f"/api/activity/{entry['id']}/tags/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+    def test_detach_not_attached(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        resp = client.delete(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/activity/{activity_id}/tags  — list tags on activity
+# ---------------------------------------------------------------------------
+
+class TestListActivityTags:
+
+    def test_list_tags_on_activity(self, client):
+        tag1 = make_tag(client, name="session-handoff")
+        tag2 = make_tag(client, name="fluxnook")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag1['id']}")
+        client.post(f"/api/activity/{entry['id']}/tags/{tag2['id']}")
+        resp = client.get(f"/api/activity/{entry['id']}/tags")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_list_tags_empty(self, client):
+        entry = make_activity(client)
+        resp = client.get(f"/api/activity/{entry['id']}/tags")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_tags_invalid_activity(self, client):
+        resp = client.get(f"/api/activity/{FAKE_UUID}/tags")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/tags/{tag_id}/activities  — reverse lookup
+# ---------------------------------------------------------------------------
+
+class TestReverseActivityLookup:
+
+    def test_list_activities_for_tag(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry1 = make_activity(client)
+        entry2 = make_activity(client, action_type="reflected")
+        client.post(f"/api/activity/{entry1['id']}/tags/{tag['id']}")
+        client.post(f"/api/activity/{entry2['id']}/tags/{tag['id']}")
+        resp = client.get(f"/api/tags/{tag['id']}/activities")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_reverse_lookup_empty(self, client):
+        tag = make_tag(client, name="unused")
+        resp = client.get(f"/api/tags/{tag['id']}/activities")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_reverse_lookup_invalid_tag(self, client):
+        resp = client.get(f"/api/tags/{FAKE_UUID}/activities")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/activity?tag=  — multi-tag AND filter
+# ---------------------------------------------------------------------------
+
+class TestActivityTagFilter:
+
+    def test_filter_single_tag(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry1 = make_activity(client)
+        make_activity(client, action_type="reflected")
+        client.post(f"/api/activity/{entry1['id']}/tags/{tag['id']}")
+        resp = client.get("/api/activity?tag=session-handoff")
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["id"] == entry1["id"]
+
+    def test_filter_multiple_tags_and_logic(self, client):
+        tag1 = make_tag(client, name="movie")
+        tag2 = make_tag(client, name="fluxnook")
+        entry_both = make_activity(client, action_type="reflected")
+        entry_one = make_activity(client, action_type="completed")
+        client.post(f"/api/activity/{entry_both['id']}/tags/{tag1['id']}")
+        client.post(f"/api/activity/{entry_both['id']}/tags/{tag2['id']}")
+        client.post(f"/api/activity/{entry_one['id']}/tags/{tag1['id']}")
+
+        resp = client.get("/api/activity?tag=movie,fluxnook")
+        entries = resp.json()
+        assert len(entries) == 1
+        assert entries[0]["id"] == entry_both["id"]
+
+    def test_filter_tag_case_insensitive(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        resp = client.get("/api/activity?tag=session-handoff")
+        assert len(resp.json()) == 1
+
+    def test_filter_tag_no_matches(self, client):
+        make_activity(client)
+        resp = client.get("/api/activity?tag=nonexistent")
+        assert resp.json() == []
+
+    def test_filter_tag_composable_with_action_type(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry1 = make_activity(client, action_type="completed")
+        entry2 = make_activity(client, action_type="reflected")
+        client.post(f"/api/activity/{entry1['id']}/tags/{tag['id']}")
+        client.post(f"/api/activity/{entry2['id']}/tags/{tag['id']}")
+        resp = client.get("/api/activity?tag=session-handoff&action_type=reflected")
+        entries = resp.json()
+        assert len(entries) == 1
+        assert entries[0]["id"] == entry2["id"]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/activity with tag_ids  — tag at create
+# ---------------------------------------------------------------------------
+
+class TestTagAtCreate:
+
+    def test_create_with_tag_ids(self, client):
+        tag1 = make_tag(client, name="session-handoff")
+        tag2 = make_tag(client, name="fluxnook")
+        resp = client.post(
+            "/api/activity",
+            json={
+                "action_type": "reflected",
+                "tag_ids": [tag1["id"], tag2["id"]],
+            },
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert len(body["tags"]) == 2
+        tag_names = {t["name"] for t in body["tags"]}
+        assert tag_names == {"session-handoff", "fluxnook"}
+
+    def test_create_with_empty_tag_ids(self, client):
+        resp = client.post(
+            "/api/activity",
+            json={"action_type": "reflected", "tag_ids": []},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["tags"] == []
+
+    def test_create_without_tag_ids(self, client):
+        resp = client.post(
+            "/api/activity",
+            json={"action_type": "reflected"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["tags"] == []
+
+    def test_create_with_invalid_tag_id(self, client):
+        resp = client.post(
+            "/api/activity",
+            json={
+                "action_type": "reflected",
+                "tag_ids": [FAKE_UUID],
+            },
+        )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Tags in activity responses
+# ---------------------------------------------------------------------------
+
+class TestActivityResponseIncludesTags:
+
+    def test_list_response_includes_tags(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        resp = client.get("/api/activity")
+        entries = resp.json()
+        assert len(entries) == 1
+        assert len(entries[0]["tags"]) == 1
+        assert entries[0]["tags"][0]["name"] == "session-handoff"
+
+    def test_detail_response_includes_tags(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        resp = client.get(f"/api/activity/{entry['id']}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["tags"]) == 1
+        assert body["tags"][0]["name"] == "session-handoff"
+
+
+# ---------------------------------------------------------------------------
+# Cascade — deleting a tag removes activity associations
+# ---------------------------------------------------------------------------
+
+class TestActivityTagCascade:
+
+    def test_delete_tag_cascades_activity_associations(self, client):
+        tag = make_tag(client, name="temp")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        client.delete(f"/api/tags/{tag['id']}")
+        resp = client.get(f"/api/activity/{entry['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == []
+
+    def test_delete_activity_cascades_tag_associations(self, client):
+        tag = make_tag(client, name="persist")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        client.delete(f"/api/activity/{entry['id']}")
+        # Tag still exists
+        resp = client.get(f"/api/tags/{tag['id']}")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Adds many-to-many tagging support for activity log entries, mirroring the existing task-tag pattern from TICKET-06. Tags can be attached/detached individually, included at creation time via `tag_ids`, filtered with AND logic on the list endpoint, and looked up in reverse from the tag side.

## Changes

- **`app/models.py`** — Added `ActivityTag` association table and `tags` relationship on both `ActivityLog` and `Tag` models.
- **`app/schemas/activity.py`** — Added optional `tag_ids` field on `ActivityLogCreate`, `tags` field on `ActivityLogResponse` (inherited by detail response).
- **`app/routers/activity.py`** — Added `activity_tags_router` with attach (`POST`), detach (`DELETE`), and list (`GET`) endpoints. Updated `create_activity` to handle `tag_ids` at creation. Added `tag` query parameter (comma-separated, AND logic) to `list_activity`. Eager-loads tags on detail endpoint.
- **`app/routers/tags.py`** — Added `GET /api/tags/{tag_id}/activities` reverse lookup endpoint.
- **`app/main.py`** — Registered `activity_tags_router` under `/api/activity` prefix.
- **`alembic/versions/002_activity_tags.py`** — Migration creating `activity_tags` table with composite PK and CASCADE foreign keys.
- **`tests/test_activity_tags.py`** — 27 tests covering attach, detach, list, reverse lookup, multi-tag AND filter, tag-at-create, response inclusion, and cascade behavior.

## How to Verify

1. `pytest -v` — 325 tests pass (298 existing + 27 new)
2. Start the API and confirm new endpoints appear at `/docs`:
   - `POST /api/activity/{id}/tags/{tag_id}`
   - `DELETE /api/activity/{id}/tags/{tag_id}`
   - `GET /api/activity/{id}/tags`
   - `GET /api/tags/{id}/activities`
3. Create an activity with `tag_ids` in the POST body and confirm tags appear in the response
4. Filter `GET /api/activity?tag=name1,name2` and confirm AND logic

## Deviations

None

## Test Results

```
============================= 325 passed in 3.38s =============================
```

Lint: `ruff check` — All checks passed!

## Acceptance Checklist

- [x] `activity_tags` association table with Alembic migration
- [x] Tag attachment endpoints: attach (`POST`), detach (`DELETE`), list (`GET`) on activity
- [x] Reverse lookup: `GET /api/tags/{id}/activities`
- [x] Multi-tag filter on `GET /api/activity` (AND logic, comma-separated tag names)
- [x] Optional `tag_ids` on `POST /api/activity` for tagging at creation time
- [x] Tags included in activity response schema (list and detail)
- [x] Mirrors task_tags pattern (idempotent attach, 404 on detach-not-attached, cascade deletes)
- [x] All existing tests pass (no regressions)
- [x] 27 new tests covering all new functionality

Closes #73