### PR TITLE
Release: BRAIN 3.0 v1.1.0 — Activity Tags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 # Copy this file to .env and adjust values as needed:
 #   cp .env.example .env
 
+# Docker Compose — identifies this stack so multiple environments can coexist
+COMPOSE_PROJECT_NAME=brain3-dev
+
 # PostgreSQL
 POSTGRES_USER=brain3
 POSTGRES_PASSWORD=brain3_dev

--- a/.env.production.example
+++ b/.env.production.example
@@ -2,6 +2,9 @@
 # Copy to .env and set a strong password before deploying:
 #   cp .env.production.example .env
 
+# Docker Compose — identifies this stack so multiple environments can coexist
+COMPOSE_PROJECT_NAME=brain3-prod
+
 # PostgreSQL
 POSTGRES_USER=brain3
 POSTGRES_PASSWORD=CHANGE_ME_TO_A_STRONG_PASSWORD

--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,20 @@
+# BRAIN 3.0 — Test Environment Variables
+# Copy to .env and adjust values as needed:
+#   cp .env.test.example .env
+
+# Docker Compose — identifies this stack so multiple environments can coexist
+COMPOSE_PROJECT_NAME=brain3-test
+
+# PostgreSQL
+POSTGRES_USER=brain3
+POSTGRES_PASSWORD=CHANGE_ME_TO_A_STRONG_PASSWORD
+POSTGRES_DB=brain3
+POSTGRES_HOST=db
+POSTGRES_PORT=5433
+
+# API
+API_HOST=0.0.0.0
+API_PORT=8100
+
+# CORS — comma-separated list of allowed origins (set to your server IP)
+CORS_ORIGINS=http://TRUENAS_IP:8100

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ brain3/
 │   ├── tickets/
 │   └── ...
 ├── docker-compose.dev.yml
+├── docker-compose.test.yml
 ├── docker-compose.prod.yml
 ├── Dockerfile
 ├── requirements.txt

--- a/README.md
+++ b/README.md
@@ -44,15 +44,35 @@ Everything flows from domains down through goals and projects to tasks, with rou
 | MCP Transport | Anthropic Python MCP SDK | latest stable |
 | Deployment | Docker on TrueNAS | Docker Compose v2 |
 
-## Production Deployment
+## Deployment
 
-To deploy BRAIN 3.0 on a home server (TrueNAS or any Docker-capable host):
+BRAIN 3.0 supports three environments. Each has its own compose file and can coexist on the same host:
+
+| Environment | Compose File | API Port | Use Case |
+|-------------|-------------|----------|----------|
+| Dev | `docker-compose.dev.yml` | 8000 (native) | Local development — postgres only, uvicorn runs natively |
+| Test | `docker-compose.test.yml` | 8100 | UAT — full stack in Docker from `develop` branch |
+| Prod | `docker-compose.prod.yml` | 8000 | Production — full stack in Docker from `main` branch |
+
+### Production
+
 ```bash
 git clone -b main https://github.com/WilliM233/brain3.git
 cd brain3
 cp .env.production.example .env
 # Edit .env with strong credentials — do not use dev defaults
 docker compose -f docker-compose.prod.yml up -d --build
+```
+
+### Test Stack
+
+```bash
+git clone -b develop https://github.com/WilliM233/brain3.git brain3-test
+cd brain3-test
+cp .env.test.example .env
+# Edit .env with credentials
+docker compose -f docker-compose.test.yml up -d --build
+# Verify: curl http://localhost:8100/health
 ```
 
 ## Quick Start (Development)
