### PR TITLE
TICKET-99: Seed data framework and content migration scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Task CRUD endpoints with composable ADHD-aware filters (#5)
 - Task filters: energy cost range, friction range, cognitive type, context, due dates, overdue, standalone (#5)
 - Pydantic validators for 1-5 scale fields (energy_cost, activation_friction) (#5)
+- Content migration script (`scripts/migrate_to_artifacts.py`) with --dry-run, --tag, and --api-url flags (#99)
+- Seed data loading script (`scripts/seed_data.py`) with idempotent batch loading, --only and --dry-run flags (#99)
+- Seed data files in `scripts/seeds/` — minimal starter protocols, directives, and skills (#99)
+- Seed data validation tests covering JSON parsing, schema compliance, cross-references, and script logic (#99)

--- a/scripts/migrate_to_artifacts.py
+++ b/scripts/migrate_to_artifacts.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Migrate activity log content to artifacts.
+
+Reads activity log entries tagged with document-type tags and creates
+corresponding artifacts via the BRAIN 3.0 API. Does NOT delete source
+entries — they remain as historical record.
+
+Usage:
+    python scripts/migrate_to_artifacts.py --api-url http://localhost:8000 --dry-run
+    python scripts/migrate_to_artifacts.py --api-url http://localhost:8000
+    python scripts/migrate_to_artifacts.py --api-url http://localhost:8000 --tag claude-md
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import httpx
+
+# Tags whose activity entries contain document content worth migrating
+TAG_TO_ARTIFACT_TYPE: dict[str, str] = {
+    "claude-md": "document",
+    "process-decision": "document",
+    "stellan-blueprint": "brief",
+}
+
+DEFAULT_API_URL = "http://localhost:8000"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Migrate activity log entries to artifacts",
+    )
+    parser.add_argument(
+        "--api-url",
+        default=DEFAULT_API_URL,
+        help=f"BRAIN 3.0 API base URL (default: {DEFAULT_API_URL})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be migrated without creating artifacts",
+    )
+    parser.add_argument(
+        "--tag",
+        help="Migrate only entries with a specific tag (for incremental migration)",
+    )
+    return parser.parse_args(argv)
+
+
+def fetch_tags(client: httpx.Client, api_url: str) -> list[dict]:
+    """Fetch all tags from the API."""
+    resp = client.get(f"{api_url}/api/tags")
+    resp.raise_for_status()
+    return resp.json()
+
+
+def find_tag_by_name(tags: list[dict], name: str) -> dict | None:
+    """Find a tag by name (case-insensitive)."""
+    for tag in tags:
+        if tag["name"].lower() == name.lower():
+            return tag
+    return None
+
+
+def fetch_activity_entries_by_tag(
+    client: httpx.Client, api_url: str, tag_name: str,
+) -> list[dict]:
+    """Fetch activity log entries filtered by tag name."""
+    resp = client.get(f"{api_url}/api/activity", params={"tag": tag_name})
+    resp.raise_for_status()
+    return resp.json()
+
+
+def check_artifact_exists(
+    client: httpx.Client, api_url: str, title: str,
+) -> bool:
+    """Check if an artifact with this title already exists."""
+    resp = client.get(f"{api_url}/api/artifacts", params={"search": title})
+    resp.raise_for_status()
+    for artifact in resp.json():
+        if artifact["title"].lower() == title.lower():
+            return True
+    return False
+
+
+def create_artifact(
+    client: httpx.Client,
+    api_url: str,
+    title: str,
+    artifact_type: str,
+    content: str,
+    tag_ids: list[str] | None = None,
+    parent_id: str | None = None,
+) -> dict:
+    """Create an artifact via the API."""
+    payload: dict = {
+        "title": title,
+        "artifact_type": artifact_type,
+        "content": content,
+    }
+    if tag_ids:
+        payload["tag_ids"] = tag_ids
+    if parent_id:
+        payload["parent_id"] = parent_id
+
+    resp = client.post(f"{api_url}/api/artifacts", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def build_artifact_title(entry: dict, tag_name: str) -> str:
+    """Build a descriptive artifact title from an activity entry."""
+    notes = entry.get("notes") or ""
+    # Try to extract a title from the first line of notes
+    first_line = notes.split("\n")[0].strip()
+    # Strip common prefixes like [CLAUDE.md], [Process Decision], etc.
+    for prefix in ("[CLAUDE.md]", "[Process Decision]", "[Brief]"):
+        if first_line.startswith(prefix):
+            first_line = first_line[len(prefix):].strip()
+            break
+
+    if first_line and len(first_line) <= 200:
+        return first_line
+    # Fallback: use tag name + entry ID
+    return f"Migrated from {tag_name} — {entry['id'][:8]}"
+
+
+def migrate(args: argparse.Namespace) -> None:
+    """Run the migration."""
+    api_url = args.api_url.rstrip("/")
+
+    with httpx.Client(timeout=30) as client:
+        # Verify API is reachable
+        try:
+            health = client.get(f"{api_url}/health")
+            health.raise_for_status()
+        except httpx.HTTPError as exc:
+            print(f"ERROR: Cannot reach BRAIN 3.0 API at {api_url}: {exc}")
+            sys.exit(1)
+
+        # Fetch all tags for reference
+        all_tags = fetch_tags(client, api_url)
+
+        # Determine which tags to process
+        tags_to_process: dict[str, str] = {}
+        if args.tag:
+            if args.tag in TAG_TO_ARTIFACT_TYPE:
+                tags_to_process[args.tag] = TAG_TO_ARTIFACT_TYPE[args.tag]
+            else:
+                # Unknown tag — default to document type
+                tags_to_process[args.tag] = "document"
+        else:
+            tags_to_process = dict(TAG_TO_ARTIFACT_TYPE)
+
+        # Stats
+        total_entries = 0
+        total_created = 0
+        total_skipped = 0
+        errors: list[str] = []
+
+        for tag_name, artifact_type in tags_to_process.items():
+            tag = find_tag_by_name(all_tags, tag_name)
+            if not tag:
+                print(f"  SKIP: Tag '{tag_name}' not found in BRAIN")
+                continue
+
+            print(f"\n--- Processing tag: {tag_name} → artifact_type: {artifact_type} ---")
+
+            entries = fetch_activity_entries_by_tag(client, api_url, tag_name)
+            print(f"  Found {len(entries)} activity entries")
+
+            # Group entries that share a common prefix (for multi-part content)
+            parent_map: dict[str, str] = {}  # prefix → parent artifact ID
+
+            for entry in entries:
+                total_entries += 1
+                notes = entry.get("notes") or ""
+                if not notes.strip():
+                    print(f"  SKIP (empty): {entry['id'][:8]}")
+                    total_skipped += 1
+                    continue
+
+                title = build_artifact_title(entry, tag_name)
+
+                # Check for existing artifact with this title
+                if check_artifact_exists(client, api_url, title):
+                    print(f"  SKIP (exists): {title}")
+                    total_skipped += 1
+                    continue
+
+                if args.dry_run:
+                    print(f"  WOULD CREATE: [{artifact_type}] {title}")
+                    total_created += 1
+                    continue
+
+                # Detect multi-part content (e.g., "Part 1 of 2", "Part 2 of 2")
+                parent_id = None
+                first_line = notes.split("\n")[0]
+                if "Part " in first_line and " of " in first_line:
+                    # Extract the base prefix before "Part X of Y"
+                    part_idx = first_line.index("Part ")
+                    prefix = first_line[:part_idx].strip().rstrip("(—-– ")
+                    if prefix in parent_map:
+                        parent_id = parent_map[prefix]
+
+                # Get tag IDs from the entry
+                entry_tag_ids = [t["id"] for t in entry.get("tags", [])]
+
+                try:
+                    artifact = create_artifact(
+                        client,
+                        api_url,
+                        title=title,
+                        artifact_type=artifact_type,
+                        content=notes,
+                        tag_ids=entry_tag_ids,
+                        parent_id=parent_id,
+                    )
+                    print(f"  CREATED: [{artifact_type}] {title}")
+                    total_created += 1
+
+                    # Track as potential parent for multi-part content
+                    if "Part 1 of" in first_line:
+                        part_idx = first_line.index("Part ")
+                        prefix = first_line[:part_idx].strip().rstrip("(—-– ")
+                        parent_map[prefix] = artifact["id"]
+
+                except httpx.HTTPStatusError as exc:
+                    error_msg = (
+                        f"  ERROR creating artifact for {entry['id'][:8]}:"
+                        f" {exc.response.text}"
+                    )
+                    print(error_msg)
+                    errors.append(error_msg)
+
+        # Summary
+        print("\n" + "=" * 60)
+        print("Migration Summary")
+        print("=" * 60)
+        action = "Would create" if args.dry_run else "Created"
+        print(f"  Entries processed: {total_entries}")
+        print(f"  {action}: {total_created}")
+        print(f"  Skipped: {total_skipped}")
+        if errors:
+            print(f"  Errors: {len(errors)}")
+            for err in errors:
+                print(f"    {err}")
+        if args.dry_run:
+            print("\n  (Dry run — no changes made)")
+
+
+def main() -> None:
+    """Entry point."""
+    args = parse_args()
+    migrate(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed_data.py
+++ b/scripts/seed_data.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Load seed data into BRAIN 3.0 via the batch API.
+
+Reads JSON seed files from scripts/seeds/ and loads them in dependency
+order: protocols → directives → skills. Idempotent — checks by name
+before creating and skips existing entities.
+
+Usage:
+    python scripts/seed_data.py --api-url http://localhost:8000 --dry-run
+    python scripts/seed_data.py --api-url http://localhost:8000
+    python scripts/seed_data.py --api-url http://localhost:8000 --only protocols
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import httpx
+
+DEFAULT_API_URL = "http://localhost:8000"
+SEEDS_DIR = Path(__file__).parent / "seeds"
+
+# Load order matters — skills reference protocols and directives by name
+ENTITY_ORDER = ["protocols", "directives", "skills"]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Load seed data into BRAIN 3.0",
+    )
+    parser.add_argument(
+        "--api-url",
+        default=DEFAULT_API_URL,
+        help=f"BRAIN 3.0 API base URL (default: {DEFAULT_API_URL})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be loaded without creating entities",
+    )
+    parser.add_argument(
+        "--only",
+        choices=ENTITY_ORDER,
+        help="Load only a specific entity type",
+    )
+    return parser.parse_args(argv)
+
+
+def load_seed_file(entity_type: str) -> dict:
+    """Load and parse a seed JSON file."""
+    path = SEEDS_DIR / f"{entity_type}.json"
+    if not path.exists():
+        print(f"  WARNING: Seed file not found: {path}")
+        return {"items": []}
+    with open(path) as f:
+        return json.load(f)
+
+
+def fetch_existing_by_name(
+    client: httpx.Client, api_url: str, entity_type: str,
+) -> dict[str, dict]:
+    """Fetch all existing entities of a type, keyed by name."""
+    resp = client.get(f"{api_url}/api/{entity_type}")
+    resp.raise_for_status()
+    return {item["name"]: item for item in resp.json()}
+
+
+def resolve_skill_references(
+    item: dict,
+    existing_protocols: dict[str, dict],
+    existing_directives: dict[str, dict],
+) -> dict:
+    """Resolve protocol_names and directive_names to IDs for skill creation.
+
+    Returns a new dict with protocol_ids and directive_ids replacing
+    the name-based references. Raises ValueError if a referenced name
+    is not found.
+    """
+    resolved = dict(item)
+
+    protocol_names = resolved.pop("protocol_names", [])
+    directive_names = resolved.pop("directive_names", [])
+
+    protocol_ids = []
+    for name in protocol_names:
+        if name not in existing_protocols:
+            msg = f"Protocol '{name}' not found — load protocols first"
+            raise ValueError(msg)
+        protocol_ids.append(existing_protocols[name]["id"])
+
+    directive_ids = []
+    for name in directive_names:
+        if name not in existing_directives:
+            msg = f"Directive '{name}' not found — load directives first"
+            raise ValueError(msg)
+        directive_ids.append(existing_directives[name]["id"])
+
+    if protocol_ids:
+        resolved["protocol_ids"] = protocol_ids
+    if directive_ids:
+        resolved["directive_ids"] = directive_ids
+
+    return resolved
+
+
+def load_entity_type(
+    client: httpx.Client,
+    api_url: str,
+    entity_type: str,
+    dry_run: bool,
+    existing_protocols: dict[str, dict] | None = None,
+    existing_directives: dict[str, dict] | None = None,
+) -> tuple[int, int, list[str]]:
+    """Load seed data for a single entity type.
+
+    Returns (created_count, skipped_count, errors).
+    """
+    seed_data = load_seed_file(entity_type)
+    items = seed_data.get("items", [])
+    if not items:
+        return 0, 0, []
+
+    # Check existing entities for idempotency
+    existing = fetch_existing_by_name(client, api_url, entity_type)
+
+    created = 0
+    skipped = 0
+    errors: list[str] = []
+
+    # Filter to only new items
+    to_create = []
+    for item in items:
+        name = item["name"]
+        if name in existing:
+            print(f"    SKIP (exists): {name}")
+            skipped += 1
+            continue
+
+        # Skills need name→ID resolution
+        if entity_type == "skills":
+            try:
+                item = resolve_skill_references(
+                    item,
+                    existing_protocols or {},
+                    existing_directives or {},
+                )
+            except ValueError as exc:
+                error_msg = f"    ERROR resolving references for '{name}': {exc}"
+                print(error_msg)
+                errors.append(error_msg)
+                continue
+
+        if dry_run:
+            print(f"    WOULD CREATE: {name}")
+            created += 1
+            continue
+
+        to_create.append(item)
+
+    # Batch create all new items at once
+    if to_create and not dry_run:
+        try:
+            resp = client.post(
+                f"{api_url}/api/{entity_type}/batch",
+                json={"items": to_create},
+            )
+            resp.raise_for_status()
+            result = resp.json()
+            batch_count = result.get("count", len(to_create))
+            for item in to_create:
+                print(f"    CREATED: {item['name']}")
+            created += batch_count
+        except httpx.HTTPStatusError as exc:
+            error_msg = f"    ERROR in batch create: {exc.response.text}"
+            print(error_msg)
+            errors.append(error_msg)
+
+    return created, skipped, errors
+
+
+def seed(args: argparse.Namespace) -> None:
+    """Run the seed loading."""
+    api_url = args.api_url.rstrip("/")
+
+    with httpx.Client(timeout=30) as client:
+        # Verify API is reachable
+        try:
+            health = client.get(f"{api_url}/health")
+            health.raise_for_status()
+        except httpx.HTTPError as exc:
+            print(f"ERROR: Cannot reach BRAIN 3.0 API at {api_url}: {exc}")
+            sys.exit(1)
+
+        entities_to_load = [args.only] if args.only else ENTITY_ORDER
+
+        total_created = 0
+        total_skipped = 0
+        all_errors: list[str] = []
+
+        # We need to track what exists for skill reference resolution
+        existing_protocols: dict[str, dict] = {}
+        existing_directives: dict[str, dict] = {}
+
+        for entity_type in entities_to_load:
+            print(f"\n--- Loading {entity_type} ---")
+
+            # Refresh protocol/directive maps before loading skills
+            if entity_type == "skills":
+                existing_protocols = fetch_existing_by_name(
+                    client, api_url, "protocols",
+                )
+                existing_directives = fetch_existing_by_name(
+                    client, api_url, "directives",
+                )
+
+            created, skipped, errors = load_entity_type(
+                client,
+                api_url,
+                entity_type,
+                args.dry_run,
+                existing_protocols=existing_protocols,
+                existing_directives=existing_directives,
+            )
+            total_created += created
+            total_skipped += skipped
+            all_errors.extend(errors)
+
+            # Update maps after loading (for subsequent skill resolution)
+            if entity_type == "protocols" and not args.dry_run:
+                existing_protocols = fetch_existing_by_name(
+                    client, api_url, "protocols",
+                )
+            elif entity_type == "directives" and not args.dry_run:
+                existing_directives = fetch_existing_by_name(
+                    client, api_url, "directives",
+                )
+
+        # Summary
+        print("\n" + "=" * 60)
+        print("Seed Loading Summary")
+        print("=" * 60)
+        action = "Would create" if args.dry_run else "Created"
+        print(f"  {action}: {total_created}")
+        print(f"  Skipped (already exist): {total_skipped}")
+        if all_errors:
+            print(f"  Errors: {len(all_errors)}")
+            for err in all_errors:
+                print(f"    {err}")
+        if args.dry_run:
+            print("\n  (Dry run — no changes made)")
+
+
+def main() -> None:
+    """Entry point."""
+    args = parse_args()
+    seed(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seeds/directives.json
+++ b/scripts/seeds/directives.json
@@ -1,0 +1,20 @@
+{
+  "items": [
+    {
+      "name": "log-it-dont-fix-it",
+      "content": "When you discover a bug, inconsistency, or concern while working on something else, file a GitHub issue — do not fix it inline. Scope creep is how PRs become unreviewable.",
+      "scope": "global",
+      "scope_ref": null,
+      "priority": 3,
+      "is_seedable": true
+    },
+    {
+      "name": "match-tasks-to-energy",
+      "content": "Consider energy cost, activation friction, and current energy state when suggesting tasks. Recommend low-friction tasks during low-energy periods and reserve high-cost tasks for peak capacity.",
+      "scope": "global",
+      "scope_ref": null,
+      "priority": 5,
+      "is_seedable": true
+    }
+  ]
+}

--- a/scripts/seeds/protocols.json
+++ b/scripts/seeds/protocols.json
@@ -1,0 +1,42 @@
+{
+  "items": [
+    {
+      "name": "session-startup",
+      "description": "Standard procedure for beginning a new BRAIN session",
+      "steps": [
+        {
+          "order": 1,
+          "title": "Load skill context",
+          "instruction": "Call get_skill_full for the active skill to load protocols, directives, and domain context",
+          "is_optional": false
+        },
+        {
+          "order": 2,
+          "title": "Check pending tasks",
+          "instruction": "List tasks with status=active or status=pending to identify current work",
+          "is_optional": false
+        }
+      ],
+      "is_seedable": true
+    },
+    {
+      "name": "bug-discovery",
+      "description": "Steps for handling bugs found during other work — log it, don't fix it",
+      "steps": [
+        {
+          "order": 1,
+          "title": "File GitHub issue",
+          "instruction": "Create a GitHub issue with type, ticket context, description, severity, and suggested fix",
+          "is_optional": false
+        },
+        {
+          "order": 2,
+          "title": "Assess severity",
+          "instruction": "Classify as Blocker, Major, Minor, or Cosmetic. Flag blockers to L immediately",
+          "is_optional": false
+        }
+      ],
+      "is_seedable": true
+    }
+  ]
+}

--- a/scripts/seeds/skills.json
+++ b/scripts/seeds/skills.json
@@ -1,0 +1,20 @@
+{
+  "items": [
+    {
+      "name": "core-protocol",
+      "description": "Always-active base skill providing session management and standard operating procedures",
+      "is_seedable": true,
+      "is_default": true,
+      "protocol_names": ["session-startup", "bug-discovery"],
+      "directive_names": ["log-it-dont-fix-it"]
+    },
+    {
+      "name": "wellness",
+      "description": "Health and energy management mode — tracks energy patterns and suggests restorative actions",
+      "is_seedable": true,
+      "is_default": false,
+      "protocol_names": [],
+      "directive_names": ["match-tasks-to-energy"]
+    }
+  ]
+}

--- a/tests/test_seed_data.py
+++ b/tests/test_seed_data.py
@@ -1,0 +1,295 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for seed data structure and script logic."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.schemas.directives import DirectiveCreate
+from app.schemas.protocols import ProtocolCreate
+from scripts.migrate_to_artifacts import (
+    build_artifact_title,
+)
+from scripts.migrate_to_artifacts import (
+    parse_args as parse_migrate_args,
+)
+from scripts.seed_data import (
+    load_seed_file,
+    resolve_skill_references,
+)
+from scripts.seed_data import (
+    parse_args as parse_seed_args,
+)
+
+SEEDS_PATH = Path(__file__).parent.parent / "scripts" / "seeds"
+
+
+# ---------------------------------------------------------------------------
+# Seed JSON parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestSeedFileParsing:
+    """Verify seed JSON files load and parse correctly."""
+
+    def test_protocols_json_loads(self):
+        with open(SEEDS_PATH / "protocols.json") as f:
+            data = json.load(f)
+        assert "items" in data
+        assert len(data["items"]) > 0
+
+    def test_directives_json_loads(self):
+        with open(SEEDS_PATH / "directives.json") as f:
+            data = json.load(f)
+        assert "items" in data
+        assert len(data["items"]) > 0
+
+    def test_skills_json_loads(self):
+        with open(SEEDS_PATH / "skills.json") as f:
+            data = json.load(f)
+        assert "items" in data
+        assert len(data["items"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Seed data schema validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestSeedDataSchemaValidation:
+    """Verify seed data matches Pydantic schemas."""
+
+    def test_protocols_match_schema(self):
+        with open(SEEDS_PATH / "protocols.json") as f:
+            data = json.load(f)
+        for item in data["items"]:
+            protocol = ProtocolCreate(**item)
+            assert protocol.name
+            assert protocol.is_seedable is True
+
+    def test_directives_match_schema(self):
+        with open(SEEDS_PATH / "directives.json") as f:
+            data = json.load(f)
+        for item in data["items"]:
+            directive = DirectiveCreate(**item)
+            assert directive.name
+            assert directive.is_seedable is True
+
+    def test_skills_seed_has_required_fields(self):
+        """Skills use name-based references, so we validate structure not schema."""
+        with open(SEEDS_PATH / "skills.json") as f:
+            data = json.load(f)
+        for item in data["items"]:
+            assert "name" in item
+            assert "is_seedable" in item
+            assert item["is_seedable"] is True
+            # Name-based references must be lists
+            assert isinstance(item.get("protocol_names", []), list)
+            assert isinstance(item.get("directive_names", []), list)
+
+    def test_protocols_have_meaningful_steps(self):
+        with open(SEEDS_PATH / "protocols.json") as f:
+            data = json.load(f)
+        for item in data["items"]:
+            if item.get("steps"):
+                for step in item["steps"]:
+                    assert step["title"].strip()
+                    assert step["instruction"].strip()
+                    assert step["order"] >= 1
+
+    def test_directives_have_correct_scope(self):
+        with open(SEEDS_PATH / "directives.json") as f:
+            data = json.load(f)
+        for item in data["items"]:
+            assert item["scope"] in ("global", "skill", "agent")
+            if item["scope"] == "global":
+                assert item.get("scope_ref") is None
+
+    def test_exactly_one_default_skill(self):
+        with open(SEEDS_PATH / "skills.json") as f:
+            data = json.load(f)
+        defaults = [i for i in data["items"] if i.get("is_default")]
+        assert len(defaults) == 1, f"Expected 1 default skill, found {len(defaults)}"
+
+    def test_all_seed_items_are_seedable(self):
+        """Every item in every seed file must have is_seedable=true."""
+        for filename in ("protocols.json", "directives.json", "skills.json"):
+            with open(SEEDS_PATH / filename) as f:
+                data = json.load(f)
+            for item in data["items"]:
+                assert item.get("is_seedable") is True, (
+                    f"{filename}: {item['name']} missing is_seedable=true"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Seed data cross-reference tests
+# ---------------------------------------------------------------------------
+
+
+class TestSeedCrossReferences:
+    """Verify skills reference protocols/directives that exist in seed data."""
+
+    def test_skill_protocol_references_are_valid(self):
+        with open(SEEDS_PATH / "protocols.json") as f:
+            protocol_names = {p["name"] for p in json.load(f)["items"]}
+        with open(SEEDS_PATH / "skills.json") as f:
+            skills = json.load(f)["items"]
+
+        for skill in skills:
+            for ref in skill.get("protocol_names", []):
+                assert ref in protocol_names, (
+                    f"Skill '{skill['name']}' references unknown protocol '{ref}'"
+                )
+
+    def test_skill_directive_references_are_valid(self):
+        with open(SEEDS_PATH / "directives.json") as f:
+            directive_names = {d["name"] for d in json.load(f)["items"]}
+        with open(SEEDS_PATH / "skills.json") as f:
+            skills = json.load(f)["items"]
+
+        for skill in skills:
+            for ref in skill.get("directive_names", []):
+                assert ref in directive_names, (
+                    f"Skill '{skill['name']}' references unknown directive '{ref}'"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Script logic tests
+# ---------------------------------------------------------------------------
+
+
+class TestSeedScriptLogic:
+    """Test seed_data.py functions with mocked API calls."""
+
+    def test_load_seed_file_returns_items(self):
+        data = load_seed_file("protocols")
+        assert "items" in data
+        assert len(data["items"]) > 0
+
+    def test_load_seed_file_missing_returns_empty(self):
+        data = load_seed_file("nonexistent_entity")
+        assert data == {"items": []}
+
+    def test_resolve_skill_references_success(self):
+        item = {
+            "name": "test-skill",
+            "description": "Test",
+            "is_seedable": True,
+            "is_default": False,
+            "protocol_names": ["session-startup"],
+            "directive_names": ["log-it-dont-fix-it"],
+        }
+        protocols = {"session-startup": {"id": "proto-uuid-1", "name": "session-startup"}}
+        directives = {"log-it-dont-fix-it": {"id": "dir-uuid-1", "name": "log-it-dont-fix-it"}}
+
+        resolved = resolve_skill_references(item, protocols, directives)
+        assert resolved["protocol_ids"] == ["proto-uuid-1"]
+        assert resolved["directive_ids"] == ["dir-uuid-1"]
+        assert "protocol_names" not in resolved
+        assert "directive_names" not in resolved
+
+    def test_resolve_skill_references_missing_protocol(self):
+        item = {
+            "name": "test-skill",
+            "protocol_names": ["nonexistent"],
+            "directive_names": [],
+        }
+        with pytest.raises(ValueError, match="Protocol 'nonexistent' not found"):
+            resolve_skill_references(item, {}, {})
+
+    def test_resolve_skill_references_missing_directive(self):
+        item = {
+            "name": "test-skill",
+            "protocol_names": [],
+            "directive_names": ["nonexistent"],
+        }
+        with pytest.raises(ValueError, match="Directive 'nonexistent' not found"):
+            resolve_skill_references(item, {}, {})
+
+    def test_parse_args_defaults(self):
+        args = parse_seed_args([])
+        assert args.api_url == "http://localhost:8000"
+        assert args.dry_run is False
+        assert args.only is None
+
+    def test_parse_args_all_flags(self):
+        args = parse_seed_args([
+            "--api-url", "http://example.com:9000",
+            "--dry-run",
+            "--only", "protocols",
+        ])
+        assert args.api_url == "http://example.com:9000"
+        assert args.dry_run is True
+        assert args.only == "protocols"
+
+
+class TestMigrateScriptLogic:
+    """Test migrate_to_artifacts.py functions."""
+
+    def test_build_artifact_title_from_claude_md(self):
+        entry = {
+            "id": "abcdef12-3456-7890-abcd-ef1234567890",
+            "notes": "[CLAUDE.md] brain3/CLAUDE.md — Core API\nContent here...",
+        }
+        title = build_artifact_title(entry, "claude-md")
+        assert title == "brain3/CLAUDE.md — Core API"
+
+    def test_build_artifact_title_from_process_decision(self):
+        entry = {
+            "id": "abcdef12-3456-7890-abcd-ef1234567890",
+            "notes": "[Process Decision] Some decision\nDetails...",
+        }
+        title = build_artifact_title(entry, "process-decision")
+        assert title == "Some decision"
+
+    def test_build_artifact_title_fallback(self):
+        entry = {
+            "id": "abcdef12-3456-7890-abcd-ef1234567890",
+            "notes": "A" * 250 + "\nContent",
+        }
+        title = build_artifact_title(entry, "some-tag")
+        assert title.startswith("Migrated from some-tag")
+
+    def test_build_artifact_title_empty_notes(self):
+        entry = {
+            "id": "abcdef12-3456-7890-abcd-ef1234567890",
+            "notes": "",
+        }
+        title = build_artifact_title(entry, "some-tag")
+        assert title.startswith("Migrated from some-tag")
+
+    def test_parse_migrate_args_defaults(self):
+        args = parse_migrate_args([])
+        assert args.api_url == "http://localhost:8000"
+        assert args.dry_run is False
+        assert args.tag is None
+
+    def test_parse_migrate_args_all_flags(self):
+        args = parse_migrate_args([
+            "--api-url", "http://example.com:9000",
+            "--dry-run",
+            "--tag", "claude-md",
+        ])
+        assert args.api_url == "http://example.com:9000"
+        assert args.dry_run is True
+        assert args.tag == "claude-md"


### PR DESCRIPTION
## Summary

Builds the seed data loading pipeline and content migration framework for BRAIN 3.0. The seed loader reads JSON files from `scripts/seeds/` and loads them via the batch API in dependency order (protocols → directives → skills). The migration script reads activity log entries tagged with document-type tags and creates corresponding artifacts. Both scripts are framework-only — seed content is intentionally minimal (1-2 examples per entity type) to validate the pipeline works. Comprehensive content will be added organically from production usage.

Closes #99

## Changes

**New files:**
- `scripts/seeds/protocols.json` — 2 starter protocols (session-startup, bug-discovery) with meaningful steps
- `scripts/seeds/directives.json` — 2 global directives (log-it-dont-fix-it, match-tasks-to-energy)
- `scripts/seeds/skills.json` — 2 skills (core-protocol as default, wellness) with name-based protocol/directive references
- `scripts/seed_data.py` — Seed loading script with `--dry-run`, `--only`, `--api-url` flags. Idempotent (checks by name before creating). Loads in dependency order. Resolves skill→protocol/directive name references to UUIDs at load time.
- `scripts/migrate_to_artifacts.py` — Migration script with `--dry-run`, `--tag`, `--api-url` flags. Maps tag names to artifact types (claude-md→document, process-decision→document, stellan-blueprint→brief). Handles multi-part content via parent_id linking. Does not delete source activity entries.
- `scripts/__init__.py` — Makes scripts directory importable for tests
- `tests/test_seed_data.py` — 25 tests covering JSON parsing, Pydantic schema validation, cross-reference integrity, script logic (argument parsing, reference resolution, title building)

**Modified files:**
- `CHANGELOG.md` — Added entries for seed framework and migration scripts

## How to Verify

1. **Tests:** `pytest tests/test_seed_data.py -v` — 25 tests pass
2. **Full suite:** `pytest -v` — 621 tests pass, no regressions
3. **Lint:** `ruff check .` — all checks pass
4. **Dry run (seed):** With API running: `python scripts/seed_data.py --api-url http://localhost:8000 --dry-run`
5. **Dry run (migrate):** With API running: `python scripts/migrate_to_artifacts.py --api-url http://localhost:8000 --dry-run`
6. **Load seeds:** `python scripts/seed_data.py --api-url http://localhost:8000` — creates 2 protocols, 2 directives, 2 skills
7. **Idempotent re-run:** Run seed_data.py again — all items skipped, 0 created

## Deviations

- **Minimal seed content per brief:** The GitHub issue spec listed 5 protocols, 5+ directives, and 4 skills with comprehensive steps/content. Per PO brief, seed files contain only 1-2 minimal examples per entity type to validate the pipeline. Comprehensive content deferred to production usage.

## Test Results

```
$ pytest tests/test_seed_data.py -v
25 passed in 0.18s

$ pytest -v
621 passed in 8.22s

$ ruff check .
All checks passed!
```

## Acceptance Checklist

### Migration Script
- [x] Identifies activity log entries with document-type tags
- [x] Creates artifacts with correct type and content
- [x] Preserves tags on migrated artifacts
- [x] Links multi-part content via parent_id
- [x] Dry-run mode shows planned changes without executing
- [x] Does NOT delete source activity log entries
- [x] Prints clear summary of actions taken
- [x] Handles API errors gracefully (reports and continues)
- [x] `--tag` flag for incremental migration

### Seed Data
- [x] All seed JSON files validate against batch create schemas
- [x] Protocols have meaningful steps
- [x] Directives have correct scope assignments
- [x] Skills reference protocols and directives by name (resolved at load time)
- [x] core-protocol skill has `is_default=true`
- [x] All seed items have `is_seedable=true`

### Seed Loading Script
- [x] Loads seed data via batch API in correct dependency order
- [x] Resolves name references (skill → protocol/directive names → IDs)
- [x] `--only` flag for partial loading
- [x] `--dry-run` mode
- [x] Idempotent — running twice does not create duplicates (checks by name)
- [x] Reports what was created vs skipped

### Tests
- [x] Seed JSON files parse correctly
- [x] Seed data matches Pydantic schemas
- [x] Migration script logic tested (argument parsing, title building)
- [x] Cross-reference integrity validated