### PR TITLE
Issue-80: Fix Docker Compose gap — add test stack, remove hardcoded container names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 # Copy this file to .env and adjust values as needed:
 #   cp .env.example .env
 
+# Docker Compose — identifies this stack so multiple environments can coexist
+COMPOSE_PROJECT_NAME=brain3-dev
+
 # PostgreSQL
 POSTGRES_USER=brain3
 POSTGRES_PASSWORD=brain3_dev

--- a/.env.production.example
+++ b/.env.production.example
@@ -2,6 +2,9 @@
 # Copy to .env and set a strong password before deploying:
 #   cp .env.production.example .env
 
+# Docker Compose — identifies this stack so multiple environments can coexist
+COMPOSE_PROJECT_NAME=brain3-prod
+
 # PostgreSQL
 POSTGRES_USER=brain3
 POSTGRES_PASSWORD=CHANGE_ME_TO_A_STRONG_PASSWORD

--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,20 @@
+# BRAIN 3.0 — Test Environment Variables
+# Copy to .env and adjust values as needed:
+#   cp .env.test.example .env
+
+# Docker Compose — identifies this stack so multiple environments can coexist
+COMPOSE_PROJECT_NAME=brain3-test
+
+# PostgreSQL
+POSTGRES_USER=brain3
+POSTGRES_PASSWORD=CHANGE_ME_TO_A_STRONG_PASSWORD
+POSTGRES_DB=brain3
+POSTGRES_HOST=db
+POSTGRES_PORT=5433
+
+# API
+API_HOST=0.0.0.0
+API_PORT=8100
+
+# CORS — comma-separated list of allowed origins (set to your server IP)
+CORS_ORIGINS=http://TRUENAS_IP:8100

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ brain3/
 │   ├── tickets/
 │   └── ...
 ├── docker-compose.dev.yml
+├── docker-compose.test.yml
 ├── docker-compose.prod.yml
 ├── Dockerfile
 ├── requirements.txt

--- a/README.md
+++ b/README.md
@@ -44,15 +44,35 @@ Everything flows from domains down through goals and projects to tasks, with rou
 | MCP Transport | Anthropic Python MCP SDK | latest stable |
 | Deployment | Docker on TrueNAS | Docker Compose v2 |
 
-## Production Deployment
+## Deployment
 
-To deploy BRAIN 3.0 on a home server (TrueNAS or any Docker-capable host):
+BRAIN 3.0 supports three environments. Each has its own compose file and can coexist on the same host:
+
+| Environment | Compose File | API Port | Use Case |
+|-------------|-------------|----------|----------|
+| Dev | `docker-compose.dev.yml` | 8000 (native) | Local development — postgres only, uvicorn runs natively |
+| Test | `docker-compose.test.yml` | 8100 | UAT — full stack in Docker from `develop` branch |
+| Prod | `docker-compose.prod.yml` | 8000 | Production — full stack in Docker from `main` branch |
+
+### Production
+
 ```bash
 git clone -b main https://github.com/WilliM233/brain3.git
 cd brain3
 cp .env.production.example .env
 # Edit .env with strong credentials — do not use dev defaults
 docker compose -f docker-compose.prod.yml up -d --build
+```
+
+### Test Stack
+
+```bash
+git clone -b develop https://github.com/WilliM233/brain3.git brain3-test
+cd brain3-test
+cp .env.test.example .env
+# Edit .env with credentials
+docker compose -f docker-compose.test.yml up -d --build
+# Verify: curl http://localhost:8100/health
 ```
 
 ## Quick Start (Development)