@@ -85,7 +105,7 @@ Verify it's running:
 docker compose -f docker-compose.dev.yml ps
 ```
 
-You should see `brain3-postgres-dev` with status `healthy`.
+You should see the postgres service with status `healthy`.
 
 ### 3. Install dependencies
 

--- a/alembic/versions/002_activity_tags.py
+++ b/alembic/versions/002_activity_tags.py
@@ -1,0 +1,54 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""add activity_tags association table
+
+Revision ID: a1b2c3d4e5f6
+Revises: 5ccf2b58d02a
+Create Date: 2026-04-02 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "5ccf2b58d02a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "activity_tags",
+        sa.Column("activity_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tag_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["activity_id"], ["activity_log.id"], ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tag_id"], ["tags.id"], ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("activity_id", "tag_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("activity_tags")

--- a/app/main.py
+++ b/app/main.py
@@ -77,3 +77,6 @@ app.include_router(checkins.router, prefix="/api/checkins", tags=["Check-ins"])
 app.include_router(activity.router, prefix="/api/activity", tags=["Activity Log"])
 app.include_router(reports.router, prefix="/api/reports", tags=["Reports"])
 app.include_router(tags.task_tags_router, prefix="/api/tasks", tags=["Task Tags"])
+app.include_router(
+    activity.activity_tags_router, prefix="/api/activity", tags=["Activity Tags"],
+)

--- a/app/models.py
+++ b/app/models.py
@@ -53,6 +53,19 @@ class TaskTag(Base):
     )
 
 
+class ActivityTag(Base):
+    """Many-to-many link between activity log entries and tags."""
+
+    __tablename__ = "activity_tags"
+
+    activity_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("activity_log.id", ondelete="CASCADE"), primary_key=True,
+    )
+    tag_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Pillar 1: Domains
 # ---------------------------------------------------------------------------
@@ -249,6 +262,9 @@ class Tag(Base):
     tasks: Mapped[list["Task"]] = relationship(
         secondary="task_tags", back_populates="tags",
     )
+    activity_logs: Mapped[list["ActivityLog"]] = relationship(
+        secondary="activity_tags", back_populates="tags",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -436,3 +452,6 @@ class ActivityLog(Base):
     task: Mapped["Task | None"] = relationship(back_populates="activity_logs")
     routine: Mapped["Routine | None"] = relationship(back_populates="activity_logs")
     checkin: Mapped["StateCheckin | None"] = relationship(back_populates="activity_logs")
+    tags: Mapped[list["Tag"]] = relationship(
+        secondary="activity_tags", back_populates="activity_logs",
+    )

--- a/app/routers/activity.py
+++ b/app/routers/activity.py
@@ -23,15 +23,17 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session, joinedload
 
 from app.database import get_db
-from app.models import ActivityLog, Routine, StateCheckin, Task
+from app.models import ActivityLog, ActivityTag, Routine, StateCheckin, Tag, Task
 from app.schemas.activity import (
     ActivityLogCreate,
     ActivityLogDetailResponse,
     ActivityLogResponse,
     ActivityLogUpdate,
 )
+from app.schemas.tags import TagResponse
 
 router = APIRouter()
+activity_tags_router = APIRouter()
 
 
 @router.post("/", response_model=ActivityLogResponse, status_code=status.HTTP_201_CREATED)
@@ -47,8 +49,22 @@ def create_activity(payload: ActivityLogCreate, db: Session = Depends(get_db)) -
         if not db.query(StateCheckin).filter(StateCheckin.id == payload.checkin_id).first():
             raise HTTPException(status_code=400, detail="Check-in not found")
 
-    entry = ActivityLog(**payload.model_dump())
+    # Validate tag_ids if provided
+    tags = []
+    if payload.tag_ids:
+        for tid in payload.tag_ids:
+            tag = db.query(Tag).filter(Tag.id == tid).first()
+            if not tag:
+                raise HTTPException(status_code=400, detail=f"Tag {tid} not found")
+            tags.append(tag)
+
+    entry = ActivityLog(**payload.model_dump(exclude={"tag_ids"}))
     db.add(entry)
+    db.flush()
+
+    for tag in tags:
+        db.add(ActivityTag(activity_id=entry.id, tag_id=tag.id))
+
     db.commit()
     db.refresh(entry)
     return entry
@@ -63,6 +79,7 @@ def list_activity(
     logged_before: datetime | None = Query(None),
     has_task: bool | None = Query(None),
     has_routine: bool | None = Query(None),
+    tag: str | None = Query(None, description="Comma-separated tag names (AND logic)"),
     db: Session = Depends(get_db),
 ) -> list[ActivityLog]:
     """List activity log entries with optional filters. Descending by logged_at."""
@@ -86,6 +103,12 @@ def list_activity(
         query = query.filter(ActivityLog.routine_id.isnot(None))
     elif has_routine is False:
         query = query.filter(ActivityLog.routine_id.is_(None))
+    if tag is not None:
+        tag_names = [t.strip().lower() for t in tag.split(",") if t.strip()]
+        for tag_name in tag_names:
+            query = query.filter(
+                ActivityLog.tags.any(Tag.name == tag_name)
+            )
 
     return query.order_by(ActivityLog.logged_at.desc()).all()
 
@@ -99,6 +122,7 @@ def get_activity(entry_id: UUID, db: Session = Depends(get_db)) -> ActivityLog:
             joinedload(ActivityLog.task),
             joinedload(ActivityLog.routine),
             joinedload(ActivityLog.checkin),
+            joinedload(ActivityLog.tags),
         )
         .filter(ActivityLog.id == entry_id)
         .first()
@@ -152,4 +176,71 @@ def delete_activity(entry_id: UUID, db: Session = Depends(get_db)) -> None:
     if not entry:
         raise HTTPException(status_code=404, detail="Activity log entry not found")
     db.delete(entry)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Activity-Tag attachment — /api/activity/{activity_id}/tags
+# ---------------------------------------------------------------------------
+
+
+@activity_tags_router.get("/{activity_id}/tags", response_model=list[TagResponse])
+def list_tags_on_activity(
+    activity_id: UUID, db: Session = Depends(get_db)
+) -> list[Tag]:
+    """List all tags attached to an activity log entry."""
+    entry = db.query(ActivityLog).filter(ActivityLog.id == activity_id).first()
+    if not entry:
+        raise HTTPException(status_code=404, detail="Activity log entry not found")
+    return entry.tags
+
+
+@activity_tags_router.post(
+    "/{activity_id}/tags/{tag_id}", response_model=TagResponse,
+)
+def attach_tag_to_activity(
+    activity_id: UUID, tag_id: UUID, db: Session = Depends(get_db)
+) -> Tag:
+    """Attach a tag to an activity log entry. Idempotent."""
+    entry = db.query(ActivityLog).filter(ActivityLog.id == activity_id).first()
+    if not entry:
+        raise HTTPException(status_code=404, detail="Activity log entry not found")
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    existing = (
+        db.query(ActivityTag)
+        .filter(ActivityTag.activity_id == activity_id, ActivityTag.tag_id == tag_id)
+        .first()
+    )
+    if not existing:
+        db.add(ActivityTag(activity_id=activity_id, tag_id=tag_id))
+        db.commit()
+
+    return tag
+
+
+@activity_tags_router.delete(
+    "/{activity_id}/tags/{tag_id}", status_code=status.HTTP_204_NO_CONTENT,
+)
+def detach_tag_from_activity(
+    activity_id: UUID, tag_id: UUID, db: Session = Depends(get_db)
+) -> None:
+    """Remove a tag from an activity log entry."""
+    entry = db.query(ActivityLog).filter(ActivityLog.id == activity_id).first()
+    if not entry:
+        raise HTTPException(status_code=404, detail="Activity log entry not found")
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    link = (
+        db.query(ActivityTag)
+        .filter(ActivityTag.activity_id == activity_id, ActivityTag.tag_id == tag_id)
+        .first()
+    )
+    if not link:
+        raise HTTPException(status_code=404, detail="Tag is not attached to this activity")
+    db.delete(link)
     db.commit()

--- a/app/routers/tags.py
+++ b/app/routers/tags.py
@@ -22,7 +22,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.models import Tag, Task, TaskTag
+from app.models import ActivityLog, Tag, Task, TaskTag
+from app.schemas.activity import ActivityLogResponse
 from app.schemas.tags import TagCreate, TagResponse, TagUpdate
 from app.schemas.tasks import TaskResponse
 
@@ -117,6 +118,22 @@ def list_tasks_for_tag(tag_id: UUID, db: Session = Depends(get_db)) -> list[Task
     if not tag:
         raise HTTPException(status_code=404, detail="Tag not found")
     return tag.tasks
+
+
+# ---------------------------------------------------------------------------
+# Reverse lookup — /api/tags/{tag_id}/activities
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{tag_id}/activities", response_model=list[ActivityLogResponse])
+def list_activities_for_tag(
+    tag_id: UUID, db: Session = Depends(get_db)
+) -> list[ActivityLog]:
+    """List all activity log entries that have a given tag."""
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    return tag.activity_logs
 
 
 # ---------------------------------------------------------------------------

--- a/app/schemas/activity.py
+++ b/app/schemas/activity.py
@@ -42,6 +42,7 @@ class ActivityLogCreate(BaseModel):
     mood_rating: int | None = None
     friction_actual: int | None = None
     duration_minutes: int | None = None
+    tag_ids: list[UUID] | None = None
 
     @field_validator("energy_before", "energy_after", "mood_rating", "friction_actual")
     @classmethod
@@ -100,6 +101,7 @@ class ActivityLogResponse(BaseModel):
     friction_actual: int | None = None
     duration_minutes: int | None = None
     logged_at: datetime
+    tags: list["TagResponse"] = []
 
 
 class ActivityLogDetailResponse(ActivityLogResponse):
@@ -112,6 +114,8 @@ class ActivityLogDetailResponse(ActivityLogResponse):
 
 from app.schemas.checkins import CheckinResponse  # noqa: E402
 from app.schemas.routines import RoutineResponse  # noqa: E402
+from app.schemas.tags import TagResponse  # noqa: E402
 from app.schemas.tasks import TaskResponse  # noqa: E402
 
+ActivityLogResponse.model_rebuild()
 ActivityLogDetailResponse.model_rebuild()

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,6 @@
 services:
   postgres:
     image: postgres:16.13-alpine
-    container_name: brain3-postgres-dev
     restart: unless-stopped
     env_file: .env
     ports:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,8 +3,10 @@ services:
     image: postgres:16.13-alpine
     restart: unless-stopped
     env_file: .env
+    ports:
+      - "${POSTGRES_PORT:-5433}:5432"
     volumes:
-      - brain3_prod_data:/var/lib/postgresql/data
+      - brain3_test_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-brain3}"]
       interval: 10s
@@ -18,7 +20,7 @@ services:
     restart: unless-stopped
     env_file: .env
     ports:
-      - "${API_PORT:-8000}:${API_PORT:-8000}"
+      - "${API_PORT:-8100}:${API_PORT:-8100}"
     depends_on:
       db:
         condition: service_healthy
@@ -30,4 +32,4 @@ networks:
     driver: bridge
 
 volumes:
-  brain3_prod_data:
+  brain3_test_data:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,6 +13,29 @@ Deploy BRAIN 3.0 to TrueNAS or any Docker-capable Linux server. This guide cover
 
 ---
 
+## Environments
+
+BRAIN 3.0 supports three deployment environments, each with its own compose file and project name:
+
+| Environment | Compose File | Branch | API Port | Postgres Port | Project Name |
+|-------------|-------------|--------|----------|---------------|--------------|
+| **Dev** | `docker-compose.dev.yml` | any | 8000 (native uvicorn) | 5432 | `brain3-dev` |
+| **Test** | `docker-compose.test.yml` | `develop` | 8100 | 5433 | `brain3-test` |
+| **Prod** | `docker-compose.prod.yml` | `main` | 8000 | internal only | `brain3-prod` |
+
+- **Dev** runs postgres only — the developer runs uvicorn natively for hot-reload during development.
+- **Test** runs a full stack (API + DB in Docker) for UAT verification against the `develop` branch.
+- **Prod** runs a full stack deployed from `main` on TrueNAS.
+
+All three can coexist on the same host without conflicts. The `COMPOSE_PROJECT_NAME` in each `.env` ensures Docker Compose manages each stack independently — `docker compose down` only touches containers belonging to that project.
+
+Each environment has an `.env` example file:
+- Dev: `cp .env.example .env`
+- Test: `cp .env.test.example .env`
+- Prod: `cp .env.production.example .env`
+
+---
+
 ## Environment Configuration
 
 ### 1. Clone the repository
@@ -85,7 +108,7 @@ The production compose runs **both** PostgreSQL and the API as containers on a p
 docker compose -f docker-compose.prod.yml ps
 ```
 
