### PR TITLE
TICKET-95: Protocols — Model, Migration, CRUD & Tagging

### DIFF
--- a/alembic/versions/004_protocols.py
+++ b/alembic/versions/004_protocols.py
@@ -1,0 +1,87 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""add protocols and protocol_tags tables
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-04-10 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "protocols",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("steps", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "artifact_id", postgresql.UUID(as_uuid=True), nullable=True,
+        ),
+        sa.Column("is_seedable", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", name="uq_protocols_name"),
+        sa.ForeignKeyConstraint(
+            ["artifact_id"], ["artifacts.id"], ondelete="SET NULL",
+        ),
+    )
+    op.create_index("ix_protocols_is_seedable", "protocols", ["is_seedable"])
+
+    op.create_table(
+        "protocol_tags",
+        sa.Column("protocol_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tag_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["protocol_id"], ["protocols.id"], ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tag_id"], ["tags.id"], ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("protocol_id", "tag_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("protocol_tags")
+    op.drop_index("ix_protocols_is_seedable", table_name="protocols")
+    op.drop_table("protocols")

--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.routers import (
     domains,
     goals,
     projects,
+    protocols,
     reports,
     routines,
     tags,
@@ -84,4 +85,8 @@ app.include_router(
 app.include_router(artifacts.router, prefix="/api/artifacts", tags=["Artifacts"])
 app.include_router(
     artifacts.artifact_tags_router, prefix="/api/artifacts", tags=["Artifact Tags"],
+)
+app.include_router(protocols.router, prefix="/api/protocols", tags=["Protocols"])
+app.include_router(
+    protocols.protocol_tags_router, prefix="/api/protocols", tags=["Protocol Tags"],
 )

--- a/app/models.py
+++ b/app/models.py
@@ -21,6 +21,7 @@ from datetime import date, datetime
 from uuid import uuid4
 
 from sqlalchemy import (
+    JSON,
     Boolean,
     CheckConstraint,
     Date,
@@ -74,6 +75,19 @@ class ArtifactTag(Base):
 
     artifact_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("artifacts.id", ondelete="CASCADE"), primary_key=True,
+    )
+    tag_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True,
+    )
+
+
+class ProtocolTag(Base):
+    """Many-to-many link between protocols and tags."""
+
+    __tablename__ = "protocol_tags"
+
+    protocol_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("protocols.id", ondelete="CASCADE"), primary_key=True,
     )
     tag_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True,
@@ -281,6 +295,9 @@ class Tag(Base):
     )
     artifacts: Mapped[list["Artifact"]] = relationship(
         secondary="artifact_tags", back_populates="tags",
+    )
+    protocols: Mapped[list["Protocol"]] = relationship(
+        secondary="protocol_tags", back_populates="tags",
     )
 
 
@@ -527,3 +544,42 @@ class Artifact(Base):
     children: Mapped[list["Artifact"]] = relationship(
         foreign_keys=[parent_id], overlaps="parent",
     )
+    protocols: Mapped[list["Protocol"]] = relationship(back_populates="artifact")
+
+
+# ---------------------------------------------------------------------------
+# Protocols — step-by-step procedures
+# ---------------------------------------------------------------------------
+
+class Protocol(Base):
+    """Repeatable behavioral pattern with ordered steps (JSONB)."""
+
+    __tablename__ = "protocols"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4,
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    description: Mapped[str | None] = mapped_column(Text)
+    steps: Mapped[dict | None] = mapped_column(JSON)
+    artifact_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("artifacts.id", ondelete="SET NULL"),
+    )
+    is_seedable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_protocols_is_seedable", "is_seedable"),
+    )
+
+    # Relationships
+    tags: Mapped[list["Tag"]] = relationship(
+        secondary="protocol_tags", back_populates="protocols",
+    )
+    artifact: Mapped["Artifact | None"] = relationship(back_populates="protocols")

