### PR TITLE
TICKET-96: Directives model, migration, CRUD & tagging

### DIFF
--- a/alembic/versions/005_directives.py
+++ b/alembic/versions/005_directives.py
@@ -1,0 +1,91 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""add directives and directive_tags tables
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-04-10 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "directives",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("scope", sa.String(), nullable=False),
+        sa.Column("scope_ref", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("priority", sa.Integer(), nullable=False, server_default="5"),
+        sa.Column("is_seedable", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "scope IN ('global', 'skill', 'agent')",
+            name="ck_directives_scope",
+        ),
+        sa.CheckConstraint(
+            "priority BETWEEN 1 AND 10",
+            name="ck_directives_priority",
+        ),
+    )
+    op.create_index("ix_directives_scope", "directives", ["scope"])
+    op.create_index("ix_directives_priority", "directives", ["priority"])
+
+    op.create_table(
+        "directive_tags",
+        sa.Column("directive_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tag_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["directive_id"], ["directives.id"], ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tag_id"], ["tags.id"], ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("directive_id", "tag_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("directive_tags")
+    op.drop_index("ix_directives_priority", table_name="directives")
+    op.drop_index("ix_directives_scope", table_name="directives")
+    op.drop_table("directives")

--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,7 @@ from app.routers import (
     activity,
     artifacts,
     checkins,
+    directives,
     domains,
     goals,
     projects,
@@ -89,4 +90,8 @@ app.include_router(
 app.include_router(protocols.router, prefix="/api/protocols", tags=["Protocols"])
 app.include_router(
     protocols.protocol_tags_router, prefix="/api/protocols", tags=["Protocol Tags"],
+)
+app.include_router(directives.router, prefix="/api/directives", tags=["Directives"])
+app.include_router(
+    directives.directive_tags_router, prefix="/api/directives", tags=["Directive Tags"],
 )

--- a/app/models.py
+++ b/app/models.py
@@ -94,6 +94,19 @@ class ProtocolTag(Base):
     )
 
 
+class DirectiveTag(Base):
+    """Many-to-many link between directives and tags."""
+
+    __tablename__ = "directive_tags"
+
+    directive_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("directives.id", ondelete="CASCADE"), primary_key=True,
+    )
+    tag_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Pillar 1: Domains
 # ---------------------------------------------------------------------------
@@ -298,6 +311,9 @@ class Tag(Base):
     )
     protocols: Mapped[list["Protocol"]] = relationship(
         secondary="protocol_tags", back_populates="tags",
+    )
+    directives: Mapped[list["Directive"]] = relationship(
+        secondary="directive_tags", back_populates="tags",
     )
 
 
@@ -583,3 +599,47 @@ class Protocol(Base):
         secondary="protocol_tags", back_populates="protocols",
     )
     artifact: Mapped["Artifact | None"] = relationship(back_populates="protocols")
+
+
+# ---------------------------------------------------------------------------
+# Directives — principles and guardrails
+# ---------------------------------------------------------------------------
+
+class Directive(Base):
+    """Declarative rule or guardrail with scope-based resolution."""
+
+    __tablename__ = "directives"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4,
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    scope: Mapped[str] = mapped_column(String, nullable=False)
+    scope_ref: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=5)
+    is_seedable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "scope IN ('global', 'skill', 'agent')",
+            name="ck_directives_scope",
+        ),
+        CheckConstraint(
+            "priority BETWEEN 1 AND 10",
+            name="ck_directives_priority",
+        ),
+        Index("ix_directives_scope", "scope"),
+        Index("ix_directives_priority", "priority"),
+    )
+
+    # Relationships
+    tags: Mapped[list["Tag"]] = relationship(
+        secondary="directive_tags", back_populates="directives",
+    )