-Both `brain3-db` and `brain3-api` should show as running.
+Both `db` and `api` services should show as running.
 
 Check the health endpoint:
 
@@ -116,11 +139,53 @@ The smoke test creates and deletes test entities across the full API surface: do
 
 ---
 
+## Test Stack Deployment
+
+The test stack runs the full application (API + DB) in Docker for UAT verification. It uses different ports so it can run alongside the production stack on the same host.
+
+### 1. Create the environment file
+
+```bash
+cp .env.test.example .env
+```
+
+Edit `.env` with appropriate values. The test defaults use port 8100 for the API and 5433 for postgres.
+
+### 2. Build and start
+
+```bash
+docker compose -f docker-compose.test.yml up -d --build
+```
+
+### 3. Verify
+
+```bash
+docker compose -f docker-compose.test.yml ps
+curl http://localhost:8100/health
+```
+
+### 4. Update to latest code
+
+```bash
+git pull origin develop
+docker compose -f docker-compose.test.yml up -d --build
+```
+
+### 5. Tear down
+
+```bash
+docker compose -f docker-compose.test.yml down
+```
+
+This removes only the test containers. Production and dev stacks are unaffected.
+
+---
+
 ## Configure Backups
 
 ### What the backup script does
 
-`scripts/backup.sh` runs `pg_dump` inside the `brain3-db` container, compresses the output with gzip, and stores it in `BACKUP_PATH`. It then deletes backups older than `BACKUP_RETENTION_DAYS` (default: 30).
+`scripts/backup.sh` runs `pg_dump` via `docker compose exec` against the `db` service, compresses the output with gzip, and stores it in `BACKUP_PATH`. It then deletes backups older than `BACKUP_RETENTION_DAYS` (default: 30). The script defaults to using `docker-compose.prod.yml` — override with `COMPOSE_FILE` to back up a different environment.
 
 Backup files are created with restrictive permissions (mode 600, owner-only readable) via `umask 077`. The script logs every run to `BACKUP_PATH/backup.log`.
 
