### PR TITLE
v1.2.0: Resolve QA and security findings

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -32,7 +32,7 @@ from sqlalchemy import (
     String,
     Text,
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
@@ -624,7 +624,7 @@ class Protocol(Base):
     )
     name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     description: Mapped[str | None] = mapped_column(Text)
-    steps: Mapped[dict | None] = mapped_column(JSON)
+    steps: Mapped[list | None] = mapped_column(JSON().with_variant(JSONB, "postgresql"))
     artifact_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("artifacts.id", ondelete="SET NULL"),
     )

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -56,20 +56,25 @@ def batch_create_tasks(
 ) -> dict:
     """Batch create tasks. Atomic — all succeed or all fail."""
     created = []
-    for idx, item in enumerate(payload.items):
-        if item.project_id is not None:
-            project = db.query(Project).filter(Project.id == item.project_id).first()
-            if not project:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Batch item {idx}: Project not found (project_id: {item.project_id})",
-                )
+    try:
+        for idx, item in enumerate(payload.items):
+            if item.project_id is not None:
+                project = db.query(Project).filter(Project.id == item.project_id).first()
+                if not project:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Batch item {idx}: Project not found"
+                    f" (project_id: {item.project_id})",
+                    )
 
-        task = Task(**item.model_dump())
-        db.add(task)
-        created.append(task)
+            task = Task(**item.model_dump())
+            db.add(task)
+            db.flush()
+            created.append(task)
+    except HTTPException:
+        db.rollback()
+        raise
 
-    db.flush()
     db.commit()
     for task in created:
         db.refresh(task)

--- a/app/schemas/artifacts.py
+++ b/app/schemas/artifacts.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 ArtifactType = Literal[
     "document", "protocol", "brief", "prompt", "template", "journal", "spec"
@@ -39,6 +39,13 @@ class ArtifactCreate(BaseModel):
     is_seedable: bool = False
     tag_ids: list[UUID] | None = None
 
+    @field_validator("content")
+    @classmethod
+    def validate_content_byte_length(cls, v: str) -> str:
+        if len(v.encode("utf-8")) > 524_288:
+            raise ValueError("Content exceeds 512KB byte limit")
+        return v
+
 
 class ArtifactUpdate(BaseModel):
     """All fields optional — supports partial PATCH updates."""
@@ -48,6 +55,13 @@ class ArtifactUpdate(BaseModel):
     content: str | None = Field(default=None, max_length=500_000)
     parent_id: UUID | None = None
     is_seedable: bool | None = None
+
+    @field_validator("content")
+    @classmethod
+    def validate_content_byte_length(cls, v: str | None) -> str | None:
+        if v is not None and len(v.encode("utf-8")) > 524_288:
+            raise ValueError("Content exceeds 512KB byte limit")
+        return v
 
 
 class ArtifactResponse(BaseModel):

--- a/app/schemas/batch.py
+++ b/app/schemas/batch.py
@@ -58,7 +58,7 @@ class BatchActivityCreate(BaseModel):
 class BatchArtifactCreate(BaseModel):
     """Batch create artifacts."""
 
-    items: list[ArtifactCreate] = Field(max_length=100)
+    items: list[ArtifactCreate] = Field(max_length=25)
 
 
 class BatchProtocolCreate(BaseModel):

--- a/app/schemas/protocols.py
+++ b/app/schemas/protocols.py
@@ -38,7 +38,7 @@ class ProtocolCreate(BaseModel):
 
     name: str = Field(max_length=100)
     description: str | None = Field(default=None, max_length=5000)
-    steps: list[ProtocolStep] | None = None
+    steps: list[ProtocolStep] | None = Field(default=None, max_length=50)
     artifact_id: UUID | None = None
     is_seedable: bool = True
     tag_ids: list[UUID] | None = None
@@ -49,7 +49,7 @@ class ProtocolUpdate(BaseModel):
 
     name: str | None = Field(default=None, max_length=100)
     description: str | None = Field(default=None, max_length=5000)
-    steps: list[ProtocolStep] | None = None
+    steps: list[ProtocolStep] | None = Field(default=None, max_length=50)
     artifact_id: UUID | None = None
     is_seedable: bool | None = None
 

--- a/scripts/seeds/directives.json
+++ b/scripts/seeds/directives.json
@@ -15,6 +15,30 @@
       "scope_ref": null,
       "priority": 5,
       "is_seedable": true
+    },
+    {
+      "name": "low-friction-design",
+      "content": "Minimize activation barriers in all system interactions. Every extra step, confirmation, or context switch is friction that compounds for ADHD users. Default to the simplest path that preserves correctness.",
+      "scope": "global",
+      "scope_ref": null,
+      "priority": 2,
+      "is_seedable": true
+    },
+    {
+      "name": "write-to-brain-not-context",
+      "content": "Persist decisions, context, and state in BRAIN (activity logs, tasks, artifacts), not in conversation memory or ephemeral notes. Conversation context disappears between sessions — BRAIN is the durable record.",
+      "scope": "global",
+      "scope_ref": null,
+      "priority": 1,
+      "is_seedable": true
+    },
+    {
+      "name": "graduated-scaffolding",
+      "content": "Support structures should phase out as habits solidify. Start with high scaffolding (reminders, checklists, prompts) and gradually reduce as the user demonstrates consistent follow-through. The goal is independence, not dependency.",
+      "scope": "global",
+      "scope_ref": null,
+      "priority": 4,
+      "is_seedable": true
     }
   ]
 }