--- a/app/routers/directives.py
+++ b/app/routers/directives.py
@@ -1,0 +1,266 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""CRUD endpoints for Directives."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import Directive, DirectiveTag, Tag
+from app.schemas.directives import (
+    DirectiveCreate,
+    DirectiveResolveResponse,
+    DirectiveResponse,
+    DirectiveUpdate,
+)
+from app.schemas.tags import TagResponse
+
+router = APIRouter()
+directive_tags_router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Resolve — must be registered BEFORE /{id} to avoid path conflict
+# ---------------------------------------------------------------------------
+
+
+@router.get("/resolve", response_model=DirectiveResolveResponse)
+def resolve_directives(
+    skill_id: UUID | None = Query(
+        None, description="Include skill-scoped directives for this skill",
+    ),
+    scope_ref: UUID | None = Query(
+        None, description="Include agent-scoped directives for this agent project",
+    ),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Merge directives by scope — global + optional skill + optional agent."""
+    global_directives = (
+        db.query(Directive)
+        .filter(Directive.scope == "global")
+        .order_by(Directive.priority.desc())
+        .all()
+    )
+
+    skill_directives = []
+    if skill_id is not None:
+        skill_directives = (
+            db.query(Directive)
+            .filter(Directive.scope == "skill", Directive.scope_ref == skill_id)
+            .order_by(Directive.priority.desc())
+            .all()
+        )
+
+    agent_directives = []
+    if scope_ref is not None:
+        agent_directives = (
+            db.query(Directive)
+            .filter(Directive.scope == "agent", Directive.scope_ref == scope_ref)
+            .order_by(Directive.priority.desc())
+            .all()
+        )
+
+    return {
+        "global_directives": global_directives,
+        "skill_directives": skill_directives,
+        "agent_directives": agent_directives,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Directive CRUD — /api/directives
+# ---------------------------------------------------------------------------
+
+
+@router.post("/", response_model=DirectiveResponse, status_code=status.HTTP_201_CREATED)
+def create_directive(payload: DirectiveCreate, db: Session = Depends(get_db)) -> Directive:
+    """Create a new directive. Validates tag_ids if provided."""
+    tags = []
+    if payload.tag_ids:
+        for tid in payload.tag_ids:
+            tag = db.query(Tag).filter(Tag.id == tid).first()
+            if not tag:
+                raise HTTPException(status_code=400, detail=f"Tag {tid} not found")
+            tags.append(tag)
+
+    directive = Directive(
+        **payload.model_dump(exclude={"tag_ids"}),
+    )
+    db.add(directive)
+    db.flush()
+
+    for tag in tags:
+        db.add(DirectiveTag(directive_id=directive.id, tag_id=tag.id))
+
+    db.commit()
+    db.refresh(directive)
+    return directive
+
+
+@router.get("/", response_model=list[DirectiveResponse])
+def list_directives(
+    scope: str | None = Query(None, description="Filter by scope enum"),
+    scope_ref: UUID | None = Query(None, description="Filter by scope reference"),
+    is_seedable: bool | None = Query(None),
+    priority_min: int | None = Query(None, ge=1, le=10, description="Minimum priority (inclusive)"),
+    priority_max: int | None = Query(None, ge=1, le=10, description="Maximum priority (inclusive)"),
+    search: str | None = Query(None, description="Case-insensitive name search"),
+    tag: str | None = Query(None, description="Comma-separated tag names (AND logic)"),
+    db: Session = Depends(get_db),
+) -> list[Directive]:
+    """List directives with composable filters."""
+    query = db.query(Directive)
+
+    if scope is not None:
+        query = query.filter(Directive.scope == scope)
+    if scope_ref is not None:
+        query = query.filter(Directive.scope_ref == scope_ref)
+    if is_seedable is not None:
+        query = query.filter(Directive.is_seedable == is_seedable)
+    if priority_min is not None:
+        query = query.filter(Directive.priority >= priority_min)
+    if priority_max is not None:
+        query = query.filter(Directive.priority <= priority_max)
+    if search is not None:
+        query = query.filter(Directive.name.ilike(f"%{search}%"))
+    if tag is not None:
+        tag_names = [t.strip().lower() for t in tag.split(",") if t.strip()]
+        for tag_name in tag_names:
+            query = query.filter(
+                Directive.tags.any(Tag.name == tag_name)
+            )
+
+    return query.order_by(Directive.created_at.desc()).all()
+
+
+@router.get("/{directive_id}", response_model=DirectiveResponse)
+def get_directive(directive_id: UUID, db: Session = Depends(get_db)) -> Directive:
+    """Get a single directive by ID."""
+    directive = db.query(Directive).filter(Directive.id == directive_id).first()
+    if not directive:
+        raise HTTPException(status_code=404, detail="Directive not found")
+    return directive
+
+
+@router.patch("/{directive_id}", response_model=DirectiveResponse)
+def update_directive(
+    directive_id: UUID, payload: DirectiveUpdate, db: Session = Depends(get_db)
+) -> Directive:
+    """Partial update with post-merge scope/scope_ref cross-validation."""
+    directive = db.query(Directive).filter(Directive.id == directive_id).first()
+    if not directive:
+        raise HTTPException(status_code=404, detail="Directive not found")
+
+    updates = payload.model_dump(exclude_unset=True)
+
+    for field, value in updates.items():
+        setattr(directive, field, value)
+
+    # Validate scope/scope_ref on post-merge state
+    if directive.scope == "global" and directive.scope_ref is not None:
+        raise HTTPException(
+            status_code=422,
+            detail="scope_ref must be null for global directives",
+        )
+    if directive.scope in ("skill", "agent") and directive.scope_ref is None:
+        raise HTTPException(
+            status_code=422,
+            detail="scope_ref is required for skill and agent directives",
+        )
+
+    db.commit()
+    db.refresh(directive)
+    return directive
+
+
+@router.delete("/{directive_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_directive(directive_id: UUID, db: Session = Depends(get_db)) -> None:
+    """Delete a directive."""
+    directive = db.query(Directive).filter(Directive.id == directive_id).first()
+    if not directive:
+        raise HTTPException(status_code=404, detail="Directive not found")
+    db.delete(directive)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Directive-Tag attachment — /api/directives/{directive_id}/tags
+# ---------------------------------------------------------------------------
+
+
+@directive_tags_router.get("/{directive_id}/tags", response_model=list[TagResponse])
+def list_tags_on_directive(
+    directive_id: UUID, db: Session = Depends(get_db)
+) -> list[Tag]:
+    """List all tags attached to a directive."""
+    directive = db.query(Directive).filter(Directive.id == directive_id).first()
+    if not directive:
+        raise HTTPException(status_code=404, detail="Directive not found")
+    return directive.tags
+
+
+@directive_tags_router.post(
+    "/{directive_id}/tags/{tag_id}", response_model=TagResponse,
+)
+def attach_tag_to_directive(
+    directive_id: UUID, tag_id: UUID, db: Session = Depends(get_db)
+) -> Tag:
+    """Attach a tag to a directive. Idempotent."""
+    directive = db.query(Directive).filter(Directive.id == directive_id).first()
+    if not directive:
+        raise HTTPException(status_code=404, detail="Directive not found")
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    existing = (
+        db.query(DirectiveTag)
+        .filter(DirectiveTag.directive_id == directive_id, DirectiveTag.tag_id == tag_id)
+        .first()
+    )
+    if not existing:
+        db.add(DirectiveTag(directive_id=directive_id, tag_id=tag_id))
+        db.commit()
+
+    return tag
+
+
+@directive_tags_router.delete(
+    "/{directive_id}/tags/{tag_id}", status_code=status.HTTP_204_NO_CONTENT,
+)
+def detach_tag_from_directive(
+    directive_id: UUID, tag_id: UUID, db: Session = Depends(get_db)
+) -> None:
+    """Remove a tag from a directive."""
+    directive = db.query(Directive).filter(Directive.id == directive_id).first()
+    if not directive:
+        raise HTTPException(status_code=404, detail="Directive not found")
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    link = (
+        db.query(DirectiveTag)
+        .filter(DirectiveTag.directive_id == directive_id, DirectiveTag.tag_id == tag_id)
+        .first()
+    )
+    if not link:
+        raise HTTPException(status_code=404, detail="Tag is not attached to this directive")
+    db.delete(link)
+    db.commit()

--- a/app/routers/tags.py
+++ b/app/routers/tags.py
@@ -22,9 +22,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.models import ActivityLog, Artifact, Protocol, Tag, Task, TaskTag
+from app.models import ActivityLog, Artifact, Directive, Protocol, Tag, Task, TaskTag
 from app.schemas.activity import ActivityLogResponse
 from app.schemas.artifacts import ArtifactResponse
+from app.schemas.directives import DirectiveResponse
 from app.schemas.protocols import ProtocolResponse
 from app.schemas.tags import TagCreate, TagResponse, TagUpdate
 from app.schemas.tasks import TaskResponse
@@ -168,6 +169,22 @@ def list_protocols_for_tag(
     if not tag:
         raise HTTPException(status_code=404, detail="Tag not found")
     return tag.protocols
+
+
+# ---------------------------------------------------------------------------
+# Reverse lookup — /api/tags/{tag_id}/directives
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{tag_id}/directives", response_model=list[DirectiveResponse])
+def list_directives_for_tag(
+    tag_id: UUID, db: Session = Depends(get_db)
+) -> list[Directive]:
+    """List all directives that have a given tag."""
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    return tag.directives
 
 
 # ---------------------------------------------------------------------------

--- a/app/schemas/directives.py
+++ b/app/schemas/directives.py
@@ -1,0 +1,86 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Pydantic schemas for Directive CRUD operations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class DirectiveCreate(BaseModel):
+    """Fields required to create a directive."""
+
+    name: str = Field(max_length=200)
+    content: str = Field(max_length=10_000)
+    scope: Literal["global", "skill", "agent"]
+    scope_ref: UUID | None = None
+    priority: int = Field(default=5, ge=1, le=10)
+    is_seedable: bool = True
+    tag_ids: list[UUID] | None = None
+
+    @model_validator(mode="after")
+    def validate_scope_ref(self) -> "DirectiveCreate":
+        if self.scope == "global" and self.scope_ref is not None:
+            raise ValueError("scope_ref must be null for global directives")
+        if self.scope in ("skill", "agent") and self.scope_ref is None:
+            raise ValueError("scope_ref is required for skill and agent directives")
+        return self
+
+
+class DirectiveUpdate(BaseModel):
+    """All fields optional — supports partial PATCH updates."""
+
+    name: str | None = Field(default=None, max_length=200)
+    content: str | None = Field(default=None, max_length=10_000)
+    scope: Literal["global", "skill", "agent"] | None = None
+    scope_ref: UUID | None = None
+    priority: int | None = Field(default=None, ge=1, le=10)
+    is_seedable: bool | None = None
+
+
+class DirectiveResponse(BaseModel):
+    """Directive returned from list and create endpoints."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    content: str
+    scope: str
+    scope_ref: UUID | None
+    priority: int
+    is_seedable: bool
+    created_at: datetime
+    updated_at: datetime
+    tags: list["TagResponse"] = []
+
+
+class DirectiveResolveResponse(BaseModel):
+    """Grouped directives from the resolve endpoint."""
+
+    global_directives: list[DirectiveResponse]
+    skill_directives: list[DirectiveResponse]
+    agent_directives: list[DirectiveResponse]
+
+
+from app.schemas.tags import TagResponse  # noqa: E402
+
+DirectiveResponse.model_rebuild()

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -1,0 +1,582 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for Directives — CRUD, scope validation, resolve endpoint, tagging, filters."""
+
+import uuid
+
+from tests.conftest import FAKE_UUID, make_tag
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SKILL_UUID = str(uuid.uuid4())
+AGENT_UUID = str(uuid.uuid4())
+
+
+def make_directive(client, **overrides) -> dict:
+    """Create a directive via the API and return the response JSON."""
+    data = {
+        "name": "test-directive",
+        "content": "This is a test directive.",
+        "scope": "global",
+        **overrides,
+    }
+    resp = client.post("/api/directives", json=data)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/directives — Create
+# ---------------------------------------------------------------------------
+
+class TestCreateDirective:
+
+    def test_create_global_minimal(self, client):
+        resp = client.post("/api/directives", json={
+            "name": "low friction",
+            "content": "Low friction is a design requirement.",
+            "scope": "global",
+        })
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["name"] == "low friction"
+        assert body["content"] == "Low friction is a design requirement."
+        assert body["scope"] == "global"
+        assert body["scope_ref"] is None
+        assert body["priority"] == 5
+        assert body["is_seedable"] is True
+        assert body["tags"] == []
+
+    def test_create_skill_scoped(self, client):
+        resp = client.post("/api/directives", json={
+            "name": "skill directive",
+            "content": "Applies to a specific skill.",
+            "scope": "skill",
+            "scope_ref": SKILL_UUID,
+            "priority": 8,
+        })
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["scope"] == "skill"
+        assert body["scope_ref"] == SKILL_UUID
+        assert body["priority"] == 8
+
+    def test_create_agent_scoped(self, client):
+        resp = client.post("/api/directives", json={
+            "name": "agent directive",
+            "content": "Agent-specific guardrail.",
+            "scope": "agent",
+            "scope_ref": AGENT_UUID,
+        })
+        assert resp.status_code == 201
+        assert resp.json()["scope"] == "agent"
+        assert resp.json()["scope_ref"] == AGENT_UUID
+
+    def test_create_with_all_fields(self, client):
+        tag = make_tag(client, name="guardrail")
+        resp = client.post("/api/directives", json={
+            "name": "full directive",
+            "content": "A fully specified directive.",
+            "scope": "skill",
+            "scope_ref": SKILL_UUID,
+            "priority": 10,
+            "is_seedable": False,
+            "tag_ids": [tag["id"]],
+        })
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["is_seedable"] is False
+        assert body["priority"] == 10
+        assert len(body["tags"]) == 1
+        assert body["tags"][0]["name"] == "guardrail"
+
+    def test_create_global_with_scope_ref_fails(self, client):
+        resp = client.post("/api/directives", json={
+            "name": "bad global",
+            "content": "Should fail.",
+            "scope": "global",
+            "scope_ref": SKILL_UUID,
+        })
+        assert resp.status_code == 422
+
+    def test_create_skill_without_scope_ref_fails(self, client):
+        resp = client.post("/api/directives", json={
+            "name": "bad skill",
+            "content": "Should fail.",
+            "scope": "skill",
+        })
+        assert resp.status_code == 422
+
+    def test_create_agent_without_scope_ref_fails(self, client):
+        resp = client.post("/api/directives", json={
+            "name": "bad agent",
+            "content": "Should fail.",
+            "scope": "agent",
+        })
+        assert resp.status_code == 422
+
+    def test_create_invalid_scope_fails(self, client):
+        resp = client.post("/api/directives", json={
+            "name": "bad scope",
+            "content": "Should fail.",
+            "scope": "invalid",
+        })
+        assert resp.status_code == 422
+
+    def test_create_priority_below_range(self, client):
+        resp = client.post("/api/directives", json={
+            "name": "low priority",
+            "content": "Should fail.",
+            "scope": "global",
+            "priority": 0,
+        })
+        assert resp.status_code == 422
+
+    def test_create_priority_above_range(self, client):
+        resp = client.post("/api/directives", json={
+            "name": "high priority",
+            "content": "Should fail.",
+            "scope": "global",
+            "priority": 11,
+        })
+        assert resp.status_code == 422
+
+    def test_create_with_invalid_tag_id(self, client):
+        resp = client.post("/api/directives", json={
+            "name": "bad tag",
+            "content": "Should fail.",
+            "scope": "global",
+            "tag_ids": [FAKE_UUID],
+        })
+        assert resp.status_code == 400
+
+    def test_create_duplicate_name_allowed(self, client):
+        """Directive names are NOT unique — multiple can share a name."""
+        make_directive(client, name="shared-name")
+        resp = client.post("/api/directives", json={
+            "name": "shared-name",
+            "content": "Same name, different directive.",
+            "scope": "global",
+        })
+        assert resp.status_code == 201
+
+
+# ---------------------------------------------------------------------------
+# GET /api/directives — List
+# ---------------------------------------------------------------------------
+
+class TestListDirectives:
+
+    def test_list_empty(self, client):
+        resp = client.get("/api/directives")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_returns_all(self, client):
+        make_directive(client, name="alpha")
+        make_directive(client, name="beta")
+        resp = client.get("/api/directives")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_list_filter_scope(self, client):
+        make_directive(client, name="global-d", scope="global")
+        make_directive(client, name="skill-d", scope="skill", scope_ref=SKILL_UUID)
+        resp = client.get("/api/directives", params={"scope": "global"})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "global-d"
+
+    def test_list_filter_scope_ref(self, client):
+        make_directive(client, name="s1", scope="skill", scope_ref=SKILL_UUID)
+        make_directive(client, name="s2", scope="agent", scope_ref=AGENT_UUID)
+        resp = client.get("/api/directives", params={"scope_ref": SKILL_UUID})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "s1"
+
+    def test_list_filter_is_seedable(self, client):
+        make_directive(client, name="seedable", is_seedable=True)
+        make_directive(client, name="not-seedable", is_seedable=False)
+        resp = client.get("/api/directives", params={"is_seedable": True})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "seedable"
+
+    def test_list_filter_priority_min(self, client):
+        make_directive(client, name="low", priority=2)
+        make_directive(client, name="high", priority=8)
+        resp = client.get("/api/directives", params={"priority_min": 5})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "high"
+
+    def test_list_filter_priority_max(self, client):
+        make_directive(client, name="low", priority=2)
+        make_directive(client, name="high", priority=8)
+        resp = client.get("/api/directives", params={"priority_max": 5})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "low"
+
+    def test_list_filter_priority_range(self, client):
+        make_directive(client, name="low", priority=2)
+        make_directive(client, name="mid", priority=5)
+        make_directive(client, name="high", priority=8)
+        resp = client.get("/api/directives", params={"priority_min": 3, "priority_max": 7})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "mid"
+
+    def test_list_filter_search(self, client):
+        make_directive(client, name="low friction")
+        make_directive(client, name="graduated scaffolding")
+        resp = client.get("/api/directives", params={"search": "friction"})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "low friction"
+
+    def test_list_filter_search_case_insensitive(self, client):
+        make_directive(client, name="Low Friction")
+        resp = client.get("/api/directives", params={"search": "low"})
+        assert len(resp.json()) == 1
+
+    def test_list_filter_tag(self, client):
+        tag = make_tag(client, name="core")
+        d = make_directive(client, name="tagged")
+        client.post(f"/api/directives/{d['id']}/tags/{tag['id']}")
+        make_directive(client, name="untagged")
+        resp = client.get("/api/directives", params={"tag": "core"})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "tagged"
+
+    def test_list_filter_tag_and_logic(self, client):
+        tag1 = make_tag(client, name="core")
+        tag2 = make_tag(client, name="guardrail")
+        d = make_directive(client, name="both-tags")
+        client.post(f"/api/directives/{d['id']}/tags/{tag1['id']}")
+        client.post(f"/api/directives/{d['id']}/tags/{tag2['id']}")
+        d2 = make_directive(client, name="one-tag")
+        client.post(f"/api/directives/{d2['id']}/tags/{tag1['id']}")
+        resp = client.get("/api/directives", params={"tag": "core,guardrail"})
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "both-tags"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/directives/{id} — Detail
+# ---------------------------------------------------------------------------
+
+class TestGetDirective:
+
+    def test_get_directive(self, client):
+        d = make_directive(client, name="get-me")
+        resp = client.get(f"/api/directives/{d['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "get-me"
+
+    def test_get_directive_not_found(self, client):
+        resp = client.get(f"/api/directives/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/directives/{id} — Update
+# ---------------------------------------------------------------------------
+
+class TestUpdateDirective:
+
+    def test_update_name(self, client):
+        d = make_directive(client, name="old-name")
+        resp = client.patch(f"/api/directives/{d['id']}", json={"name": "new-name"})
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "new-name"
+
+    def test_update_content(self, client):
+        d = make_directive(client, name="update-content")
+        resp = client.patch(f"/api/directives/{d['id']}", json={"content": "Updated."})
+        assert resp.status_code == 200
+        assert resp.json()["content"] == "Updated."
+
+    def test_update_priority(self, client):
+        d = make_directive(client, name="update-priority")
+        resp = client.patch(f"/api/directives/{d['id']}", json={"priority": 10})
+        assert resp.status_code == 200
+        assert resp.json()["priority"] == 10
+
+    def test_update_is_seedable(self, client):
+        d = make_directive(client, name="update-seedable")
+        resp = client.patch(f"/api/directives/{d['id']}", json={"is_seedable": False})
+        assert resp.status_code == 200
+        assert resp.json()["is_seedable"] is False
+
+    def test_update_scope_with_scope_ref(self, client):
+        """Change from global to skill — must also provide scope_ref."""
+        d = make_directive(client, name="scope-change")
+        resp = client.patch(f"/api/directives/{d['id']}", json={
+            "scope": "skill",
+            "scope_ref": SKILL_UUID,
+        })
+        assert resp.status_code == 200
+        assert resp.json()["scope"] == "skill"
+        assert resp.json()["scope_ref"] == SKILL_UUID
+
+    def test_update_scope_to_global_clears_scope_ref(self, client):
+        """Change from skill to global — must also clear scope_ref."""
+        d = make_directive(
+            client, name="clear-ref", scope="skill", scope_ref=SKILL_UUID,
+        )
+        resp = client.patch(f"/api/directives/{d['id']}", json={
+            "scope": "global",
+            "scope_ref": None,
+        })
+        assert resp.status_code == 200
+        assert resp.json()["scope"] == "global"
+        assert resp.json()["scope_ref"] is None
+
+    def test_update_scope_to_skill_without_ref_fails(self, client):
+        """Post-merge: scope=skill but no scope_ref should fail."""
+        d = make_directive(client, name="bad-scope-update")
+        resp = client.patch(f"/api/directives/{d['id']}", json={"scope": "skill"})
+        assert resp.status_code == 422
+
+    def test_update_global_adding_scope_ref_fails(self, client):
+        """Post-merge: scope=global with scope_ref should fail."""
+        d = make_directive(client, name="bad-ref-update")
+        resp = client.patch(f"/api/directives/{d['id']}", json={"scope_ref": SKILL_UUID})
+        assert resp.status_code == 422
+
+    def test_update_not_found(self, client):
+        resp = client.patch(f"/api/directives/{FAKE_UUID}", json={"name": "x"})
+        assert resp.status_code == 404
+
+    def test_update_priority_out_of_range(self, client):
+        d = make_directive(client, name="bad-priority")
+        resp = client.patch(f"/api/directives/{d['id']}", json={"priority": 11})
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/directives/{id}
+# ---------------------------------------------------------------------------
+
+class TestDeleteDirective:
+
+    def test_delete(self, client):
+        d = make_directive(client, name="delete-me")
+        resp = client.delete(f"/api/directives/{d['id']}")
+        assert resp.status_code == 204
+        assert client.get(f"/api/directives/{d['id']}").status_code == 404
+
+    def test_delete_not_found(self, client):
+        resp = client.delete(f"/api/directives/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/directives/resolve — Resolve endpoint
+# ---------------------------------------------------------------------------
+
+class TestResolveDirectives:
+
+    def test_resolve_global_only(self, client):
+        make_directive(client, name="g1", priority=8)
+        make_directive(client, name="g2", priority=3)
+        resp = client.get("/api/directives/resolve")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["global_directives"]) == 2
+        assert body["skill_directives"] == []
+        assert body["agent_directives"] == []
+        # Sorted by priority desc
+        assert body["global_directives"][0]["name"] == "g1"
+        assert body["global_directives"][1]["name"] == "g2"
+
+    def test_resolve_with_skill_id(self, client):
+        make_directive(client, name="global-d")
+        make_directive(
+            client, name="skill-d", scope="skill",
+            scope_ref=SKILL_UUID, priority=7,
+        )
+        # Directive for a different skill — should not appear
+        other_skill = str(uuid.uuid4())
+        make_directive(
+            client, name="other-skill-d", scope="skill",
+            scope_ref=other_skill,
+        )
+        resp = client.get("/api/directives/resolve", params={"skill_id": SKILL_UUID})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["global_directives"]) == 1
+        assert len(body["skill_directives"]) == 1
+        assert body["skill_directives"][0]["name"] == "skill-d"
+        assert body["agent_directives"] == []
+
+    def test_resolve_with_scope_ref(self, client):
+        make_directive(client, name="global-d")
+        make_directive(
+            client, name="agent-d", scope="agent",
+            scope_ref=AGENT_UUID, priority=9,
+        )
+        resp = client.get("/api/directives/resolve", params={"scope_ref": AGENT_UUID})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["global_directives"]) == 1
+        assert len(body["agent_directives"]) == 1
+        assert body["agent_directives"][0]["name"] == "agent-d"
+
+    def test_resolve_all_scopes(self, client):
+        make_directive(client, name="g", priority=5)
+        make_directive(
+            client, name="s", scope="skill",
+            scope_ref=SKILL_UUID, priority=8,
+        )
+        make_directive(
+            client, name="a", scope="agent",
+            scope_ref=AGENT_UUID, priority=10,
+        )
+        resp = client.get("/api/directives/resolve", params={
+            "skill_id": SKILL_UUID,
+            "scope_ref": AGENT_UUID,
+        })
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["global_directives"]) == 1
+        assert len(body["skill_directives"]) == 1
+        assert len(body["agent_directives"]) == 1
+
+    def test_resolve_sorted_by_priority_desc(self, client):
+        make_directive(client, name="low", priority=1)
+        make_directive(client, name="mid", priority=5)
+        make_directive(client, name="high", priority=10)
+        resp = client.get("/api/directives/resolve")
+        body = resp.json()
+        priorities = [d["priority"] for d in body["global_directives"]]
+        assert priorities == [10, 5, 1]
+
+    def test_resolve_empty(self, client):
+        resp = client.get("/api/directives/resolve")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["global_directives"] == []
+        assert body["skill_directives"] == []
+        assert body["agent_directives"] == []
+
+
+# ---------------------------------------------------------------------------
+# Directive-Tag attachment
+# ---------------------------------------------------------------------------
+
+class TestDirectiveTagging:
+
+    def test_attach_tag(self, client):
+        d = make_directive(client, name="tag-test")
+        tag = make_tag(client, name="core")
+        resp = client.post(f"/api/directives/{d['id']}/tags/{tag['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "core"
+
+    def test_attach_tag_idempotent(self, client):
+        d = make_directive(client, name="idem-test")
+        tag = make_tag(client, name="core")
+        client.post(f"/api/directives/{d['id']}/tags/{tag['id']}")
+        resp = client.post(f"/api/directives/{d['id']}/tags/{tag['id']}")
+        assert resp.status_code == 200
+        tags_resp = client.get(f"/api/directives/{d['id']}/tags")
+        assert len(tags_resp.json()) == 1
+
+    def test_list_tags_on_directive(self, client):
+        d = make_directive(client, name="list-tags")
+        tag1 = make_tag(client, name="alpha")
+        tag2 = make_tag(client, name="beta")
+        client.post(f"/api/directives/{d['id']}/tags/{tag1['id']}")
+        client.post(f"/api/directives/{d['id']}/tags/{tag2['id']}")
+        resp = client.get(f"/api/directives/{d['id']}/tags")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_detach_tag(self, client):
+        d = make_directive(client, name="detach-test")
+        tag = make_tag(client, name="remove-me")
+        client.post(f"/api/directives/{d['id']}/tags/{tag['id']}")
+        resp = client.delete(f"/api/directives/{d['id']}/tags/{tag['id']}")
+        assert resp.status_code == 204
+        tags_resp = client.get(f"/api/directives/{d['id']}/tags")
+        assert len(tags_resp.json()) == 0
+
+    def test_detach_tag_not_attached(self, client):
+        d = make_directive(client, name="not-attached")
+        tag = make_tag(client, name="loose")
+        resp = client.delete(f"/api/directives/{d['id']}/tags/{tag['id']}")
+        assert resp.status_code == 404
+
+    def test_attach_tag_directive_not_found(self, client):
+        tag = make_tag(client, name="orphan")
+        resp = client.post(f"/api/directives/{FAKE_UUID}/tags/{tag['id']}")
+        assert resp.status_code == 404
+
+    def test_attach_tag_tag_not_found(self, client):
+        d = make_directive(client, name="no-tag")
+        resp = client.post(f"/api/directives/{d['id']}/tags/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+    def test_list_tags_directive_not_found(self, client):
+        resp = client.get(f"/api/directives/{FAKE_UUID}/tags")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Reverse lookup — /api/tags/{tag_id}/directives
+# ---------------------------------------------------------------------------
+
+class TestTagReverseDirectives:
+
+    def test_reverse_lookup(self, client):
+        tag = make_tag(client, name="reverse-test")
+        d = make_directive(client, name="reverse-d")
+        client.post(f"/api/directives/{d['id']}/tags/{tag['id']}")
+        resp = client.get(f"/api/tags/{tag['id']}/directives")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "reverse-d"
+
+    def test_reverse_lookup_empty(self, client):
+        tag = make_tag(client, name="empty-reverse")
+        resp = client.get(f"/api/tags/{tag['id']}/directives")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_reverse_lookup_tag_not_found(self, client):
+        resp = client.get(f"/api/tags/{FAKE_UUID}/directives")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# tag_ids on create
+# ---------------------------------------------------------------------------
+
+class TestCreateWithTagIds:
+
+    def test_tag_ids_on_create(self, client):
+        tag1 = make_tag(client, name="t1")
+        tag2 = make_tag(client, name="t2")
+        resp = client.post("/api/directives", json={
+            "name": "tagged-create",
+            "content": "Tagged at creation.",
+            "scope": "global",
+            "tag_ids": [tag1["id"], tag2["id"]],
+        })
+        assert resp.status_code == 201
+        body = resp.json()
+        assert len(body["tags"]) == 2
+        tag_names = {t["name"] for t in body["tags"]}
+        assert tag_names == {"t1", "t2"}


### PR DESCRIPTION
Closes #96

## Summary

Adds the Directives entity — declarative rules and guardrails that govern BRAIN and its AI partners. Directives are scoped (global, skill, agent) with priority-based conflict resolution (1-10, higher wins). Includes a resolve endpoint that merges directives by scope for Claude's behavioral context bootstrapping.

## Changes

- **`app/models.py`** — Added `DirectiveTag` association model and `Directive` model with scope enum CHECK constraint, priority range CHECK, and indexes on `scope` and `priority`. Added `directives` relationship to `Tag`.
- **`alembic/versions/005_directives.py`** — Migration creating `directives` and `directive_tags` tables with all constraints and indexes.
- **`app/schemas/directives.py`** — `DirectiveCreate` (with `model_validator` for scope/scope_ref cross-validation), `DirectiveUpdate`, `DirectiveResponse`, and `DirectiveResolveResponse` schemas.
- **`app/routers/directives.py`** — 10 endpoints: CRUD (5), resolve (1), tag attachment (3), plus composable list filters (scope, scope_ref, is_seedable, priority_min, priority_max, search, tag). Resolve endpoint registered before `/{id}` to avoid path conflict. Post-merge scope/scope_ref validation on PATCH follows the activity log `at_most_one_reference` pattern.
- **`app/routers/tags.py`** — Added reverse lookup `GET /api/tags/{tag_id}/directives`.
- **`app/main.py`** — Registered directives router and directive_tags_router.
- **`tests/test_directives.py`** — 56 tests covering CRUD, scope validation, scope_ref cross-validation, priority range, resolve endpoint (all scope combinations, sort order, empty), filters, tagging (attach, detach, idempotent, not found), reverse lookup, and tag_ids on create.

## How to Verify

1. `git checkout feature/TICKET-96-directives`
2. `pytest tests/test_directives.py -v` — 56 tests pass
3. `pytest -v` — full suite (483 tests) passes with zero regressions
4. `ruff check` — clean
5. Start dev server, visit `/docs` — all directive endpoints visible
6. Create directives at each scope, verify resolve endpoint groups correctly

## Deviations

None

## Test Results

```
tests/test_directives.py — 56 passed in 0.79s
Full suite — 483 passed in 6.30s
ruff check — All checks passed
```

## Acceptance Checklist

- [x] Alembic migration creates `directives` and `directive_tags` tables with all constraints
- [x] All five Directive CRUD endpoints working
- [x] `scope` validated against enum ('global', 'skill', 'agent')
- [x] `scope_ref` is required when scope is 'skill' or 'agent' (Pydantic model_validator)
- [x] `scope_ref` must be null when scope is 'global'
- [x] Cross-validation works on PATCH (post-merge state validation)
- [x] `priority` validated between 1 and 10 (Pydantic + DB CHECK)
- [x] `is_seedable` defaults to true
- [x] Resolve endpoint returns grouped directives (global + skill + agent)
- [x] Resolve endpoint correctly filters by skill_id and scope_ref
- [x] Resolve endpoint sorts each group by priority descending
- [x] List filters working: scope, scope_ref, is_seedable, priority_min, priority_max, search, tag
- [x] All tagging endpoints work (attach, detach, list)
- [x] Tag attachment is idempotent
- [x] Reverse lookup works
- [x] `tag_ids` on create works
- [x] 404 for invalid directive_id or tag_id
- [x] All endpoints visible at `/docs`
- [x] Tests cover: happy path CRUD, scope validation, scope_ref validation, priority range, resolve endpoint with various scope combinations, filters, tagging