@@ -85,7 +105,7 @@ Verify it's running:
 docker compose -f docker-compose.dev.yml ps
 ```
 
-You should see `brain3-postgres-dev` with status `healthy`.
+You should see the postgres service with status `healthy`.
 
 ### 3. Install dependencies
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,6 @@
 services:
   postgres:
     image: postgres:16.13-alpine
-    container_name: brain3-postgres-dev
     restart: unless-stopped
     env_file: .env
     ports:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,8 +3,10 @@ services:
     image: postgres:16.13-alpine
     restart: unless-stopped
     env_file: .env
+    ports:
+      - "${POSTGRES_PORT:-5433}:5432"
     volumes:
-      - brain3_prod_data:/var/lib/postgresql/data
+      - brain3_test_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-brain3}"]
       interval: 10s
@@ -18,7 +20,7 @@ services:
     restart: unless-stopped
     env_file: .env
     ports:
-      - "${API_PORT:-8000}:${API_PORT:-8000}"
+      - "${API_PORT:-8100}:${API_PORT:-8100}"
     depends_on:
       db:
         condition: service_healthy
@@ -30,4 +32,4 @@ networks:
     driver: bridge
 
 volumes:
-  brain3_prod_data:
+  brain3_test_data:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,6 +13,29 @@ Deploy BRAIN 3.0 to TrueNAS or any Docker-capable Linux server. This guide cover
 
 ---
 
+## Environments
+
+BRAIN 3.0 supports three deployment environments, each with its own compose file and project name:
+
+| Environment | Compose File | Branch | API Port | Postgres Port | Project Name |
+|-------------|-------------|--------|----------|---------------|--------------|
+| **Dev** | `docker-compose.dev.yml` | any | 8000 (native uvicorn) | 5432 | `brain3-dev` |
+| **Test** | `docker-compose.test.yml` | `develop` | 8100 | 5433 | `brain3-test` |
+| **Prod** | `docker-compose.prod.yml` | `main` | 8000 | internal only | `brain3-prod` |
+
+- **Dev** runs postgres only — the developer runs uvicorn natively for hot-reload during development.
+- **Test** runs a full stack (API + DB in Docker) for UAT verification against the `develop` branch.
+- **Prod** runs a full stack deployed from `main` on TrueNAS.
+
+All three can coexist on the same host without conflicts. The `COMPOSE_PROJECT_NAME` in each `.env` ensures Docker Compose manages each stack independently — `docker compose down` only touches containers belonging to that project.
+
+Each environment has an `.env` example file:
+- Dev: `cp .env.example .env`
+- Test: `cp .env.test.example .env`
+- Prod: `cp .env.production.example .env`
+
+---
+
 ## Environment Configuration
 
 ### 1. Clone the repository
@@ -85,7 +108,7 @@ The production compose runs **both** PostgreSQL and the API as containers on a p
 docker compose -f docker-compose.prod.yml ps
 ```
 
-Both `brain3-db` and `brain3-api` should show as running.
+Both `db` and `api` services should show as running.
 
 Check the health endpoint:
 
@@ -116,11 +139,53 @@ The smoke test creates and deletes test entities across the full API surface: do
 
 ---
 
+## Test Stack Deployment
+
+The test stack runs the full application (API + DB) in Docker for UAT verification. It uses different ports so it can run alongside the production stack on the same host.
+
+### 1. Create the environment file
+
+```bash
+cp .env.test.example .env
+```
+
+Edit `.env` with appropriate values. The test defaults use port 8100 for the API and 5433 for postgres.
+
+### 2. Build and start
+
+```bash
+docker compose -f docker-compose.test.yml up -d --build
+```
+
+### 3. Verify
+
+```bash
+docker compose -f docker-compose.test.yml ps
+curl http://localhost:8100/health
+```
+
+### 4. Update to latest code
+
+```bash
+git pull origin develop
+docker compose -f docker-compose.test.yml up -d --build
+```
+
+### 5. Tear down
+
+```bash
+docker compose -f docker-compose.test.yml down
+```
+
+This removes only the test containers. Production and dev stacks are unaffected.
+
+---
+
 ## Configure Backups
 
 ### What the backup script does
 
-`scripts/backup.sh` runs `pg_dump` inside the `brain3-db` container, compresses the output with gzip, and stores it in `BACKUP_PATH`. It then deletes backups older than `BACKUP_RETENTION_DAYS` (default: 30).
+`scripts/backup.sh` runs `pg_dump` via `docker compose exec` against the `db` service, compresses the output with gzip, and stores it in `BACKUP_PATH`. It then deletes backups older than `BACKUP_RETENTION_DAYS` (default: 30). The script defaults to using `docker-compose.prod.yml` — override with `COMPOSE_FILE` to back up a different environment.
 
 Backup files are created with restrictive permissions (mode 600, owner-only readable) via `umask 077`. The script logs every run to `BACKUP_PATH/backup.log`.
 
@@ -229,12 +294,20 @@ In Phase 1 (no web UI), the primary consumer is the MCP server, which makes serv
 
 ## Updating
 
-To deploy a new version:
+To deploy a new version, pull the latest code and rebuild. Use the compose file matching your environment:
 
+**Production:**
+```bash
+cd /path/to/brain3
+git pull origin main
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+**Test:**
 ```bash
 cd /path/to/brain3
 git pull origin develop
