### PR TITLE
TICKET-94: Artifacts model, migration, CRUD & tagging

### DIFF
--- a/alembic/versions/003_artifacts.py
+++ b/alembic/versions/003_artifacts.py
@@ -1,0 +1,99 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""add artifacts and artifact_tags tables
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-10 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "artifacts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("artifact_type", sa.String(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=True),
+        sa.Column("content_size", sa.Integer(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column(
+            "parent_id", postgresql.UUID(as_uuid=True), nullable=True,
+        ),
+        sa.Column("is_seedable", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["parent_id"], ["artifacts.id"], ondelete="SET NULL",
+        ),
+        sa.CheckConstraint(
+            "artifact_type IN ("
+            "'document', 'protocol', 'brief', 'prompt', 'template', 'journal', 'spec'"
+            ")",
+            name="ck_artifacts_artifact_type",
+        ),
+        sa.CheckConstraint(
+            "octet_length(content) <= 524288",
+            name="ck_artifacts_content_size",
+        ),
+    )
+    op.create_index("ix_artifacts_artifact_type", "artifacts", ["artifact_type"])
+    op.create_index("ix_artifacts_is_seedable", "artifacts", ["is_seedable"])
+
+    op.create_table(
+        "artifact_tags",
+        sa.Column("artifact_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tag_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["artifact_id"], ["artifacts.id"], ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tag_id"], ["tags.id"], ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("artifact_id", "tag_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("artifact_tags")
+    op.drop_index("ix_artifacts_is_seedable", table_name="artifacts")
+    op.drop_index("ix_artifacts_artifact_type", table_name="artifacts")
+    op.drop_table("artifacts")

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from app.config import settings
 from app.database import SessionLocal
 from app.routers import (
     activity,
+    artifacts,
     checkins,
     domains,
     goals,
@@ -79,4 +80,8 @@ app.include_router(reports.router, prefix="/api/reports", tags=["Reports"])
 app.include_router(tags.task_tags_router, prefix="/api/tasks", tags=["Task Tags"])
 app.include_router(
     activity.activity_tags_router, prefix="/api/activity", tags=["Activity Tags"],
+)
+app.include_router(artifacts.router, prefix="/api/artifacts", tags=["Artifacts"])
+app.include_router(
+    artifacts.artifact_tags_router, prefix="/api/artifacts", tags=["Artifact Tags"],
 )

--- a/app/models.py
+++ b/app/models.py
@@ -21,6 +21,7 @@ from datetime import date, datetime
 from uuid import uuid4
 
 from sqlalchemy import (
+    Boolean,
     CheckConstraint,
     Date,
     DateTime,
@@ -60,6 +61,19 @@ class ActivityTag(Base):
 
     activity_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("activity_log.id", ondelete="CASCADE"), primary_key=True,
+    )
+    tag_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True,
+    )
+
+
+class ArtifactTag(Base):
+    """Many-to-many link between artifacts and tags."""
+
+    __tablename__ = "artifact_tags"
+
+    artifact_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("artifacts.id", ondelete="CASCADE"), primary_key=True,
     )
     tag_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True,
@@ -265,6 +279,9 @@ class Tag(Base):
     activity_logs: Mapped[list["ActivityLog"]] = relationship(
         secondary="activity_tags", back_populates="tags",
     )
+    artifacts: Mapped[list["Artifact"]] = relationship(
+        secondary="artifact_tags", back_populates="tags",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -454,4 +471,59 @@ class ActivityLog(Base):
     checkin: Mapped["StateCheckin | None"] = relationship(back_populates="activity_logs")
     tags: Mapped[list["Tag"]] = relationship(
         secondary="activity_tags", back_populates="activity_logs",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Artifacts — living reference documents
+# ---------------------------------------------------------------------------
+
+class Artifact(Base):
+    """Stored document with versioning, multi-part grouping, and tagging."""
+
+    __tablename__ = "artifacts"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4,
+    )
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    artifact_type: Mapped[str] = mapped_column(String, nullable=False)
+    content: Mapped[str | None] = mapped_column(Text)
+    content_size: Mapped[int] = mapped_column(Integer, nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    parent_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("artifacts.id", ondelete="SET NULL"),
+    )
+    is_seedable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "artifact_type IN ("
+            "'document', 'protocol', 'brief', 'prompt', 'template', 'journal', 'spec'"
+            ")",
+            name="ck_artifacts_artifact_type",
+        ),
+        CheckConstraint(
+            "octet_length(content) <= 524288",
+            name="ck_artifacts_content_size",
+        ),
+        Index("ix_artifacts_artifact_type", "artifact_type"),
+        Index("ix_artifacts_is_seedable", "is_seedable"),
+    )
+
+    # Relationships
+    tags: Mapped[list["Tag"]] = relationship(
+        secondary="artifact_tags", back_populates="artifacts",
+    )
+    parent: Mapped["Artifact | None"] = relationship(
+        remote_side=[id], foreign_keys=[parent_id],
+    )
+    children: Mapped[list["Artifact"]] = relationship(
+        foreign_keys=[parent_id], overlaps="parent",
     )

--- a/app/routers/artifacts.py
+++ b/app/routers/artifacts.py
@@ -1,0 +1,237 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""CRUD endpoints for Artifacts."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session, joinedload
+
+from app.database import get_db
+from app.models import Artifact, ArtifactTag, Tag
+from app.schemas.artifacts import (
+    ArtifactCreate,
+    ArtifactDetailResponse,
+    ArtifactResponse,
+    ArtifactUpdate,
+)
+from app.schemas.tags import TagResponse
+
+router = APIRouter()
+artifact_tags_router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Artifact CRUD — /api/artifacts
+# ---------------------------------------------------------------------------
+
+
+@router.post("/", response_model=ArtifactResponse, status_code=status.HTTP_201_CREATED)
+def create_artifact(payload: ArtifactCreate, db: Session = Depends(get_db)) -> Artifact:
+    """Create a new artifact. Validates parent_id and tag_ids if provided."""
+    if payload.parent_id is not None:
+        if not db.query(Artifact).filter(Artifact.id == payload.parent_id).first():
+            raise HTTPException(status_code=400, detail="Parent artifact not found")
+
+    tags = []
+    if payload.tag_ids:
+        for tid in payload.tag_ids:
+            tag = db.query(Tag).filter(Tag.id == tid).first()
+            if not tag:
+                raise HTTPException(status_code=400, detail=f"Tag {tid} not found")
+            tags.append(tag)
+
+    content_size = len(payload.content.encode("utf-8"))
+    artifact = Artifact(
+        **payload.model_dump(exclude={"tag_ids"}),
+        content_size=content_size,
+    )
+    db.add(artifact)
+    db.flush()
+
+    for tag in tags:
+        db.add(ArtifactTag(artifact_id=artifact.id, tag_id=tag.id))
+
+    db.commit()
+    db.refresh(artifact)
+    return artifact
+
+
+@router.get("/", response_model=list[ArtifactResponse])
+def list_artifacts(
+    artifact_type: str | None = Query(None),
+    is_seedable: bool | None = Query(None),
+    search: str | None = Query(None, description="Case-insensitive title search"),
+    parent_id: UUID | None = Query(None, description="Children of a specific artifact"),
+    tag: str | None = Query(None, description="Comma-separated tag names (AND logic)"),
+    db: Session = Depends(get_db),
+) -> list[Artifact]:
+    """List artifacts (metadata only — no content). Supports composable filters."""
+    query = db.query(Artifact)
+
+    if artifact_type is not None:
+        query = query.filter(Artifact.artifact_type == artifact_type)
+    if is_seedable is not None:
+        query = query.filter(Artifact.is_seedable == is_seedable)
+    if search is not None:
+        query = query.filter(Artifact.title.ilike(f"%{search}%"))
+    if parent_id is not None:
+        query = query.filter(Artifact.parent_id == parent_id)
+    if tag is not None:
+        tag_names = [t.strip().lower() for t in tag.split(",") if t.strip()]
+        for tag_name in tag_names:
+            query = query.filter(
+                Artifact.tags.any(Tag.name == tag_name)
+            )
+
+    return query.order_by(Artifact.created_at.desc()).all()
+
+
+@router.get("/{artifact_id}", response_model=ArtifactDetailResponse)
+def get_artifact(artifact_id: UUID, db: Session = Depends(get_db)) -> Artifact:
+    """Get a single artifact with content and resolved parent."""
+    artifact = (
+        db.query(Artifact)
+        .options(
+            joinedload(Artifact.tags),
+            joinedload(Artifact.parent),
+        )
+        .filter(Artifact.id == artifact_id)
+        .first()
+    )
+    if not artifact:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+    return artifact
+
+
+@router.patch("/{artifact_id}", response_model=ArtifactDetailResponse)
+def update_artifact(
+    artifact_id: UUID, payload: ArtifactUpdate, db: Session = Depends(get_db)
+) -> Artifact:
+    """Partial update. Auto-increments version and recomputes content_size on content change."""
+    artifact = db.query(Artifact).filter(Artifact.id == artifact_id).first()
+    if not artifact:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+
+    updates = payload.model_dump(exclude_unset=True)
+
+    if "parent_id" in updates and updates["parent_id"] is not None:
+        if not db.query(Artifact).filter(Artifact.id == updates["parent_id"]).first():
+            raise HTTPException(status_code=400, detail="Parent artifact not found")
+
+    if "content" in updates:
+        content = updates["content"]
+        if content is not None:
+            updates["content_size"] = len(content.encode("utf-8"))
+        else:
+            updates["content_size"] = 0
+        updates["version"] = artifact.version + 1
+
+    for field, value in updates.items():
+        setattr(artifact, field, value)
+
+    db.commit()
+    db.refresh(artifact)
+
+    # Eager-load for detail response
+    artifact = (
+        db.query(Artifact)
+        .options(
+            joinedload(Artifact.tags),
+            joinedload(Artifact.parent),
+        )
+        .filter(Artifact.id == artifact_id)
+        .first()
+    )
+    return artifact
+
+
+@router.delete("/{artifact_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_artifact(artifact_id: UUID, db: Session = Depends(get_db)) -> None:
+    """Delete an artifact. Children get parent_id set to NULL."""
+    artifact = db.query(Artifact).filter(Artifact.id == artifact_id).first()
+    if not artifact:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+    db.delete(artifact)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Artifact-Tag attachment — /api/artifacts/{artifact_id}/tags
+# ---------------------------------------------------------------------------
+
+
+@artifact_tags_router.get("/{artifact_id}/tags", response_model=list[TagResponse])
+def list_tags_on_artifact(
+    artifact_id: UUID, db: Session = Depends(get_db)
+) -> list[Tag]:
+    """List all tags attached to an artifact."""
+    artifact = db.query(Artifact).filter(Artifact.id == artifact_id).first()
+    if not artifact:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+    return artifact.tags
+
+
+@artifact_tags_router.post(
+    "/{artifact_id}/tags/{tag_id}", response_model=TagResponse,
+)
+def attach_tag_to_artifact(
+    artifact_id: UUID, tag_id: UUID, db: Session = Depends(get_db)
+) -> Tag:
+    """Attach a tag to an artifact. Idempotent."""
+    artifact = db.query(Artifact).filter(Artifact.id == artifact_id).first()
+    if not artifact:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    existing = (
+        db.query(ArtifactTag)
+        .filter(ArtifactTag.artifact_id == artifact_id, ArtifactTag.tag_id == tag_id)
+        .first()
+    )
+    if not existing:
+        db.add(ArtifactTag(artifact_id=artifact_id, tag_id=tag_id))
+        db.commit()
+
+    return tag
+
+
+@artifact_tags_router.delete(
+    "/{artifact_id}/tags/{tag_id}", status_code=status.HTTP_204_NO_CONTENT,
+)
+def detach_tag_from_artifact(
+    artifact_id: UUID, tag_id: UUID, db: Session = Depends(get_db)
+) -> None:
+    """Remove a tag from an artifact."""
+    artifact = db.query(Artifact).filter(Artifact.id == artifact_id).first()
+    if not artifact:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    link = (
+        db.query(ArtifactTag)
+        .filter(ArtifactTag.artifact_id == artifact_id, ArtifactTag.tag_id == tag_id)
+        .first()
+    )
+    if not link:
+        raise HTTPException(status_code=404, detail="Tag is not attached to this artifact")
+    db.delete(link)
+    db.commit()

--- a/app/routers/tags.py
+++ b/app/routers/tags.py
@@ -22,8 +22,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.models import ActivityLog, Tag, Task, TaskTag
+from app.models import ActivityLog, Artifact, Tag, Task, TaskTag
 from app.schemas.activity import ActivityLogResponse
+from app.schemas.artifacts import ArtifactResponse
 from app.schemas.tags import TagCreate, TagResponse, TagUpdate
 from app.schemas.tasks import TaskResponse
 
@@ -134,6 +135,22 @@ def list_activities_for_tag(
     if not tag:
         raise HTTPException(status_code=404, detail="Tag not found")
     return tag.activity_logs
+
+
+# ---------------------------------------------------------------------------
+# Reverse lookup — /api/tags/{tag_id}/artifacts
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{tag_id}/artifacts", response_model=list[ArtifactResponse])
+def list_artifacts_for_tag(
+    tag_id: UUID, db: Session = Depends(get_db)
+) -> list[Artifact]:
+    """List all artifacts that have a given tag."""
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    return tag.artifacts
 
 
 # ---------------------------------------------------------------------------

--- a/app/schemas/artifacts.py
+++ b/app/schemas/artifacts.py
@@ -1,0 +1,80 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Pydantic schemas for Artifact CRUD operations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ArtifactType = Literal[
+    "document", "protocol", "brief", "prompt", "template", "journal", "spec"
+]
+
+
+class ArtifactCreate(BaseModel):
+    """Fields required to create an artifact."""
+
+    title: str = Field(max_length=200)
+    artifact_type: ArtifactType
+    content: str = Field(max_length=500_000)
+    parent_id: UUID | None = None
+    is_seedable: bool = False
+    tag_ids: list[UUID] | None = None
+
+
+class ArtifactUpdate(BaseModel):
+    """All fields optional — supports partial PATCH updates."""
+
+    title: str | None = Field(default=None, max_length=200)
+    artifact_type: ArtifactType | None = None
+    content: str | None = Field(default=None, max_length=500_000)
+    parent_id: UUID | None = None
+    is_seedable: bool | None = None
+
+
+class ArtifactResponse(BaseModel):
+    """Artifact metadata returned from list endpoints — no content."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    title: str
+    artifact_type: str
+    content_size: int
+    version: int
+    parent_id: UUID | None = None
+    is_seedable: bool
+    created_at: datetime
+    updated_at: datetime
+    tags: list["TagResponse"] = []
+
+
+class ArtifactDetailResponse(ArtifactResponse):
+    """Single artifact with content and resolved parent."""
+
+    content: str | None = None
+    parent: ArtifactResponse | None = None
+
+
+from app.schemas.tags import TagResponse  # noqa: E402
+
+ArtifactResponse.model_rebuild()
+ArtifactDetailResponse.model_rebuild()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -18,7 +18,6 @@
 
 from tests.conftest import FAKE_UUID, make_tag
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -178,7 +177,7 @@ class TestListArtifacts:
 
     def test_filter_by_parent_id(self, client):
         parent = make_artifact(client, title="Parent")
-        child1 = make_artifact(client, title="Child 1", parent_id=parent["id"])
+        make_artifact(client, title="Child 1", parent_id=parent["id"])
         make_artifact(client, title="Child 2", parent_id=parent["id"])
         make_artifact(client, title="Standalone")
         resp = client.get(f"/api/artifacts?parent_id={parent['id']}")
@@ -515,7 +514,7 @@ class TestArtifactResponseIncludesTags:
 
     def test_list_response_includes_tags(self, client):
         tag = make_tag(client, name="claude-md")
-        artifact = make_artifact(client, tag_ids=[tag["id"]])
+        make_artifact(client, tag_ids=[tag["id"]])
         resp = client.get("/api/artifacts")
         items = resp.json()
         assert len(items) == 1

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,531 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for Artifacts — CRUD, tagging, filters, parent relationships, version logic."""
+
+from tests.conftest import FAKE_UUID, make_tag
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_artifact(client, **overrides) -> dict:
+    """Create an artifact via the API and return the response JSON."""
+    data = {
+        "title": "Test Artifact",
+        "artifact_type": "document",
+        "content": "Hello, world!",
+        **overrides,
+    }
+    resp = client.post("/api/artifacts", json=data)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/artifacts — Create
+# ---------------------------------------------------------------------------
+
+class TestCreateArtifact:
+
+    def test_create_minimal(self, client):
+        resp = client.post("/api/artifacts", json={
+            "title": "My Doc",
+            "artifact_type": "document",
+            "content": "Some content",
+        })
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["title"] == "My Doc"
+        assert body["artifact_type"] == "document"
+        assert body["version"] == 1
+        assert body["is_seedable"] is False
+        assert body["parent_id"] is None
+        assert "content" not in body  # list-style response — no content
+
+    def test_create_computes_content_size(self, client):
+        content = "Hello, BRAIN!"
+        artifact = make_artifact(client, content=content)
+        assert artifact["content_size"] == len(content.encode("utf-8"))
+
+    def test_create_content_size_utf8(self, client):
+        content = "Héllo wörld 🧠"
+        artifact = make_artifact(client, content=content)
+        assert artifact["content_size"] == len(content.encode("utf-8"))
+
+    def test_create_with_parent(self, client):
+        parent = make_artifact(client, title="Part 1")
+        child = make_artifact(client, title="Part 2", parent_id=parent["id"])
+        assert child["parent_id"] == parent["id"]
+
+    def test_create_with_invalid_parent(self, client):
+        resp = client.post("/api/artifacts", json={
+            "title": "Orphan",
+            "artifact_type": "document",
+            "content": "Content",
+            "parent_id": FAKE_UUID,
+        })
+        assert resp.status_code == 400
+
+    def test_create_with_tag_ids(self, client):
+        tag1 = make_tag(client, name="claude-md")
+        tag2 = make_tag(client, name="protocol")
+        resp = client.post("/api/artifacts", json={
+            "title": "Tagged Doc",
+            "artifact_type": "document",
+            "content": "Content",
+            "tag_ids": [tag1["id"], tag2["id"]],
+        })
+        assert resp.status_code == 201
+        body = resp.json()
+        assert len(body["tags"]) == 2
+        tag_names = {t["name"] for t in body["tags"]}
+        assert tag_names == {"claude-md", "protocol"}
+
+    def test_create_with_invalid_tag_id(self, client):
+        resp = client.post("/api/artifacts", json={
+            "title": "Bad Tags",
+            "artifact_type": "document",
+            "content": "Content",
+            "tag_ids": [FAKE_UUID],
+        })
+        assert resp.status_code == 400
+
+    def test_create_invalid_artifact_type(self, client):
+        resp = client.post("/api/artifacts", json={
+            "title": "Bad Type",
+            "artifact_type": "invalid_type",
+            "content": "Content",
+        })
+        assert resp.status_code == 422
+
+    def test_create_all_valid_types(self, client):
+        for atype in ("document", "protocol", "brief", "prompt", "template", "journal", "spec"):
+            resp = client.post("/api/artifacts", json={
+                "title": f"Test {atype}",
+                "artifact_type": atype,
+                "content": "Content",
+            })
+            assert resp.status_code == 201, f"Failed for type: {atype}"
+
+    def test_create_seedable(self, client):
+        artifact = make_artifact(client, is_seedable=True)
+        assert artifact["is_seedable"] is True
+
+    def test_create_content_too_long(self, client):
+        resp = client.post("/api/artifacts", json={
+            "title": "Too Big",
+            "artifact_type": "document",
+            "content": "x" * 500_001,
+        })
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/artifacts — List (metadata only)
+# ---------------------------------------------------------------------------
+
+class TestListArtifacts:
+
+    def test_list_returns_metadata_only(self, client):
+        make_artifact(client, content="Secret content inside")
+        resp = client.get("/api/artifacts")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 1
+        assert "content" not in body[0]
+        assert "content_size" in body[0]
+
+    def test_list_empty(self, client):
+        resp = client.get("/api/artifacts")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_filter_by_artifact_type(self, client):
+        make_artifact(client, artifact_type="document")
+        make_artifact(client, title="Brief", artifact_type="brief")
+        resp = client.get("/api/artifacts?artifact_type=brief")
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["artifact_type"] == "brief"
+
+    def test_filter_by_is_seedable(self, client):
+        make_artifact(client, is_seedable=True)
+        make_artifact(client, title="Non-seed", is_seedable=False)
+        resp = client.get("/api/artifacts?is_seedable=true")
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["is_seedable"] is True
+
+    def test_filter_by_search(self, client):
+        make_artifact(client, title="CLAUDE.md Org Standards")
+        make_artifact(client, title="Agent Brief")
+        resp = client.get("/api/artifacts?search=claude")
+        assert len(resp.json()) == 1
+        assert "CLAUDE" in resp.json()[0]["title"]
+
+    def test_filter_by_parent_id(self, client):
+        parent = make_artifact(client, title="Parent")
+        child1 = make_artifact(client, title="Child 1", parent_id=parent["id"])
+        make_artifact(client, title="Child 2", parent_id=parent["id"])
+        make_artifact(client, title="Standalone")
+        resp = client.get(f"/api/artifacts?parent_id={parent['id']}")
+        children = resp.json()
+        assert len(children) == 2
+
+    def test_filter_by_tag(self, client):
+        tag = make_tag(client, name="claude-md")
+        a1 = make_artifact(client, title="Tagged", tag_ids=[tag["id"]])
+        make_artifact(client, title="Untagged")
+        resp = client.get("/api/artifacts?tag=claude-md")
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["id"] == a1["id"]
+
+    def test_filter_by_tag_and_logic(self, client):
+        tag1 = make_tag(client, name="claude-md")
+        tag2 = make_tag(client, name="org-level")
+        a_both = make_artifact(client, title="Both Tags", tag_ids=[tag1["id"], tag2["id"]])
+        make_artifact(client, title="One Tag", tag_ids=[tag1["id"]])
+        resp = client.get("/api/artifacts?tag=claude-md,org-level")
+        results = resp.json()
+        assert len(results) == 1
+        assert results[0]["id"] == a_both["id"]
+
+    def test_filter_composable(self, client):
+        tag = make_tag(client, name="proto")
+        make_artifact(client, artifact_type="protocol", tag_ids=[tag["id"]])
+        make_artifact(client, title="Doc", artifact_type="document", tag_ids=[tag["id"]])
+        resp = client.get("/api/artifacts?artifact_type=protocol&tag=proto")
+        assert len(resp.json()) == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /api/artifacts/{id} — Detail (with content)
+# ---------------------------------------------------------------------------
+
+class TestGetArtifact:
+
+    def test_get_returns_content(self, client):
+        artifact = make_artifact(client, content="Full content here")
+        resp = client.get(f"/api/artifacts/{artifact['id']}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["content"] == "Full content here"
+        assert body["title"] == "Test Artifact"
+
+    def test_get_resolves_parent(self, client):
+        parent = make_artifact(client, title="Part 1")
+        child = make_artifact(client, title="Part 2", parent_id=parent["id"])
+        resp = client.get(f"/api/artifacts/{child['id']}")
+        body = resp.json()
+        assert body["parent"] is not None
+        assert body["parent"]["id"] == parent["id"]
+        assert body["parent"]["title"] == "Part 1"
+        assert "content" not in body["parent"]  # parent is ArtifactResponse, no content
+
+    def test_get_without_parent(self, client):
+        artifact = make_artifact(client)
+        resp = client.get(f"/api/artifacts/{artifact['id']}")
+        assert resp.json()["parent"] is None
+
+    def test_get_not_found(self, client):
+        resp = client.get(f"/api/artifacts/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+    def test_get_includes_tags(self, client):
+        tag = make_tag(client, name="test-tag")
+        artifact = make_artifact(client, tag_ids=[tag["id"]])
+        resp = client.get(f"/api/artifacts/{artifact['id']}")
+        body = resp.json()
+        assert len(body["tags"]) == 1
+        assert body["tags"][0]["name"] == "test-tag"
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/artifacts/{id} — Update
+# ---------------------------------------------------------------------------
+
+class TestUpdateArtifact:
+
+    def test_update_metadata_only(self, client):
+        artifact = make_artifact(client)
+        resp = client.patch(f"/api/artifacts/{artifact['id']}", json={
+            "title": "Updated Title",
+        })
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["title"] == "Updated Title"
+        assert body["version"] == 1  # no content change — version stays
+
+    def test_update_content_increments_version(self, client):
+        artifact = make_artifact(client, content="v1 content")
+        resp = client.patch(f"/api/artifacts/{artifact['id']}", json={
+            "content": "v2 content",
+        })
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["version"] == 2
+        assert body["content"] == "v2 content"
+        assert body["content_size"] == len("v2 content".encode("utf-8"))
+
+    def test_update_content_twice(self, client):
+        artifact = make_artifact(client)
+        client.patch(f"/api/artifacts/{artifact['id']}", json={"content": "v2"})
+        resp = client.patch(f"/api/artifacts/{artifact['id']}", json={"content": "v3"})
+        assert resp.json()["version"] == 3
+
+    def test_update_content_recomputes_size(self, client):
+        artifact = make_artifact(client, content="short")
+        new_content = "a much longer piece of content for testing"
+        resp = client.patch(f"/api/artifacts/{artifact['id']}", json={
+            "content": new_content,
+        })
+        assert resp.json()["content_size"] == len(new_content.encode("utf-8"))
+
+    def test_update_parent_id(self, client):
+        parent = make_artifact(client, title="New Parent")
+        child = make_artifact(client, title="Child")
+        resp = client.patch(f"/api/artifacts/{child['id']}", json={
+            "parent_id": parent["id"],
+        })
+        assert resp.status_code == 200
+        assert resp.json()["parent_id"] == parent["id"]
+
+    def test_update_parent_id_invalid(self, client):
+        artifact = make_artifact(client)
+        resp = client.patch(f"/api/artifacts/{artifact['id']}", json={
+            "parent_id": FAKE_UUID,
+        })
+        assert resp.status_code == 400
+
+    def test_update_not_found(self, client):
+        resp = client.patch(f"/api/artifacts/{FAKE_UUID}", json={"title": "Nope"})
+        assert resp.status_code == 404
+
+    def test_update_returns_detail_response(self, client):
+        artifact = make_artifact(client, content="original")
+        resp = client.patch(f"/api/artifacts/{artifact['id']}", json={
+            "title": "Renamed",
+        })
+        body = resp.json()
+        assert "content" in body  # detail response includes content
+        assert body["content"] == "original"
+
+    def test_update_artifact_type(self, client):
+        artifact = make_artifact(client, artifact_type="document")
+        resp = client.patch(f"/api/artifacts/{artifact['id']}", json={
+            "artifact_type": "brief",
+        })
+        assert resp.json()["artifact_type"] == "brief"
+        assert resp.json()["version"] == 1  # metadata-only, no version bump
+
+    def test_update_is_seedable(self, client):
+        artifact = make_artifact(client, is_seedable=False)
+        resp = client.patch(f"/api/artifacts/{artifact['id']}", json={
+            "is_seedable": True,
+        })
+        assert resp.json()["is_seedable"] is True
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/artifacts/{id}
+# ---------------------------------------------------------------------------
+
+class TestDeleteArtifact:
+
+    def test_delete(self, client):
+        artifact = make_artifact(client)
+        resp = client.delete(f"/api/artifacts/{artifact['id']}")
+        assert resp.status_code == 204
+        resp = client.get(f"/api/artifacts/{artifact['id']}")
+        assert resp.status_code == 404
+
+    def test_delete_not_found(self, client):
+        resp = client.delete(f"/api/artifacts/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+    def test_delete_parent_nulls_children(self, client):
+        parent = make_artifact(client, title="Parent")
+        child = make_artifact(client, title="Child", parent_id=parent["id"])
+        client.delete(f"/api/artifacts/{parent['id']}")
+        resp = client.get(f"/api/artifacts/{child['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["parent_id"] is None
+        assert resp.json()["parent"] is None
+
+
+# ---------------------------------------------------------------------------
+# Artifact-Tag attachment — /api/artifacts/{artifact_id}/tags
+# ---------------------------------------------------------------------------
+
+class TestArtifactTagAttach:
+
+    def test_attach_tag(self, client):
+        tag = make_tag(client, name="claude-md")
+        artifact = make_artifact(client)
+        resp = client.post(f"/api/artifacts/{artifact['id']}/tags/{tag['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == tag["id"]
+
+    def test_attach_idempotent(self, client):
+        tag = make_tag(client, name="claude-md")
+        artifact = make_artifact(client)
+        client.post(f"/api/artifacts/{artifact['id']}/tags/{tag['id']}")
+        resp = client.post(f"/api/artifacts/{artifact['id']}/tags/{tag['id']}")
+        assert resp.status_code == 200
+        tags_resp = client.get(f"/api/artifacts/{artifact['id']}/tags")
+        assert len(tags_resp.json()) == 1
+
+    def test_attach_invalid_artifact(self, client):
+        tag = make_tag(client, name="test")
+        resp = client.post(f"/api/artifacts/{FAKE_UUID}/tags/{tag['id']}")
+        assert resp.status_code == 404
+
+    def test_attach_invalid_tag(self, client):
+        artifact = make_artifact(client)
+        resp = client.post(f"/api/artifacts/{artifact['id']}/tags/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+
+class TestArtifactTagDetach:
+
+    def test_detach_tag(self, client):
+        tag = make_tag(client, name="claude-md")
+        artifact = make_artifact(client)
+        client.post(f"/api/artifacts/{artifact['id']}/tags/{tag['id']}")
+        resp = client.delete(f"/api/artifacts/{artifact['id']}/tags/{tag['id']}")
+        assert resp.status_code == 204
+
+    def test_detach_invalid_artifact(self, client):
+        tag = make_tag(client, name="test")
+        resp = client.delete(f"/api/artifacts/{FAKE_UUID}/tags/{tag['id']}")
+        assert resp.status_code == 404
+
+    def test_detach_invalid_tag(self, client):
+        artifact = make_artifact(client)
+        resp = client.delete(f"/api/artifacts/{artifact['id']}/tags/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+    def test_detach_not_attached(self, client):
+        tag = make_tag(client, name="claude-md")
+        artifact = make_artifact(client)
+        resp = client.delete(f"/api/artifacts/{artifact['id']}/tags/{tag['id']}")
+        assert resp.status_code == 404
+
+
+class TestArtifactTagList:
+
+    def test_list_tags_on_artifact(self, client):
+        tag1 = make_tag(client, name="claude-md")
+        tag2 = make_tag(client, name="org-level")
+        artifact = make_artifact(client)
+        client.post(f"/api/artifacts/{artifact['id']}/tags/{tag1['id']}")
+        client.post(f"/api/artifacts/{artifact['id']}/tags/{tag2['id']}")
+        resp = client.get(f"/api/artifacts/{artifact['id']}/tags")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_list_tags_empty(self, client):
+        artifact = make_artifact(client)
+        resp = client.get(f"/api/artifacts/{artifact['id']}/tags")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_tags_invalid_artifact(self, client):
+        resp = client.get(f"/api/artifacts/{FAKE_UUID}/tags")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Reverse lookup — GET /api/tags/{tag_id}/artifacts
+# ---------------------------------------------------------------------------
+
+class TestReverseArtifactLookup:
+
+    def test_list_artifacts_for_tag(self, client):
+        tag = make_tag(client, name="claude-md")
+        a1 = make_artifact(client, title="Doc 1")
+        a2 = make_artifact(client, title="Doc 2")
+        client.post(f"/api/artifacts/{a1['id']}/tags/{tag['id']}")
+        client.post(f"/api/artifacts/{a2['id']}/tags/{tag['id']}")
+        resp = client.get(f"/api/tags/{tag['id']}/artifacts")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_reverse_lookup_empty(self, client):
+        tag = make_tag(client, name="unused")
+        resp = client.get(f"/api/tags/{tag['id']}/artifacts")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_reverse_lookup_invalid_tag(self, client):
+        resp = client.get(f"/api/tags/{FAKE_UUID}/artifacts")
+        assert resp.status_code == 404
+
+    def test_reverse_lookup_no_content(self, client):
+        tag = make_tag(client, name="test")
+        artifact = make_artifact(client, content="Should not appear")
+        client.post(f"/api/artifacts/{artifact['id']}/tags/{tag['id']}")
+        resp = client.get(f"/api/tags/{tag['id']}/artifacts")
+        for item in resp.json():
+            assert "content" not in item
+
+
+# ---------------------------------------------------------------------------
+# Cascade behavior
+# ---------------------------------------------------------------------------
+
+class TestArtifactCascade:
+
+    def test_delete_tag_cascades_artifact_associations(self, client):
+        tag = make_tag(client, name="temp")
+        artifact = make_artifact(client)
+        client.post(f"/api/artifacts/{artifact['id']}/tags/{tag['id']}")
+        client.delete(f"/api/tags/{tag['id']}")
+        resp = client.get(f"/api/artifacts/{artifact['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == []
+
+    def test_delete_artifact_cascades_tag_associations(self, client):
+        tag = make_tag(client, name="persist")
+        artifact = make_artifact(client)
+        client.post(f"/api/artifacts/{artifact['id']}/tags/{tag['id']}")
+        client.delete(f"/api/artifacts/{artifact['id']}")
+        resp = client.get(f"/api/tags/{tag['id']}")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Tags in artifact responses
+# ---------------------------------------------------------------------------
+
+class TestArtifactResponseIncludesTags:
+
+    def test_list_response_includes_tags(self, client):
+        tag = make_tag(client, name="claude-md")
+        artifact = make_artifact(client, tag_ids=[tag["id"]])
+        resp = client.get("/api/artifacts")
+        items = resp.json()
+        assert len(items) == 1
+        assert len(items[0]["tags"]) == 1
+        assert items[0]["tags"][0]["name"] == "claude-md"
+
+    def test_detail_response_includes_tags(self, client):
+        tag = make_tag(client, name="claude-md")
+        artifact = make_artifact(client, tag_ids=[tag["id"]])
+        resp = client.get(f"/api/artifacts/{artifact['id']}")
+        body = resp.json()
+        assert len(body["tags"]) == 1
+        assert body["tags"][0]["name"] == "claude-md"


### PR DESCRIPTION
## Summary

Adds the Artifacts entity — a proper document storage layer for BRAIN 3.0. Artifacts replace the 5,000-character activity log workaround currently used for CLAUDE.md docs, agent briefs, design documents, and process decisions. Implements the Artifacts pillar from the v1.2.0 design brief.

Closes #94

## Changes

- **`app/models.py`** — Added `ArtifactTag` association model and `Artifact` model with self-referential `parent_id` (SET NULL on delete), `content` CHECK constraint (512KB via `octet_length`), `artifact_type` CHECK constraint, indexes on `artifact_type` and `is_seedable`. Added `artifacts` relationship to `Tag` model.
- **`alembic/versions/003_artifacts.py`** — Migration creating `artifacts` and `artifact_tags` tables with all constraints, indexes, and foreign keys.
- **`app/schemas/artifacts.py`** — `ArtifactCreate` (500KB Pydantic content limit, optional `tag_ids`), `ArtifactUpdate` (partial PATCH), `ArtifactResponse` (metadata only — no content), `ArtifactDetailResponse` (with content and resolved parent).
- **`app/routers/artifacts.py`** — 5 CRUD endpoints + 3 tag attachment endpoints. List endpoint returns metadata only. Create computes `content_size` automatically. Update auto-increments `version` on content changes, recomputes `content_size`. Composable filters: `artifact_type`, `is_seedable`, `search`, `parent_id`, `tag` (AND logic).
- **`app/routers/tags.py`** — Added reverse lookup `GET /api/tags/{tag_id}/artifacts`.
- **`app/main.py`** — Registered artifacts router and artifact_tags_router.
- **`tests/test_artifacts.py`** — 57 tests covering CRUD happy paths, validation errors, 404s, all filters, tagging (attach/detach/list/idempotent), reverse lookup, parent relationship resolution, version increment logic, content_size computation, cascade behavior, and response shape verification.

## How to Verify

1. `git checkout feature/TICKET-94-artifacts`
2. `python -m pytest tests/test_artifacts.py -v` — all 57 tests pass
3. `python -m pytest -v` — full suite (382 tests) passes with no regressions
4. Start the API: `docker compose -f docker-compose.dev.yml up -d && alembic upgrade head && uvicorn app.main:app --reload`
5. Visit `/docs` — all 9 artifact endpoints visible under "Artifacts" and "Artifact Tags" tags
6. Create an artifact via POST, verify `content_size` is computed
7. List artifacts — confirm no `content` field in response
8. Get single artifact — confirm `content` and resolved `parent` in response
9. PATCH with content change — confirm `version` increments
10. PATCH metadata only — confirm `version` stays the same

## Deviations

None

## Test Results

```
============================= 382 passed in 4.08s =============================
```

57 artifact-specific tests + 325 existing tests, all passing.

## Acceptance Checklist

- [x] Alembic migration creates `artifacts` and `artifact_tags` tables with all constraints
- [x] All five Artifact CRUD endpoints working
- [x] `POST /api/artifacts` computes and stores `content_size` automatically
- [x] `GET /api/artifacts` returns metadata only — no `content` field in response
- [x] `GET /api/artifacts/{id}` returns full content + resolved parent
- [x] `PATCH /api/artifacts/{id}` auto-increments `version` when content changes
- [x] `PATCH /api/artifacts/{id}` does NOT increment version for metadata-only changes
- [x] `content_size` is recomputed on every content update
- [x] Pydantic rejects content > 500,000 characters
- [x] Database CHECK rejects content > 512KB (octet_length)
- [x] `parent_id` validated on create/update (400 for nonexistent artifact)
- [x] Self-referential parent relationship resolves in detail response
- [x] Deleting a parent artifact sets children `parent_id` to NULL (SET NULL)
- [x] `artifact_type` validated against enum
- [x] `is_seedable` filter works on list endpoint
- [x] `search` filter does case-insensitive title search
- [x] `tag` filter supports comma-separated AND logic
- [x] `parent_id` filter returns children of a specific artifact
- [x] All tagging endpoints work (attach, detach, list)
- [x] Tag attachment is idempotent
- [x] Reverse lookup `GET /api/tags/{id}/artifacts` returns artifacts with that tag
- [x] Tag `artifacts` relationship added to Tag model
- [x] `tag_ids` on create works
- [x] 404 for invalid artifact_id or tag_id
- [x] All endpoints visible at `/docs`
- [x] Tests cover: happy path CRUD, validation errors, 404s, filters, tagging, parent relationship, version increment logic, content_size computation