@@ -229,12 +294,20 @@ In Phase 1 (no web UI), the primary consumer is the MCP server, which makes serv
 
 ## Updating
 
-To deploy a new version:
+To deploy a new version, pull the latest code and rebuild. Use the compose file matching your environment:
 
+**Production:**
+```bash
+cd /path/to/brain3
+git pull origin main
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+**Test:**
 ```bash
 cd /path/to/brain3
 git pull origin develop
-docker compose -f docker-compose.prod.yml up -d --build
+docker compose -f docker-compose.test.yml up -d --build
 ```
 
 The API container runs Alembic migrations automatically on startup (`scripts/entrypoint.sh`), so database schema updates are applied with each deploy. Data is preserved — the PostgreSQL volume persists across container rebuilds.
@@ -279,7 +352,7 @@ Verify `POSTGRES_HOST=db` in your `.env` — this must match the Docker Compose 
 - Is the database container running? `docker ps | grep brain3-db`
 - Does the backup path exist and is it writable? `ls -la /mnt/pool/backups/brain3/`
 - Check the backup log: `cat /mnt/pool/backups/brain3/backup.log`
-- Is the container name correct? The script defaults to `brain3-db` (from `DB_CONTAINER_NAME` or the compose file's `container_name`).
+- Is the compose file correct? The script defaults to `docker-compose.prod.yml`. Override with `COMPOSE_FILE=docker-compose.test.yml` to back up the test stack.
 
 ### MCP can't connect to the API
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -15,7 +15,7 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 # Configuration (override via environment or .env)
 BACKUP_PATH="${BACKUP_PATH:-/mnt/pool/backups/brain3}"
 RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}"
-CONTAINER_NAME="${DB_CONTAINER_NAME:-brain3-db}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
 DB_USER="${POSTGRES_USER:-brain3}"
 DB_NAME="${POSTGRES_DB:-brain3}"
 LOG_FILE="$BACKUP_PATH/backup.log"
@@ -38,8 +38,8 @@ mkdir -p "$BACKUP_PATH"
 trap 'log "FAIL: Backup failed with exit code $?"; exit 1' ERR
 
 # Run backup
-log "Starting backup: $FILENAME"
-docker exec "$CONTAINER_NAME" pg_dump -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_PATH/$FILENAME"
+log "Starting backup: $FILENAME (compose file: $COMPOSE_FILE)"
+docker compose -f "$PROJECT_DIR/$COMPOSE_FILE" exec -T db pg_dump -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_PATH/$FILENAME"
 
 # Verify the file exists and is non-empty
 if [ ! -s "$BACKUP_PATH/$FILENAME" ]; then

--- a/tests/test_activity_tags.py
+++ b/tests/test_activity_tags.py
@@ -1,0 +1,289 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for activity-tag attachment, reverse lookup, tag filter, and tag-at-create."""
+
+from tests.conftest import FAKE_UUID, make_activity, make_tag
+
+# ---------------------------------------------------------------------------
+# POST /api/activity/{activity_id}/tags/{tag_id}  — attach
+# ---------------------------------------------------------------------------
+
+class TestAttachTagToActivity:
+
+    def test_attach_tag(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        resp = client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == tag["id"]
+
+    def test_attach_idempotent(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        resp = client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        assert resp.status_code == 200
+        tags_resp = client.get(f"/api/activity/{entry['id']}/tags")
+        assert len(tags_resp.json()) == 1
+
+    def test_attach_invalid_activity(self, client):
+        tag = make_tag(client, name="test")
+        resp = client.post(f"/api/activity/{FAKE_UUID}/tags/{tag['id']}")
+        assert resp.status_code == 404
+
+    def test_attach_invalid_tag(self, client):
+        entry = make_activity(client)
+        resp = client.post(f"/api/activity/{entry['id']}/tags/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/activity/{activity_id}/tags/{tag_id}  — detach
+# ---------------------------------------------------------------------------
+
+class TestDetachTagFromActivity:
+
+    def test_detach_tag(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        resp = client.delete(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        assert resp.status_code == 204
+
+    def test_detach_invalid_activity(self, client):
+        tag = make_tag(client, name="test")
+        resp = client.delete(f"/api/activity/{FAKE_UUID}/tags/{tag['id']}")
+        assert resp.status_code == 404
+
+    def test_detach_invalid_tag(self, client):
+        entry = make_activity(client)
+        resp = client.delete(f"/api/activity/{entry['id']}/tags/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+    def test_detach_not_attached(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        resp = client.delete(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/activity/{activity_id}/tags  — list tags on activity
+# ---------------------------------------------------------------------------
+
+class TestListActivityTags:
+
+    def test_list_tags_on_activity(self, client):
+        tag1 = make_tag(client, name="session-handoff")
+        tag2 = make_tag(client, name="fluxnook")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag1['id']}")
+        client.post(f"/api/activity/{entry['id']}/tags/{tag2['id']}")
+        resp = client.get(f"/api/activity/{entry['id']}/tags")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_list_tags_empty(self, client):
+        entry = make_activity(client)
+        resp = client.get(f"/api/activity/{entry['id']}/tags")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_tags_invalid_activity(self, client):
+        resp = client.get(f"/api/activity/{FAKE_UUID}/tags")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/tags/{tag_id}/activities  — reverse lookup
+# ---------------------------------------------------------------------------
+
+class TestReverseActivityLookup:
+
+    def test_list_activities_for_tag(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry1 = make_activity(client)
+        entry2 = make_activity(client, action_type="reflected")
+        client.post(f"/api/activity/{entry1['id']}/tags/{tag['id']}")
+        client.post(f"/api/activity/{entry2['id']}/tags/{tag['id']}")
+        resp = client.get(f"/api/tags/{tag['id']}/activities")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_reverse_lookup_empty(self, client):
+        tag = make_tag(client, name="unused")
+        resp = client.get(f"/api/tags/{tag['id']}/activities")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_reverse_lookup_invalid_tag(self, client):
+        resp = client.get(f"/api/tags/{FAKE_UUID}/activities")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/activity?tag=  — multi-tag AND filter
+# ---------------------------------------------------------------------------
+
+class TestActivityTagFilter:
+
+    def test_filter_single_tag(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry1 = make_activity(client)
+        make_activity(client, action_type="reflected")
+        client.post(f"/api/activity/{entry1['id']}/tags/{tag['id']}")
+        resp = client.get("/api/activity?tag=session-handoff")
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["id"] == entry1["id"]
+
+    def test_filter_multiple_tags_and_logic(self, client):
+        tag1 = make_tag(client, name="movie")
+        tag2 = make_tag(client, name="fluxnook")
+        entry_both = make_activity(client, action_type="reflected")
+        entry_one = make_activity(client, action_type="completed")
+        client.post(f"/api/activity/{entry_both['id']}/tags/{tag1['id']}")
+        client.post(f"/api/activity/{entry_both['id']}/tags/{tag2['id']}")
+        client.post(f"/api/activity/{entry_one['id']}/tags/{tag1['id']}")
+
+        resp = client.get("/api/activity?tag=movie,fluxnook")
+        entries = resp.json()
+        assert len(entries) == 1
+        assert entries[0]["id"] == entry_both["id"]
+
+    def test_filter_tag_case_insensitive(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        resp = client.get("/api/activity?tag=session-handoff")
+        assert len(resp.json()) == 1
+
+    def test_filter_tag_no_matches(self, client):
+        make_activity(client)
+        resp = client.get("/api/activity?tag=nonexistent")
+        assert resp.json() == []
+
+    def test_filter_tag_composable_with_action_type(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry1 = make_activity(client, action_type="completed")
+        entry2 = make_activity(client, action_type="reflected")
+        client.post(f"/api/activity/{entry1['id']}/tags/{tag['id']}")
+        client.post(f"/api/activity/{entry2['id']}/tags/{tag['id']}")
+        resp = client.get("/api/activity?tag=session-handoff&action_type=reflected")
+        entries = resp.json()
+        assert len(entries) == 1
+        assert entries[0]["id"] == entry2["id"]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/activity with tag_ids  — tag at create
+# ---------------------------------------------------------------------------
+
+class TestTagAtCreate:
+
+    def test_create_with_tag_ids(self, client):
+        tag1 = make_tag(client, name="session-handoff")
+        tag2 = make_tag(client, name="fluxnook")
+        resp = client.post(
+            "/api/activity",
+            json={
+                "action_type": "reflected",
+                "tag_ids": [tag1["id"], tag2["id"]],
+            },
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert len(body["tags"]) == 2
+        tag_names = {t["name"] for t in body["tags"]}
+        assert tag_names == {"session-handoff", "fluxnook"}
+
+    def test_create_with_empty_tag_ids(self, client):
+        resp = client.post(
+            "/api/activity",
+            json={"action_type": "reflected", "tag_ids": []},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["tags"] == []
+
+    def test_create_without_tag_ids(self, client):
+        resp = client.post(
+            "/api/activity",
+            json={"action_type": "reflected"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["tags"] == []
+
+    def test_create_with_invalid_tag_id(self, client):
+        resp = client.post(
+            "/api/activity",
+            json={
+                "action_type": "reflected",
+                "tag_ids": [FAKE_UUID],
+            },
+        )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Tags in activity responses
+# ---------------------------------------------------------------------------
+
+class TestActivityResponseIncludesTags:
+
+    def test_list_response_includes_tags(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        resp = client.get("/api/activity")
+        entries = resp.json()
+        assert len(entries) == 1
+        assert len(entries[0]["tags"]) == 1
+        assert entries[0]["tags"][0]["name"] == "session-handoff"
+
+    def test_detail_response_includes_tags(self, client):
+        tag = make_tag(client, name="session-handoff")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        resp = client.get(f"/api/activity/{entry['id']}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["tags"]) == 1
+        assert body["tags"][0]["name"] == "session-handoff"
+
+
+# ---------------------------------------------------------------------------
+# Cascade — deleting a tag removes activity associations
+# ---------------------------------------------------------------------------
+
+class TestActivityTagCascade:
+
+    def test_delete_tag_cascades_activity_associations(self, client):
+        tag = make_tag(client, name="temp")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        client.delete(f"/api/tags/{tag['id']}")
+        resp = client.get(f"/api/activity/{entry['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == []
+
+    def test_delete_activity_cascades_tag_associations(self, client):
+        tag = make_tag(client, name="persist")
+        entry = make_activity(client)
+        client.post(f"/api/activity/{entry['id']}/tags/{tag['id']}")
+        client.delete(f"/api/activity/{entry['id']}")
+        # Tag still exists
+        resp = client.get(f"/api/tags/{tag['id']}")
+        assert resp.status_code == 200


### PR DESCRIPTION
## BRAIN 3.0 — v1.1.0

**Release date:** 2026-04-03

### What's New
Activity log entries can now be tagged, enabling categorization and filtering of life logging data (meals, media, reflections) beyond task-based tracking.

### API Changes (brain3)
- New `activity_tags` association table
- `POST /api/activity/{id}/tags/{tag_id}` — attach tag to activity
- `DELETE /api/activity/{id}/tags/{tag_id}` — remove tag from activity
- `GET /api/activity/{id}/tags` — list tags on an activity entry
- `GET /api/activity` — new `tag` query parameter (comma-separated, AND logic)
- `POST /api/activity` — new optional `tag_ids` field for tagging at creation
- Activity detail responses now include `tags` array

### MCP Changes (brain3-mcp)
- New tools: `tag_activity`, `untag_activity`, `list_activity_tags`, `list_tagged_activities`
- Updated: `list_activity` (tag filter), `log_activity` (tag_ids parameter)

### Infrastructure
- New `docker-compose.test.yml` for dedicated test environment
- Parameterized container names across all compose files (dev, test, prod)
- Updated backup script for new container naming

### Testing
- 27 new unit tests for activity tags
- 12/12 integration tests passed on test instance
- Full existing test suite continues to pass

### Known Limitations
- Tags on activity entries work identically to tags on tasks. Global tag namespace shared.
- No breaking changes to existing API or MCP behavior.