-docker compose -f docker-compose.prod.yml up -d --build
+docker compose -f docker-compose.test.yml up -d --build
 ```
 
 The API container runs Alembic migrations automatically on startup (`scripts/entrypoint.sh`), so database schema updates are applied with each deploy. Data is preserved — the PostgreSQL volume persists across container rebuilds.
@@ -279,7 +352,7 @@ Verify `POSTGRES_HOST=db` in your `.env` — this must match the Docker Compose 
 - Is the database container running? `docker ps | grep brain3-db`
 - Does the backup path exist and is it writable? `ls -la /mnt/pool/backups/brain3/`
 - Check the backup log: `cat /mnt/pool/backups/brain3/backup.log`
-- Is the container name correct? The script defaults to `brain3-db` (from `DB_CONTAINER_NAME` or the compose file's `container_name`).
+- Is the compose file correct? The script defaults to `docker-compose.prod.yml`. Override with `COMPOSE_FILE=docker-compose.test.yml` to back up the test stack.
 
 ### MCP can't connect to the API
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -15,7 +15,7 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 # Configuration (override via environment or .env)
 BACKUP_PATH="${BACKUP_PATH:-/mnt/pool/backups/brain3}"
 RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}"
-CONTAINER_NAME="${DB_CONTAINER_NAME:-brain3-db}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
 DB_USER="${POSTGRES_USER:-brain3}"
 DB_NAME="${POSTGRES_DB:-brain3}"
 LOG_FILE="$BACKUP_PATH/backup.log"
@@ -38,8 +38,8 @@ mkdir -p "$BACKUP_PATH"
 trap 'log "FAIL: Backup failed with exit code $?"; exit 1' ERR
 
 # Run backup
-log "Starting backup: $FILENAME"
-docker exec "$CONTAINER_NAME" pg_dump -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_PATH/$FILENAME"
+log "Starting backup: $FILENAME (compose file: $COMPOSE_FILE)"
+docker compose -f "$PROJECT_DIR/$COMPOSE_FILE" exec -T db pg_dump -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_PATH/$FILENAME"
 
 # Verify the file exists and is non-empty
 if [ ! -s "$BACKUP_PATH/$FILENAME" ]; then


### PR DESCRIPTION
## Summary

Fixes the Docker Compose configuration gap that caused the v1.1.0 UAT failure. The test instance at 192.168.0.14:8100 was running stale v1.0.1 code because its containers were orphans — not managed by any compose file. This PR removes hardcoded `container_name` from all compose files, adds a dedicated test compose file, and documents all three deployment environments.

## Changes

**Compose files:**
- `docker-compose.dev.yml` — removed `container_name: brain3-postgres-dev`. Docker Compose now derives names from `COMPOSE_PROJECT_NAME`.
- `docker-compose.prod.yml` — removed `container_name: brain3-db` and `container_name: brain3-api`. Same rationale.
- `docker-compose.test.yml` (new) — full-stack test environment. API on port 8100, Postgres on port 5433, separate `brain3_test_data` volume, separate bridge network.

**Environment examples:**
- `.env.example` — added `COMPOSE_PROJECT_NAME=brain3-dev`.
- `.env.production.example` — added `COMPOSE_PROJECT_NAME=brain3-prod`.
- `.env.test.example` (new) — test environment template with `COMPOSE_PROJECT_NAME=brain3-test`, port 8100 for API, port 5433 for Postgres.

**Backup script:**
- `scripts/backup.sh` — replaced `docker exec` with `docker compose exec -T` so the script is compose-project-aware. Added `COMPOSE_FILE` variable (defaults to `docker-compose.prod.yml`) instead of the old `DB_CONTAINER_NAME`.

**Documentation:**
- `docs/deployment.md` — added Environments overview table, Test Stack Deployment section, updated backup documentation, updated Updating section with per-environment commands, fixed troubleshooting references.
- `README.md` — replaced single "Production Deployment" section with three-environment table, added Test Stack quick start, removed hardcoded container name reference.
- `CLAUDE.md` — added `docker-compose.test.yml` to project structure tree.

## How to Verify

1. `docker compose -f docker-compose.dev.yml config` — validates dev compose (postgres only, no container_name)
2. `docker compose -f docker-compose.test.yml config` — validates test compose (db + api, ports 5433/8100)
3. `docker compose -f docker-compose.prod.yml config` — validates prod compose (db + api, no container_name)
4. On a Docker host with appropriate `.env`:
   - `docker compose -f docker-compose.test.yml up -d --build` — full test stack starts on port 8100
   - `docker compose -f docker-compose.prod.yml up -d --build` — full prod stack starts on port 8000
   - Both coexist without container name conflicts
   - `docker compose -f docker-compose.test.yml down` removes only test containers

## Deviations

None. Implementation follows the design direction in the ticket assignment.

## Test Results

```
$ pytest -v
325 passed in 3.42s

$ ruff check .
All checks passed!
```

No application code was changed — only infrastructure files and documentation.

## Acceptance Checklist

- [x] Hardcoded `container_name` removed from all compose files
- [x] `docker-compose.test.yml` created with API:8100, Postgres:5433, separate volume
- [x] `COMPOSE_PROJECT_NAME` added to all `.env` example files
- [x] `.env.test.example` created for test environment
- [x] `scripts/backup.sh` updated to use `docker compose exec` instead of `docker exec`
- [x] `docs/deployment.md` documents all three environments and update workflows
- [x] `README.md` updated with three-environment deployment table
- [x] All three compose files can coexist on the same host without name conflicts
- [x] `docker compose down` for one environment does not affect others
- [x] `pytest -v` passes (325 tests)
- [x] `ruff check .` passes

Closes #80