--- a/scripts/seeds/protocols.json
+++ b/scripts/seeds/protocols.json
@@ -20,6 +20,31 @@
       "is_seedable": true
     },
     {
+      "name": "session-shutdown",
+      "description": "Standard procedure for ending a BRAIN session — capture context before it disappears",
+      "steps": [
+        {
+          "order": 1,
+          "title": "Log activity",
+          "instruction": "Create activity log entries for all work completed during this session, including duration and energy ratings",
+          "is_optional": false
+        },
+        {
+          "order": 2,
+          "title": "Update task statuses",
+          "instruction": "Mark completed tasks as done, update in-progress tasks with current state, defer blocked tasks with notes",
+          "is_optional": false
+        },
+        {
+          "order": 3,
+          "title": "Write handoff notes",
+          "instruction": "Document anything the next session needs to know — decisions made, blockers hit, next steps planned",
+          "is_optional": false
+        }
+      ],
+      "is_seedable": true
+    },
+    {
       "name": "bug-discovery",
       "description": "Steps for handling bugs found during other work — log it, don't fix it",
       "steps": [
@@ -33,6 +58,68 @@
           "order": 2,
           "title": "Assess severity",
           "instruction": "Classify as Blocker, Major, Minor, or Cosmetic. Flag blockers to L immediately",
+          "is_optional": false
+        }
+      ],
+      "is_seedable": true
+    },
+    {
+      "name": "agent-activation",
+      "description": "Steps for activating a Foundry agent — load identity and context before starting work",
+      "steps": [
+        {
+          "order": 1,
+          "title": "Pull CLAUDE.md",
+          "instruction": "Load the org-level and repo-specific CLAUDE.md from BRAIN artifacts tagged claude-md",
+          "is_optional": false
+        },
+        {
+          "order": 2,
+          "title": "Load agent brief",
+          "instruction": "Read the agent's identity artifact and session brief to establish role and context",
+          "is_optional": false
+        },
+        {
+          "order": 3,
+          "title": "Verify identity",
+          "instruction": "Confirm agent identity pointer matches the BRAIN project record and acknowledge role boundaries",
+          "is_optional": false
+        }
+      ],
+      "is_seedable": true
+    },
+    {
+      "name": "release-pipeline",
+      "description": "Steps for shipping a version — branch, test, PR, merge, deploy, verify",
+      "steps": [
+        {
+          "order": 1,
+          "title": "Create release branch",
+          "instruction": "Branch from develop with naming convention release/vX.Y.Z",
+          "is_optional": false
+        },
+        {
+          "order": 2,
+          "title": "Run full test suite",
+          "instruction": "Execute pytest with full coverage and ruff lint checks — all must pass",
+          "is_optional": false
+        },
+        {
+          "order": 3,
+          "title": "Open pull request",
+          "instruction": "Create PR from release branch to main with full PR template filled out",
+          "is_optional": false
+        },
+        {
+          "order": 4,
+          "title": "Merge and tag",
+          "instruction": "After approval, merge to main and create a git tag for the version",
+          "is_optional": false
+        },
+        {
+          "order": 5,
+          "title": "Deploy and verify",
+          "instruction": "Deploy to production and verify health checks pass, key endpoints respond correctly",
           "is_optional": false
         }
       ],

--- a/scripts/seeds/skills.json
+++ b/scripts/seeds/skills.json
@@ -5,8 +5,16 @@
       "description": "Always-active base skill providing session management and standard operating procedures",
       "is_seedable": true,
       "is_default": true,
-      "protocol_names": ["session-startup", "bug-discovery"],
-      "directive_names": ["log-it-dont-fix-it"]
+      "protocol_names": ["session-startup", "session-shutdown", "bug-discovery"],
+      "directive_names": ["log-it-dont-fix-it", "low-friction-design", "write-to-brain-not-context", "graduated-scaffolding", "match-tasks-to-energy"]
+    },
+    {
+      "name": "po-dev",
+      "description": "Product owner and development mode — shipping features, managing releases, and technical decision-making",
+      "is_seedable": true,
+      "is_default": false,
+      "protocol_names": ["release-pipeline"],
+      "directive_names": []
     },
     {
       "name": "wellness",
@@ -15,6 +23,14 @@
       "is_default": false,
       "protocol_names": [],
       "directive_names": ["match-tasks-to-energy"]
+    },
+    {
+      "name": "life-admin",
+      "description": "Errands, household, and finance management mode — tracking non-technical responsibilities and routine maintenance",
+      "is_seedable": true,
+      "is_default": false,
+      "protocol_names": [],
+      "directive_names": []
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Resolves 7 issues from QA (Quincy) and Security (Seraphina) review during v1.2.0 hardening
- Fixes Protocol model/schema inconsistencies, adds input validation bounds, adds missing seed data, and aligns batch endpoint patterns

## Changes

**app/models.py** — Protocol `steps` column changed from generic `JSON` to `JSON().with_variant(JSONB, "postgresql")`. Type annotation corrected from `Mapped[dict | None]` to `Mapped[list | None]`. Uses `with_variant` to maintain SQLite test compatibility while ensuring PostgreSQL uses JSONB as the migration specifies. (#107, #109)

**app/schemas/protocols.py** — Added `max_length=50` to `steps` field on both `ProtocolCreate` and `ProtocolUpdate` to bound JSONB payload size. (#110)

**app/schemas/artifacts.py** — Added `field_validator` on `content` for both `ArtifactCreate` and `ArtifactUpdate` that checks `len(v.encode("utf-8")) > 524_288` to match the database CHECK constraint on byte length. Closes the validation gap for multi-byte UTF-8 content. (#111)

**app/schemas/batch.py** — Reduced `BatchArtifactCreate.items` `max_length` from 100 to 25 to bound aggregate payload size for content-heavy artifacts. (#112)

**app/routers/tasks.py** — Wrapped `batch_create_tasks` creation loop in `try/except HTTPException` with explicit `db.rollback()`, and added per-item `db.flush()` to match the pattern used by all other batch endpoints. (#113)

**scripts/seeds/protocols.json** — Added session-shutdown, agent-activation, and release-pipeline protocols with meaningful steps per spec #99. (#108)

**scripts/seeds/directives.json** — Added low-friction-design, write-to-brain-not-context, and graduated-scaffolding as global directives per spec #99. (#108)

**scripts/seeds/skills.json** — Added po-dev and life-admin skills. Updated core-protocol to reference all 3 session/bug protocols and all 5 global directives per spec #99. (#108)

## How to Verify
1. `ruff check .` — passes clean
2. `pytest --tb=short -q` — 621 passed
3. Inspect seed JSON files for completeness against spec #99
4. Verify `alembic revision --autogenerate` produces no changes (model matches migration)

## Deviations
Protocol model uses `JSON().with_variant(JSONB, "postgresql")` instead of bare `JSONB` import. This is necessary because the test suite uses SQLite which cannot render the `JSONB` type. The `with_variant` approach is the standard SQLAlchemy pattern — PostgreSQL gets `jsonb`, SQLite gets `json`. The migration (004) remains unchanged and correctly uses `postgresql.JSONB()`.

## Test Results
```
621 passed in 8.21s
```
All checks passed (ruff).

## Acceptance Checklist
- [x] Protocol model uses JSONB for PostgreSQL (#107)
- [x] Protocol steps type annotation is list, not dict (#109)
- [x] Protocol steps bounded to max 50 items (#110)
- [x] Artifact content validates byte length at Pydantic layer (#111)
- [x] Batch artifact create limited to 25 items (#112)
- [x] batch_create_tasks has explicit rollback pattern (#113)
- [x] All 5 protocols present in seed data (#108)
- [x] All 5 directives present in seed data (#108)
- [x] All 4 skills present in seed data (#108)
- [x] core-protocol skill references all protocols and directives (#108)

Closes #107, #108, #109, #110, #111, #112, #113