--- a/app/routers/protocols.py
+++ b/app/routers/protocols.py
@@ -1,0 +1,253 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""CRUD endpoints for Protocols."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session, joinedload
+
+from app.database import get_db
+from app.models import Artifact, Protocol, ProtocolTag, Tag
+from app.schemas.protocols import (
+    ProtocolCreate,
+    ProtocolDetailResponse,
+    ProtocolResponse,
+    ProtocolUpdate,
+)
+from app.schemas.tags import TagResponse
+
+router = APIRouter()
+protocol_tags_router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Protocol CRUD — /api/protocols
+# ---------------------------------------------------------------------------
+
+
+@router.post("/", response_model=ProtocolResponse, status_code=status.HTTP_201_CREATED)
+def create_protocol(payload: ProtocolCreate, db: Session = Depends(get_db)) -> Protocol:
+    """Create a new protocol. Validates artifact_id and tag_ids if provided."""
+    # Unique name check
+    existing = db.query(Protocol).filter(Protocol.name == payload.name).first()
+    if existing:
+        raise HTTPException(status_code=409, detail="Protocol name already exists")
+
+    if payload.artifact_id is not None:
+        if not db.query(Artifact).filter(Artifact.id == payload.artifact_id).first():
+            raise HTTPException(status_code=400, detail="Artifact not found")
+
+    tags = []
+    if payload.tag_ids:
+        for tid in payload.tag_ids:
+            tag = db.query(Tag).filter(Tag.id == tid).first()
+            if not tag:
+                raise HTTPException(status_code=400, detail=f"Tag {tid} not found")
+            tags.append(tag)
+
+    # Serialize steps to dicts for JSONB storage
+    steps_data = None
+    if payload.steps is not None:
+        steps_data = [s.model_dump() for s in payload.steps]
+
+    protocol = Protocol(
+        **payload.model_dump(exclude={"tag_ids", "steps"}),
+        steps=steps_data,
+    )
+    db.add(protocol)
+    db.flush()
+
+    for tag in tags:
+        db.add(ProtocolTag(protocol_id=protocol.id, tag_id=tag.id))
+
+    db.commit()
+    db.refresh(protocol)
+    return protocol
+
+
+@router.get("/", response_model=list[ProtocolResponse])
+def list_protocols(
+    search: str | None = Query(None, description="Case-insensitive name search"),
+    is_seedable: bool | None = Query(None),
+    has_artifact: bool | None = Query(None, description="Filter by whether artifact_id is set"),
+    tag: str | None = Query(None, description="Comma-separated tag names (AND logic)"),
+    db: Session = Depends(get_db),
+) -> list[Protocol]:
+    """List protocols with composable filters."""
+    query = db.query(Protocol)
+
+    if search is not None:
+        query = query.filter(Protocol.name.ilike(f"%{search}%"))
+    if is_seedable is not None:
+        query = query.filter(Protocol.is_seedable == is_seedable)
+    if has_artifact is True:
+        query = query.filter(Protocol.artifact_id.isnot(None))
+    elif has_artifact is False:
+        query = query.filter(Protocol.artifact_id.is_(None))
+    if tag is not None:
+        tag_names = [t.strip().lower() for t in tag.split(",") if t.strip()]
+        for tag_name in tag_names:
+            query = query.filter(
+                Protocol.tags.any(Tag.name == tag_name)
+            )
+
+    return query.order_by(Protocol.created_at.desc()).all()
+
+
+@router.get("/{protocol_id}", response_model=ProtocolDetailResponse)
+def get_protocol(protocol_id: UUID, db: Session = Depends(get_db)) -> Protocol:
+    """Get a single protocol with resolved artifact."""
+    protocol = (
+        db.query(Protocol)
+        .options(
+            joinedload(Protocol.tags),
+            joinedload(Protocol.artifact),
+        )
+        .filter(Protocol.id == protocol_id)
+        .first()
+    )
+    if not protocol:
+        raise HTTPException(status_code=404, detail="Protocol not found")
+    return protocol
+
+
+@router.patch("/{protocol_id}", response_model=ProtocolDetailResponse)
+def update_protocol(
+    protocol_id: UUID, payload: ProtocolUpdate, db: Session = Depends(get_db)
+) -> Protocol:
+    """Partial update. Auto-increments version when steps or description change."""
+    protocol = db.query(Protocol).filter(Protocol.id == protocol_id).first()
+    if not protocol:
+        raise HTTPException(status_code=404, detail="Protocol not found")
+
+    updates = payload.model_dump(exclude_unset=True)
+
+    # Unique name check on update
+    if "name" in updates and updates["name"] is not None:
+        conflict = (
+            db.query(Protocol)
+            .filter(Protocol.name == updates["name"], Protocol.id != protocol_id)
+            .first()
+        )
+        if conflict:
+            raise HTTPException(status_code=409, detail="Protocol name already exists")
+
+    # Validate artifact_id if provided
+    if "artifact_id" in updates and updates["artifact_id"] is not None:
+        if not db.query(Artifact).filter(Artifact.id == updates["artifact_id"]).first():
+            raise HTTPException(status_code=400, detail="Artifact not found")
+
+    # Version bump when steps or description change
+    version_fields = {"steps", "description"}
+    if version_fields & updates.keys():
+        updates["version"] = protocol.version + 1
+
+    for field, value in updates.items():
+        setattr(protocol, field, value)
+
+    db.commit()
+    db.refresh(protocol)
+
+    # Eager-load for detail response
+    protocol = (
+        db.query(Protocol)
+        .options(
+            joinedload(Protocol.tags),
+            joinedload(Protocol.artifact),
+        )
+        .filter(Protocol.id == protocol_id)
+        .first()
+    )
+    return protocol
+
+
+@router.delete("/{protocol_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_protocol(protocol_id: UUID, db: Session = Depends(get_db)) -> None:
+    """Delete a protocol."""
+    protocol = db.query(Protocol).filter(Protocol.id == protocol_id).first()
+    if not protocol:
+        raise HTTPException(status_code=404, detail="Protocol not found")
+    db.delete(protocol)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Protocol-Tag attachment — /api/protocols/{protocol_id}/tags
+# ---------------------------------------------------------------------------
+
+
+@protocol_tags_router.get("/{protocol_id}/tags", response_model=list[TagResponse])
+def list_tags_on_protocol(
+    protocol_id: UUID, db: Session = Depends(get_db)
+) -> list[Tag]:
+    """List all tags attached to a protocol."""
+    protocol = db.query(Protocol).filter(Protocol.id == protocol_id).first()
+    if not protocol:
+        raise HTTPException(status_code=404, detail="Protocol not found")
+    return protocol.tags
+
+
+@protocol_tags_router.post(
+    "/{protocol_id}/tags/{tag_id}", response_model=TagResponse,
+)
+def attach_tag_to_protocol(
+    protocol_id: UUID, tag_id: UUID, db: Session = Depends(get_db)
+) -> Tag:
+    """Attach a tag to a protocol. Idempotent."""
+    protocol = db.query(Protocol).filter(Protocol.id == protocol_id).first()
+    if not protocol:
+        raise HTTPException(status_code=404, detail="Protocol not found")
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    existing = (
+        db.query(ProtocolTag)
+        .filter(ProtocolTag.protocol_id == protocol_id, ProtocolTag.tag_id == tag_id)
+        .first()
+    )
+    if not existing:
+        db.add(ProtocolTag(protocol_id=protocol_id, tag_id=tag_id))
+        db.commit()
+
+    return tag
+
+
+@protocol_tags_router.delete(
+    "/{protocol_id}/tags/{tag_id}", status_code=status.HTTP_204_NO_CONTENT,
+)
+def detach_tag_from_protocol(
+    protocol_id: UUID, tag_id: UUID, db: Session = Depends(get_db)
+) -> None:
+    """Remove a tag from a protocol."""
+    protocol = db.query(Protocol).filter(Protocol.id == protocol_id).first()
+    if not protocol:
+        raise HTTPException(status_code=404, detail="Protocol not found")
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    link = (
+        db.query(ProtocolTag)
+        .filter(ProtocolTag.protocol_id == protocol_id, ProtocolTag.tag_id == tag_id)
+        .first()
+    )
+    if not link:
+        raise HTTPException(status_code=404, detail="Tag is not attached to this protocol")
+    db.delete(link)
+    db.commit()

--- a/app/routers/tags.py
+++ b/app/routers/tags.py
@@ -22,9 +22,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.models import ActivityLog, Artifact, Tag, Task, TaskTag
+from app.models import ActivityLog, Artifact, Protocol, Tag, Task, TaskTag
 from app.schemas.activity import ActivityLogResponse
 from app.schemas.artifacts import ArtifactResponse
+from app.schemas.protocols import ProtocolResponse
 from app.schemas.tags import TagCreate, TagResponse, TagUpdate
 from app.schemas.tasks import TaskResponse
 
@@ -151,6 +152,22 @@ def list_artifacts_for_tag(
     if not tag:
         raise HTTPException(status_code=404, detail="Tag not found")
     return tag.artifacts
+
+
+# ---------------------------------------------------------------------------
+# Reverse lookup — /api/tags/{tag_id}/protocols
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{tag_id}/protocols", response_model=list[ProtocolResponse])
+def list_protocols_for_tag(
+    tag_id: UUID, db: Session = Depends(get_db)
+) -> list[Protocol]:
+    """List all protocols that have a given tag."""
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    return tag.protocols
 
 
 # ---------------------------------------------------------------------------

--- a/app/schemas/protocols.py
+++ b/app/schemas/protocols.py
@@ -1,0 +1,84 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Pydantic schemas for Protocol CRUD operations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProtocolStep(BaseModel):
+    """Single step within a protocol — validated but stored as JSONB."""
+
+    order: int = Field(ge=1)
+    title: str = Field(max_length=200)
+    instruction: str = Field(max_length=2000)
+    is_optional: bool = False
+
+
+class ProtocolCreate(BaseModel):
+    """Fields required to create a protocol."""
+
+    name: str = Field(max_length=100)
+    description: str | None = Field(default=None, max_length=5000)
+    steps: list[ProtocolStep] | None = None
+    artifact_id: UUID | None = None
+    is_seedable: bool = True
+    tag_ids: list[UUID] | None = None
+
+
+class ProtocolUpdate(BaseModel):
+    """All fields optional — supports partial PATCH updates."""
+
+    name: str | None = Field(default=None, max_length=100)
+    description: str | None = Field(default=None, max_length=5000)
+    steps: list[ProtocolStep] | None = None
+    artifact_id: UUID | None = None
+    is_seedable: bool | None = None
+
+
+class ProtocolResponse(BaseModel):
+    """Protocol returned from list and create endpoints."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    description: str | None
+    steps: list[ProtocolStep] | None = None
+    artifact_id: UUID | None = None
+    is_seedable: bool
+    version: int
+    created_at: datetime
+    updated_at: datetime
+    tags: list["TagResponse"] = []
+
+
+class ProtocolDetailResponse(ProtocolResponse):
+    """Single protocol with resolved artifact relationship."""
+
+    artifact: "ArtifactResponse | None" = None
+
+
+from app.schemas.artifacts import ArtifactResponse  # noqa: E402
+from app.schemas.tags import TagResponse  # noqa: E402
+
+ProtocolResponse.model_rebuild()
+ProtocolDetailResponse.model_rebuild()

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,0 +1,462 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for Protocols — CRUD, JSONB steps, tagging, filters, version logic."""
+
+from tests.conftest import FAKE_UUID, make_tag
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SAMPLE_STEPS = [
+    {
+        "order": 1, "title": "Check context",
+        "instruction": "Read the brief and issue.",
+        "is_optional": False,
+    },
+    {
+        "order": 2, "title": "Set up branch",
+        "instruction": "Create feature branch from develop.",
+        "is_optional": False,
+    },
+    {
+        "order": 3, "title": "Run smoke test",
+        "instruction": "Verify dev environment.",
+        "is_optional": True,
+    },
+]
+
+
+def make_artifact(client, **overrides) -> dict:
+    """Create an artifact via the API and return the response JSON."""
+    data = {
+        "title": "Test Artifact",
+        "artifact_type": "document",
+        "content": "Hello, world!",
+        **overrides,
+    }
+    resp = client.post("/api/artifacts", json=data)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def make_protocol(client, **overrides) -> dict:
+    """Create a protocol via the API and return the response JSON."""
+    data = {"name": "test-protocol", **overrides}
+    resp = client.post("/api/protocols", json=data)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/protocols — Create
+# ---------------------------------------------------------------------------
+
+class TestCreateProtocol:
+
+    def test_create_minimal(self, client):
+        resp = client.post("/api/protocols", json={"name": "session-startup"})
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["name"] == "session-startup"
+        assert body["description"] is None
+        assert body["steps"] is None
+        assert body["artifact_id"] is None
+        assert body["is_seedable"] is True
+        assert body["version"] == 1
+        assert body["tags"] == []
+
+    def test_create_with_steps(self, client):
+        resp = client.post("/api/protocols", json={
+            "name": "agent-activation",
+            "steps": SAMPLE_STEPS,
+        })
+        assert resp.status_code == 201
+        body = resp.json()
+        assert len(body["steps"]) == 3
+        assert body["steps"][0]["title"] == "Check context"
+        assert body["steps"][2]["is_optional"] is True
+
+    def test_create_with_all_fields(self, client):
+        artifact = make_artifact(client)
+        tag = make_tag(client, name="ops")
+        resp = client.post("/api/protocols", json={
+            "name": "full-protocol",
+            "description": "A fully specified protocol.",
+            "steps": SAMPLE_STEPS[:1],
+            "artifact_id": artifact["id"],
+            "is_seedable": False,
+            "tag_ids": [tag["id"]],
+        })
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["description"] == "A fully specified protocol."
+        assert body["artifact_id"] == artifact["id"]
+        assert body["is_seedable"] is False
+        assert len(body["tags"]) == 1
+        assert body["tags"][0]["name"] == "ops"
+
+    def test_create_duplicate_name_409(self, client):
+        make_protocol(client, name="unique-name")
+        resp = client.post("/api/protocols", json={"name": "unique-name"})
+        assert resp.status_code == 409
+
+    def test_create_with_invalid_artifact_id(self, client):
+        resp = client.post("/api/protocols", json={
+            "name": "bad-artifact",
+            "artifact_id": FAKE_UUID,
+        })
+        assert resp.status_code == 400
+
+    def test_create_with_invalid_tag_id(self, client):
+        resp = client.post("/api/protocols", json={
+            "name": "bad-tag",
+            "tag_ids": [FAKE_UUID],
+        })
+        assert resp.status_code == 400
+
+    def test_create_steps_validation_order_min(self, client):
+        resp = client.post("/api/protocols", json={
+            "name": "bad-steps",
+            "steps": [{"order": 0, "title": "X", "instruction": "Y"}],
+        })
+        assert resp.status_code == 422
+
+    def test_create_steps_validation_missing_fields(self, client):
+        resp = client.post("/api/protocols", json={
+            "name": "bad-steps-2",
+            "steps": [{"order": 1}],
+        })
+        assert resp.status_code == 422
+
+    def test_name_preserves_casing(self, client):
+        resp = client.post("/api/protocols", json={"name": "Session-Startup"})
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "Session-Startup"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/protocols — List
+# ---------------------------------------------------------------------------
+
+class TestListProtocols:
+
+    def test_list_empty(self, client):
+        resp = client.get("/api/protocols")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_returns_all(self, client):
+        make_protocol(client, name="alpha")
+        make_protocol(client, name="beta")
+        resp = client.get("/api/protocols")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_list_filter_search(self, client):
+        make_protocol(client, name="session-startup")
+        make_protocol(client, name="bug-discovery")
+        resp = client.get("/api/protocols", params={"search": "session"})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "session-startup"
+
+    def test_list_filter_search_case_insensitive(self, client):
+        make_protocol(client, name="Session-Startup")
+        resp = client.get("/api/protocols", params={"search": "session"})
+        assert len(resp.json()) == 1
+
+    def test_list_filter_is_seedable(self, client):
+        make_protocol(client, name="seedable", is_seedable=True)
+        make_protocol(client, name="not-seedable", is_seedable=False)
+        resp = client.get("/api/protocols", params={"is_seedable": True})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "seedable"
+
+    def test_list_filter_has_artifact_true(self, client):
+        artifact = make_artifact(client)
+        make_protocol(client, name="with-artifact", artifact_id=artifact["id"])
+        make_protocol(client, name="without-artifact")
+        resp = client.get("/api/protocols", params={"has_artifact": True})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "with-artifact"
+
+    def test_list_filter_has_artifact_false(self, client):
+        artifact = make_artifact(client)
+        make_protocol(client, name="with-artifact", artifact_id=artifact["id"])
+        make_protocol(client, name="without-artifact")
+        resp = client.get("/api/protocols", params={"has_artifact": False})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "without-artifact"
+
+    def test_list_filter_tag(self, client):
+        tag = make_tag(client, name="ops")
+        p = make_protocol(client, name="tagged-protocol")
+        client.post(f"/api/protocols/{p['id']}/tags/{tag['id']}")
+        make_protocol(client, name="untagged")
+        resp = client.get("/api/protocols", params={"tag": "ops"})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "tagged-protocol"
+
+    def test_list_filter_tag_and_logic(self, client):
+        tag1 = make_tag(client, name="ops")
+        tag2 = make_tag(client, name="startup")
+        p = make_protocol(client, name="both-tags")
+        client.post(f"/api/protocols/{p['id']}/tags/{tag1['id']}")
+        client.post(f"/api/protocols/{p['id']}/tags/{tag2['id']}")
+        p2 = make_protocol(client, name="one-tag")
+        client.post(f"/api/protocols/{p2['id']}/tags/{tag1['id']}")
+        resp = client.get("/api/protocols", params={"tag": "ops,startup"})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "both-tags"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/protocols/{id} — Detail
+# ---------------------------------------------------------------------------
+
+class TestGetProtocol:
+
+    def test_get_protocol(self, client):
+        p = make_protocol(client, name="get-me", steps=SAMPLE_STEPS)
+        resp = client.get(f"/api/protocols/{p['id']}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["name"] == "get-me"
+        assert len(body["steps"]) == 3
+        assert "artifact" in body  # detail field
+
+    def test_get_protocol_resolves_artifact(self, client):
+        artifact = make_artifact(client, title="Protocol Docs")
+        p = make_protocol(client, name="with-art", artifact_id=artifact["id"])
+        resp = client.get(f"/api/protocols/{p['id']}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["artifact"] is not None
+        assert body["artifact"]["title"] == "Protocol Docs"
+
+    def test_get_protocol_not_found(self, client):
+        resp = client.get(f"/api/protocols/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/protocols/{id} — Update
+# ---------------------------------------------------------------------------
+
+class TestUpdateProtocol:
+
+    def test_update_name(self, client):
+        p = make_protocol(client, name="old-name")
+        resp = client.patch(f"/api/protocols/{p['id']}", json={"name": "new-name"})
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "new-name"
+        # Name-only change should NOT bump version
+        assert resp.json()["version"] == 1
+
+    def test_update_steps_bumps_version(self, client):
+        p = make_protocol(client, name="versioned", steps=SAMPLE_STEPS)
+        new_steps = [{"order": 1, "title": "New step", "instruction": "Do the thing."}]
+        resp = client.patch(f"/api/protocols/{p['id']}", json={"steps": new_steps})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["version"] == 2
+        assert len(body["steps"]) == 1
+        assert body["steps"][0]["title"] == "New step"
+
+    def test_update_description_bumps_version(self, client):
+        p = make_protocol(client, name="desc-version")
+        resp = client.patch(f"/api/protocols/{p['id']}", json={"description": "Updated."})
+        assert resp.status_code == 200
+        assert resp.json()["version"] == 2
+
+    def test_update_is_seedable_no_version_bump(self, client):
+        p = make_protocol(client, name="seedable-change")
+        resp = client.patch(f"/api/protocols/{p['id']}", json={"is_seedable": False})
+        assert resp.status_code == 200
+        assert resp.json()["is_seedable"] is False
+        assert resp.json()["version"] == 1
+
+    def test_update_duplicate_name_409(self, client):
+        make_protocol(client, name="taken")
+        p = make_protocol(client, name="available")
+        resp = client.patch(f"/api/protocols/{p['id']}", json={"name": "taken"})
+        assert resp.status_code == 409
+
+    def test_update_same_name_no_conflict(self, client):
+        p = make_protocol(client, name="keep-name")
+        resp = client.patch(f"/api/protocols/{p['id']}", json={"name": "keep-name"})
+        assert resp.status_code == 200
+
+    def test_update_artifact_id(self, client):
+        artifact = make_artifact(client)
+        p = make_protocol(client, name="link-artifact")
+        resp = client.patch(f"/api/protocols/{p['id']}", json={"artifact_id": artifact["id"]})
+        assert resp.status_code == 200
+        assert resp.json()["artifact_id"] == artifact["id"]
+        assert resp.json()["version"] == 1  # metadata only
+
+    def test_update_invalid_artifact_id(self, client):
+        p = make_protocol(client, name="bad-art-update")
+        resp = client.patch(f"/api/protocols/{p['id']}", json={"artifact_id": FAKE_UUID})
+        assert resp.status_code == 400
+
+    def test_update_not_found(self, client):
+        resp = client.patch(f"/api/protocols/{FAKE_UUID}", json={"name": "x"})
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/protocols/{id}
+# ---------------------------------------------------------------------------
+
+class TestDeleteProtocol:
+
+    def test_delete(self, client):
+        p = make_protocol(client, name="delete-me")
+        resp = client.delete(f"/api/protocols/{p['id']}")
+        assert resp.status_code == 204
+        assert client.get(f"/api/protocols/{p['id']}").status_code == 404
+
+    def test_delete_not_found(self, client):
+        resp = client.delete(f"/api/protocols/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Artifact FK — SET NULL on delete
+# ---------------------------------------------------------------------------
+
+class TestArtifactFK:
+
+    def test_delete_artifact_sets_null(self, client):
+        artifact = make_artifact(client)
+        p = make_protocol(client, name="art-ref", artifact_id=artifact["id"])
+        assert p["artifact_id"] == artifact["id"]
+
+        client.delete(f"/api/artifacts/{artifact['id']}")
+        resp = client.get(f"/api/protocols/{p['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["artifact_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Protocol-Tag attachment
+# ---------------------------------------------------------------------------
+
+class TestProtocolTagging:
+
+    def test_attach_tag(self, client):
+        p = make_protocol(client, name="tag-test")
+        tag = make_tag(client, name="agent")
+        resp = client.post(f"/api/protocols/{p['id']}/tags/{tag['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "agent"
+
+    def test_attach_tag_idempotent(self, client):
+        p = make_protocol(client, name="idem-test")
+        tag = make_tag(client, name="agent")
+        client.post(f"/api/protocols/{p['id']}/tags/{tag['id']}")
+        resp = client.post(f"/api/protocols/{p['id']}/tags/{tag['id']}")
+        assert resp.status_code == 200
+        # Only one tag attached
+        tags_resp = client.get(f"/api/protocols/{p['id']}/tags")
+        assert len(tags_resp.json()) == 1
+
+    def test_list_tags_on_protocol(self, client):
+        p = make_protocol(client, name="list-tags")
+        tag1 = make_tag(client, name="alpha")
+        tag2 = make_tag(client, name="beta")
+        client.post(f"/api/protocols/{p['id']}/tags/{tag1['id']}")
+        client.post(f"/api/protocols/{p['id']}/tags/{tag2['id']}")
+        resp = client.get(f"/api/protocols/{p['id']}/tags")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_detach_tag(self, client):
+        p = make_protocol(client, name="detach-test")
+        tag = make_tag(client, name="remove-me")
+        client.post(f"/api/protocols/{p['id']}/tags/{tag['id']}")
+        resp = client.delete(f"/api/protocols/{p['id']}/tags/{tag['id']}")
+        assert resp.status_code == 204
+        tags_resp = client.get(f"/api/protocols/{p['id']}/tags")
+        assert len(tags_resp.json()) == 0
+
+    def test_detach_tag_not_attached(self, client):
+        p = make_protocol(client, name="not-attached")
+        tag = make_tag(client, name="loose")
+        resp = client.delete(f"/api/protocols/{p['id']}/tags/{tag['id']}")
+        assert resp.status_code == 404
+
+    def test_attach_tag_protocol_not_found(self, client):
+        tag = make_tag(client, name="orphan-tag")
+        resp = client.post(f"/api/protocols/{FAKE_UUID}/tags/{tag['id']}")
+        assert resp.status_code == 404
+
+    def test_attach_tag_tag_not_found(self, client):
+        p = make_protocol(client, name="no-tag")
+        resp = client.post(f"/api/protocols/{p['id']}/tags/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+    def test_list_tags_protocol_not_found(self, client):
+        resp = client.get(f"/api/protocols/{FAKE_UUID}/tags")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Reverse lookup — /api/tags/{tag_id}/protocols
+# ---------------------------------------------------------------------------
+
+class TestTagReverseProtocols:
+
+    def test_reverse_lookup(self, client):
+        tag = make_tag(client, name="reverse-test")
+        p = make_protocol(client, name="reverse-p")
+        client.post(f"/api/protocols/{p['id']}/tags/{tag['id']}")
+        resp = client.get(f"/api/tags/{tag['id']}/protocols")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "reverse-p"
+
+    def test_reverse_lookup_empty(self, client):
+        tag = make_tag(client, name="empty-reverse")
+        resp = client.get(f"/api/tags/{tag['id']}/protocols")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_reverse_lookup_tag_not_found(self, client):
+        resp = client.get(f"/api/tags/{FAKE_UUID}/protocols")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# tag_ids on create
+# ---------------------------------------------------------------------------
+
+class TestCreateWithTagIds:
+
+    def test_tag_ids_on_create(self, client):
+        tag1 = make_tag(client, name="t1")
+        tag2 = make_tag(client, name="t2")
+        resp = client.post("/api/protocols", json={
+            "name": "tagged-create",
+            "tag_ids": [tag1["id"], tag2["id"]],
+        })
+        assert resp.status_code == 201
+        body = resp.json()
+        assert len(body["tags"]) == 2
+        tag_names = {t["name"] for t in body["tags"]}
+        assert tag_names == {"t1", "t2"}


### PR DESCRIPTION
Closes #95

## Summary
Adds the Protocols entity — repeatable step-by-step procedures (session-startup, agent-activation, bug-discovery) that any AI partner can load and execute. First JSONB column in the brain3 codebase — steps are validated as `list[ProtocolStep]` at the Pydantic boundary and stored as a JSONB array in PostgreSQL. Second Behaviors pillar entity after Artifacts.

## Changes
- **app/models.py** — Added `Protocol` model (JSONB steps column, unique name, artifact FK with SET NULL, version tracking, is_seedable) and `ProtocolTag` association table. Added `protocols` relationship to `Tag` and `Artifact` models.
- **alembic/versions/004_protocols.py** — Migration creating `protocols` table (with JSONB steps, unique name constraint, is_seedable index) and `protocol_tags` join table.
- **app/schemas/protocols.py** — `ProtocolStep` embedded schema, `ProtocolCreate`, `ProtocolUpdate`, `ProtocolResponse`, and `ProtocolDetailResponse` (resolves artifact).
- **app/routers/protocols.py** — Full CRUD (POST/GET list/GET detail/PATCH/DELETE) with composable filters (search, is_seedable, has_artifact, tag AND logic). Three tagging endpoints (list/attach/detach). Version auto-increments on steps or description change but not metadata-only updates. 409 Conflict on duplicate name. Artifact FK validated on create/update.
- **app/routers/tags.py** — Added reverse lookup `GET /api/tags/{id}/protocols`.
- **app/main.py** — Registered protocols router and protocol_tags_router.
- **tests/test_protocols.py** — 45 tests covering all acceptance criteria.

## How to Verify
1. `pytest -v` — all 427 tests pass (45 new protocol tests)
2. `ruff check .` — clean
3. Start the API and verify endpoints at `/docs`
4. Create a protocol with steps — confirm JSONB storage and Pydantic validation
5. Update steps → version increments. Update name only → version stays.
6. Create duplicate name → 409 Conflict
7. Delete referenced artifact → protocol.artifact_id becomes NULL
8. Tag operations are idempotent; reverse lookup works

## Deviations
- **Model uses `JSON` type instead of `JSONB` import** — `sqlalchemy.dialects.postgresql.JSONB` cannot be compiled by SQLite (used in tests). The model uses `sqlalchemy.JSON` which maps to `JSON` on SQLite and `JSON` on PostgreSQL. The Alembic migration explicitly uses `postgresql.JSONB()` for the production column, ensuring PostgreSQL gets the correct native JSONB type with its indexing capabilities. This is a transparent compatibility approach — no functional difference in production.

## Test Results
```
$ pytest -v
============================= 427 passed in 5.27s =============================

$ ruff check .
All checks passed!
```

## Acceptance Checklist
- [x] Alembic migration creates `protocols` and `protocol_tags` tables
- [x] All five Protocol CRUD endpoints working
- [x] `name` is unique — 409 Conflict on duplicate
- [x] `steps` stored as JSONB, validated as `list[ProtocolStep]` by Pydantic
- [x] Each step has `order`, `title`, `instruction`, `is_optional`
- [x] `artifact_id` validated on create/update (400 if artifact not found)
- [x] Deleting a referenced artifact sets protocol `artifact_id` to NULL
- [x] `version` auto-increments when steps or description change
- [x] `version` does NOT increment for metadata-only changes
- [x] `is_seedable` defaults to true
- [x] List filters working: search, is_seedable, has_artifact, tag
- [x] All tagging endpoints work (attach, detach, list)
- [x] Tag attachment is idempotent
- [x] Reverse lookup `GET /api/tags/{id}/protocols` works
- [x] `tag_ids` on create works
- [x] Detail endpoint resolves artifact relationship
- [x] 404 for invalid protocol_id or tag_id
- [x] All endpoints visible at `/docs`
- [x] Tests cover: happy path CRUD, JSONB steps validation, unique name constraint, artifact FK, version increment, filters, tagging