### PR TITLE
v1.2.0: Documentation update — README, Wiki, ROADMAP, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,45 @@ All notable changes to BRAIN 3.0 will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased] — Phase 1: The Core Loop
+## [v1.2.0] — The Knowledge Layer
+
+### Added
+- Artifact model, migration, CRUD endpoints with content storage (512KB), versioning, parent/child hierarchy, and tagging (#94)
+- Protocol model, migration, CRUD endpoints with structured JSON steps (max 50), optional artifact linking, and tagging (#95)
+- Directive model, migration, CRUD endpoints with scoped priority (global/skill/agent), priority 1-10, and tagging (#96)
+- Directive resolution endpoint — merges global + skill + agent directives into ordered set (#96)
+- Skill model, migration, CRUD endpoints with many-to-many linking to domains, protocols, and directives (#97)
+- Skill full bootstrap endpoint (`get_skill_full`) — loads complete operating context in one call (#97)
+- Batch create endpoints for tasks, activity, artifacts, protocols, directives, and skills (#98)
+- Batch tag attachment endpoints for tasks, activity, and artifacts (#98)
+- Content migration script (`scripts/migrate_to_artifacts.py`) with --dry-run, --tag, and --api-url flags (#99)
+- Seed data loading script (`scripts/seed_data.py`) with idempotent batch loading, --only and --dry-run flags (#99)
+- Seed data files in `scripts/seeds/` — starter protocols, directives, and skills (#99)
+- Seed data validation tests covering JSON parsing, schema compliance, cross-references, and script logic (#99)
+
+### Fixed
+- Protocol steps field type corrected from dict to list (#107)
+- Protocol steps database type updated to JSON with PostgreSQL JSONB variant (#109)
+- Artifact content byte-length validation at schema level for UTF-8 safety (#111)
+- Batch artifact create limit reduced from 100 to 25 for content-heavy entities (#112)
+- Batch task create transaction robustness — explicit rollback and per-item flush (#113)
+- Protocol steps max length validation (max 50 items) (#110)
+- Missing seed data — added starter protocols, directives, and skill links (#108)
+
+## [v1.1.0] — Activity Tags
+
+### Added
+- Activity tags — `activity_tags` association table, tag/untag endpoints, tag filter on `list_activity`, reverse lookup via `list_tagged_activities` (#73)
+
+## [v1.0.1] — Patch
+
+### Fixed
+- `progress_pct` returns 0% when completed tasks exist in project (#69)
+
+### Changed
+- Added AGPL-3.0 header notices to source files (#58)
+
+## [v1.0.0] — The Core Loop
 
 ### Added
 - System design document — seven-pillar data model, full schema, architecture, ADHD design principles, phased delivery plan, and resolved design decisions
@@ -26,7 +64,3 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Task CRUD endpoints with composable ADHD-aware filters (#5)
 - Task filters: energy cost range, friction range, cognitive type, context, due dates, overdue, standalone (#5)
 - Pydantic validators for 1-5 scale fields (energy_cost, activation_friction) (#5)
-- Content migration script (`scripts/migrate_to_artifacts.py`) with --dry-run, --tag, and --api-url flags (#99)
-- Seed data loading script (`scripts/seed_data.py`) with idempotent batch loading, --only and --dry-run flags (#99)
-- Seed data files in `scripts/seeds/` — minimal starter protocols, directives, and skills (#99)
-- Seed data validation tests covering JSON parsing, schema compliance, cross-references, and script logic (#99)

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ Most task managers treat you like a filing cabinet with legs: store things, sort
 
 This is Phase 1: the core data layer and API. Claude connects through the [Model Context Protocol (MCP)](https://github.com/willim233/brain3-mcp) and acts as a partner — not an assistant. It reads your patterns, notices neglected areas of life, pushes back when you're overloading yourself, and reasons about what actually makes sense right now. For the full design rationale, see the [System Design Document](docs/BRAIN_3_0_Design_Document.md).
 
-## Architecture — The Seven Pillars
+## Architecture
 
-The data model is organized around seven core concepts that give the system a complete picture of your life:
+The data model is organized around core entities that give the system a complete picture of your life:
+
+### The Seven Pillars
 
 | Pillar | What It Captures |
 |--------|-----------------|
@@ -30,6 +32,19 @@ The data model is organized around seven core concepts that give the system a co
 | **Activity Log** | What happened and how it felt, powering pattern recognition over time |
 
 Everything flows from domains down through goals and projects to tasks, with routines running in parallel and the activity log recording what actually happened. Claude uses this full picture to reason about priorities, spot avoidance patterns, and match work to capacity.
+
+### The Knowledge Layer (v1.2.0)
+
+v1.2.0 adds four entities that give the system persistent knowledge — documents, procedures, behavioral rules, and operating modes that carry context across sessions.
+
+| Entity | What It Captures |
+|--------|-----------------|
+| **Artifacts** | Living reference documents — briefs, templates, specs, prompts. Versioned, taggable, with parent/child hierarchy and 512KB content storage. |
+| **Protocols** | Step-by-step procedures stored as structured JSON. Linked to an optional source artifact. Versioned on update. |
+| **Directives** | Behavioral rules and guardrails with scoped priority (global, skill, or agent). The system's operating constraints. |
+| **Skills** | Named operating modes that bundle domains, protocols, and directives into a loadable context. The `get_skill_full` endpoint bootstraps an entire working context in one call. |
+
+Skills tie the knowledge layer together. A skill like "session-startup" links to the domains it covers, the protocols it follows, and the directives that constrain it — giving Claude a complete operating context loaded in a single request.
 
 ## Tech Stack
 
@@ -121,7 +136,7 @@ pip install -r requirements.txt
 alembic upgrade head
 ```
 
-This creates all seven pillar tables and their relationships.
+This creates all tables — the seven pillars, knowledge layer entities, tagging associations, and skill link tables.
 
 ### 5. Start the API
 
@@ -145,24 +160,53 @@ BRAIN 3.0's primary interface is Claude, connected through the Model Context Pro
 
 **[brain3-mcp](https://github.com/willim233/brain3-mcp)** — Claude MCP integration for BRAIN 3.0
 
-The MCP server translates Claude's tool calls into BRAIN 3.0 API requests, giving Claude full CRUD access to all seven pillars plus filtered queries, activity logging, and reporting endpoints. See the brain3-mcp README for setup instructions.
+The MCP server translates Claude's tool calls into BRAIN 3.0 API requests, giving Claude full access to all entities — the seven pillars, knowledge layer, batch operations, and reporting endpoints. 109 tools covering 109 API endpoints. See the brain3-mcp README for setup instructions.
 
-Once connected, Claude can manage your goals, create tasks matched to your energy level, track routine streaks, log activities, and surface patterns in how you work and feel over time.
+Once connected, Claude can manage your goals, create tasks matched to your energy level, track routine streaks, log activities, load operating contexts via skills, and surface patterns in how you work and feel over time.
 
 ## Project Status
 
-**v1.0.0 — Phase 1 Complete**
+**v1.2.0 — The Knowledge Layer**
 
-Phase 1 delivers the core data loop: database, API, and MCP integration. All seven pillar entities have full CRUD, filtered queries, and reporting endpoints. The system is stable — 293 tests passing, lint clean, CI green.
+The latest release adds persistent knowledge entities (Artifacts, Protocols, Directives, Skills), a batch API for bulk operations, and a seed framework for reproducible data loading. 109 API endpoints, 621 tests passing, lint clean, CI green.
 
 | Phase | Focus | Status |
 |-------|-------|--------|
-| **Phase 1** | Core loop — Database, FastAPI, MCP. Claude conversation only. | **Complete** |
+| **Phase 1** | Core loop — Database, FastAPI, MCP. Seven pillars, CRUD, reporting. | **Complete** (v1.0.0) |
+| **v1.1.0** | Activity tags — tagging on activity log entries | **Complete** |
+| **v1.2.0** | Knowledge layer — Artifacts, Protocols, Directives, Skills, Batch API, seed framework | **Complete** |
 | **Phase 2** | Proactive — Scheduler, Home Assistant integration, push notifications | Planned |
 | **Phase 3** | Web UI — Mobile-first dashboard, quick entry, visual reporting | Planned |
 | **Phase 4+** | Expand — New domains, voice, calendar, deeper HA automations | Planned |
 
 **What's not here yet:** No web UI, no authentication (single-user behind firewall), no scheduler or push notifications. Those are Phase 2 and 3.
+
+## Batch API
+
+v1.2.0 introduces batch endpoints for bulk operations. All batch creates are atomic — the entire batch succeeds or rolls back.
+
+**Batch create** (`POST /api/{entity}/batch`): Tasks, Activity, Artifacts (max 25), Protocols, Directives, Skills (max 100 each unless noted).
+
+**Batch tag** (`POST /api/{entity}/{id}/tags/batch`): Attach up to 100 tags in a single request. Supported on Tasks, Activity, and Artifacts.
+
+## Seed Framework
+
+Reproducible data seeding for bootstrapping new environments with starter protocols, directives, and skills.
+
+```bash
+# Load all seed data
+python scripts/seed_data.py
+
+# Preview without writing
+python scripts/seed_data.py --dry-run
+
+# Load a specific entity type
+python scripts/seed_data.py --only protocols
+```
+
+Seed data lives in `scripts/seeds/` as JSON files. The loader is idempotent (checks by name before creating) and resolves cross-references — skills reference protocols and directives by name, resolved to IDs at load time. Loading order: protocols → directives → skills.
+
+A content migration script (`scripts/migrate_to_artifacts.py`) is also available for migrating existing reference documents into the Artifacts entity.
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,9 +14,9 @@ For individual issue details, see the [GitHub Issues](https://github.com/WilliM2
 | Version | Name | Focus | Status |
 |---------|------|-------|--------|
 | **v1.0.0** | The Core Loop | Seven-pillar data model, full CRUD API, MCP integration, TrueNAS deployment | ✅ Shipped |
-| **v1.0.1** | Patch | Bug fix + license housekeeping | 🟡 Ready |
-| **v1.1.0** | Activity Tags | First feature release — tagging on activity log entries | 🟡 Design Complete |
-| **v1.2.0** | The Data Layer | Artifacts entity + batch-first API design | 📐 Needs Design |
+| **v1.0.1** | Patch | Bug fix + license housekeeping | ✅ Shipped |
+| **v1.1.0** | Activity Tags | Tagging on activity log entries | ✅ Shipped |
+| **v1.2.0** | The Knowledge Layer | Artifacts, Protocols, Directives, Skills, Batch API, seed framework | ✅ Shipped |
 | **v1.3.0** | Graduated Scaffolding | Routines that phase out support as habits solidify | 📐 Needs Design |
 | **v2.0.0** | The System Gets Proactive | Scheduler, Home Assistant integration, push notifications | 🔭 Planned |
 | **v3.0.0** | Browse and Manage Directly | Mobile-first web UI, dashboard, visual reporting | 🔭 Planned |
@@ -36,64 +36,37 @@ Quality: 293 unit tests, 131 UAT tests (128 pass, 0 fail, 3 partial — natural 
 
 ---
 
-## v1.0.1 — Patch 🟡
+## v1.0.1 — Patch ✅
 
-**Scope:** Bug fix + license housekeeping. No design decisions needed.
+**Shipped**
 
-| Issue | Title | Type |
-|-------|-------|------|
-| [#69](https://github.com/WilliM233/brain3/issues/69) | `progress_pct` returns 0% when completed tasks exist in project | Bug (minor) |
-| [#58](https://github.com/WilliM233/brain3/issues/58) | Add AGPL-3.0 header notices to source files | Chore |
-
-**Why this is first:** Clean up before building new. The progress bug affects project reporting accuracy. The AGPL headers are a legal best practice following the license switch from MIT (PR #57). Neither requires design — just execution.
-
-**Owner:** Desmond Ops (single pass)
+Bug fix + license housekeeping. Progress percentage fix and AGPL-3.0 header notices.
 
 ---
 
-## v1.1.0 — Activity Tags 🟡
+## v1.1.0 — Activity Tags ✅
 
-**Scope:** Tags on activity log entries. First feature release.
+**Shipped**
 
-| Issue | Title | Type |
-|-------|-------|------|
-| [#73](https://github.com/WilliM233/brain3/issues/73) | Tags on Activity Log Entries | Feature |
-
-**What it unlocks:**
-- **Session handoff filtering** — tag activity entries with `session-handoff` for clean context loading between sessions
-- **FluxNook media reviews** — log movie watches as tagged activity entries with mood, energy, and notes, queryable by tag
-- **Life logging** — the activity log becomes a flexible journal, not just a productivity tracker
-
-**Design:** Mirrors the existing `task_tags` many-to-many pattern. New `activity_tags` association table, tag/untag endpoints, tag filter on `list_activity`. Additive — no breaking changes.
-
-**Why this order:** Small scope, high value. Unlocks two major use cases (session handoffs and FluxNook) without requiring the larger architectural work of v1.2.0. Proves the release cadence works.
+Tags on activity log entries. Mirrors the `task_tags` pattern — `activity_tags` association table, tag/untag endpoints, tag filter on `list_activity`, reverse lookup. Unlocked session handoff filtering, FluxNook media reviews, and flexible life logging.
 
 ---
 
-## v1.2.0 — The Data Layer 📐
+## v1.2.0 — The Knowledge Layer ✅
 
-**Scope:** Artifacts entity + batch-first API. "It's all about storing data."
+**Shipped:** April 2026
 
-| Issue | Title | Type |
-|-------|-------|------|
-| [#74](https://github.com/WilliM233/brain3/issues/74) | Artifacts — living reference documents linked to tasks | Feature |
-| [#75](https://github.com/WilliM233/brain3/issues/75) | Batch-first API design for all current and future endpoints | Enhancement |
+**Scope:** Persistent knowledge entities, batch API, and seed framework. The release that gives the system memory across sessions.
 
-**Artifacts** — A new entity type for living reference materials (Release Playbook, Team Charter, agent briefs, design documents). Artifacts have their own lifecycle — they're consulted, versioned, and updated over time. They aren't tasks and they aren't activity log entries. Key design questions:
-- Schema: title, content/pointer, version, tags, origin task linkage
-- Versioning: do updates create new versions with history preserved?
-- Querying: independently searchable by tag, title, linked task
-- Phase 3 UI: artifacts give a "documents" view separate from the task list
-
-**Batch-first API** — Every entity that supports create, update, or attachment operations gets a batch variant. Discovered during production onboarding when 40+ tag operations hit Claude's tool call limits. Candidates: tag attachment, task creation, status updates, activity logging, check-in backfill. Design questions:
-- Endpoint pattern: `POST /api/{entity}/batch`
-- Transactional behavior: all-or-nothing vs. partial success (per endpoint)
-- Max batch size limits
-- MCP tool variants (e.g., `batch_tag_tasks`)
-
-**Why together:** Both are about how data gets into and lives inside BRAIN. Artifacts adds a new storage concept; batch-first makes existing storage faster. They complement each other and share the same release testing surface.
-
-**Open design work:** Both need dedicated design sessions before implementation.
+**What shipped:**
+- **Artifacts** — versioned reference documents with content storage (512KB), parent/child hierarchy, 7 type categories, tagging
+- **Protocols** — structured step-by-step procedures (JSON steps, max 50), linked to optional source artifacts, auto-versioned
+- **Directives** — behavioral rules with scoped priority (global/skill/agent), priority 1-10, directive resolution endpoint
+- **Skills** — named operating modes with many-to-many links to domains, protocols, and directives; `get_skill_full` bootstrap endpoint
+- **Batch API** — atomic bulk create for 6 entity types, batch tag attachment for 3 entity types
+- **Seed framework** — idempotent JSON-based data loading with cross-reference resolution, CLI tooling
+- **Content migration** — script for migrating existing reference documents into Artifacts
+- **109 API endpoints**, 621 tests, QA and security reviews complete
 
 ---
 
@@ -174,5 +147,5 @@ These guide every release decision:
 
 ---
 
-*Last updated: March 31, 2026*
+*Last updated: April 10, 2026*
 *BRAIN 3.0 · Project Flux Meridian*

--- a/docs/wiki/API-Overview.md
+++ b/docs/wiki/API-Overview.md
@@ -64,24 +64,29 @@ These filters are how Claude matches tasks to your current capacity — filterin
 
 ### Tags — `/api/tags`
 
-Cross-cutting labels for tasks. Tags have globally unique names (case-insensitive) with get-or-create behavior on POST.
+Cross-cutting labels for multiple entity types. Tags have globally unique names (case-insensitive) with get-or-create behavior on POST.
 
 | Method | Path | Purpose |
 |--------|------|---------|
 | `POST` | `/api/tags` | Create or retrieve an existing tag |
-| `GET` | `/api/tags` | List all tags |
+| `GET` | `/api/tags` | List all tags (searchable) |
 | `GET` | `/api/tags/{id}` | Get a tag |
 | `PATCH` | `/api/tags/{id}` | Update a tag |
 | `DELETE` | `/api/tags/{id}` | Delete a tag |
 | `GET` | `/api/tags/{id}/tasks` | List all tasks with this tag |
+| `GET` | `/api/tags/{id}/activities` | List all activity entries with this tag |
+| `GET` | `/api/tags/{id}/artifacts` | List all artifacts with this tag |
+| `GET` | `/api/tags/{id}/protocols` | List all protocols with this tag |
+| `GET` | `/api/tags/{id}/directives` | List all directives with this tag |
 
-**Task-tag associations:**
+**Tagging associations** follow the same pattern for all taggable entities (tasks, activity, artifacts, protocols, directives):
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| `GET` | `/api/tasks/{task_id}/tags` | List tags on a task |
-| `POST` | `/api/tasks/{task_id}/tags/{tag_id}` | Attach a tag to a task |
-| `DELETE` | `/api/tasks/{task_id}/tags/{tag_id}` | Detach a tag from a task |
+| `POST` | `/api/{entity}/{id}/tags/batch` | Attach multiple tags at once (max 100) |
+| `GET` | `/api/{entity}/{id}/tags` | List tags on an entity |
+| `POST` | `/api/{entity}/{id}/tags/{tag_id}` | Attach a single tag (idempotent) |
+| `DELETE` | `/api/{entity}/{id}/tags/{tag_id}` | Detach a tag |
 
 ### Routines — `/api/routines`
 
@@ -106,9 +111,69 @@ State snapshots (energy, mood, focus). CRUD with list filtering.
 
 ### Activity Log — `/api/activity`
 
-Record of what happened and how it felt. Each entry can reference a task, routine, and/or check-in.
+Record of what happened and how it felt. Each entry can reference a task, routine, and/or check-in. Activity entries are taggable (v1.1.0+).
 
-**List filters:** `action_type`, `task_id`, `routine_id`, `logged_after`, `logged_before` (date range), `has_task`, `has_routine`
+**List filters:** `action_type`, `task_id`, `routine_id`, `logged_after`, `logged_before` (date range), `has_task`, `has_routine`, `tag` (comma-separated, AND logic)
+
+---
+
+## Knowledge Layer (v1.2.0)
+
+Four entities that give the system persistent knowledge across sessions.
+
+### Artifacts — `/api/artifacts`
+
+Living reference documents stored with inline content (up to 512KB).
+
+**List filters:** `artifact_type`, `is_seedable`, `search` (title substring), `parent_id`, `tag`
+
+**Types:** document, protocol, brief, prompt, template, journal, spec
+
+### Protocols — `/api/protocols`
+
+Step-by-step procedures with structured JSON steps. Each protocol can link to a source artifact.
+
+**List filters:** `search`, `is_seedable`, `has_artifact`, `tag`
+
+### Directives — `/api/directives`
+
+Behavioral rules with scoped priority (global, skill, agent).
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/directives/resolve` | Merge directives for a skill + agent context, ordered by priority |
+
+**List filters:** `scope`, `scope_ref`, `is_seedable`, `priority_min`, `priority_max`, `search`, `tag`
+
+### Skills — `/api/skills`
+
+Named operating modes that bundle domains, protocols, and directives.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/skills/{id}/full` | Bootstrap — load complete skill context in one call |
+| `POST/DELETE` | `/api/skills/{id}/domains/{domain_id}` | Link/unlink a domain |
+| `POST/DELETE` | `/api/skills/{id}/protocols/{protocol_id}` | Link/unlink a protocol |
+| `POST/DELETE` | `/api/skills/{id}/directives/{directive_id}` | Link/unlink a directive |
+
+**List filters:** `search`, `is_seedable`, `is_default`, `domain_id`
+
+---
+
+## Batch API (v1.2.0)
+
+Bulk operations for reducing tool-call overhead. All batch creates are **atomic** — the entire batch succeeds or rolls back.
+
+| Method | Path | Max Items | Purpose |
+|--------|------|-----------|---------|
+| `POST` | `/api/tasks/batch` | 100 | Batch create tasks |
+| `POST` | `/api/activity/batch` | 100 | Batch create activity entries |
+| `POST` | `/api/artifacts/batch` | 25 | Batch create artifacts |
+| `POST` | `/api/protocols/batch` | 100 | Batch create protocols |
+| `POST` | `/api/directives/batch` | 100 | Batch create directives |
+| `POST` | `/api/skills/batch` | 100 | Batch create skills |
+
+Batch tag attachment is available for tasks, activity, and artifacts via `POST /api/{entity}/{id}/tags/batch` (max 100 tags).
 
 ---
 

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -79,26 +79,88 @@ This is what makes BRAIN a learning system. Claude uses the log to recognize pat
 
 ---
 
-## How the Pillars Relate
+## The Knowledge Layer (v1.2.0)
+
+v1.2.0 adds four entities that give the system persistent knowledge — documents, procedures, behavioral rules, and operating modes that carry context across sessions.
+
+### 8. Artifacts
+
+Living reference documents — briefs, templates, specs, prompts, journals. Artifacts have their own lifecycle: they're versioned (auto-incremented on content change), taggable, and organized in a parent/child hierarchy. Content is stored inline (up to 512KB) rather than as file pointers.
+
+**Types:** document, protocol, brief, prompt, template, journal, spec.
+
+**Key features:**
+- Self-referential parent/child tree for document organization
+- `is_seedable` flag marks artifacts eligible for automated seeding
+- Content size tracked as a computed field for monitoring
+
+### 9. Protocols
+
+Step-by-step procedures stored as structured JSON arrays. Each step has an `order`, `instruction`, and optional `detail` field. Protocols can link to a source artifact for richer context.
+
+**Key features:**
+- Structured `steps` field (max 50 per protocol) — not freeform text
+- Optional `artifact_id` linking back to a source document
+- Versioned on update (auto-incremented when steps or description change)
+- Unique name constraint
+
+### 10. Directives
+
+Behavioral rules and guardrails — the system's operating constraints. Directives have scoped priority:
+
+| Scope | Meaning |
+|-------|---------|
+| **global** | Applies everywhere, always |
+| **skill** | Applies when a specific skill is active (`scope_ref` = skill ID) |
+| **agent** | Applies to a specific agent context (`scope_ref` = agent ID) |
+
+**Priority:** 1-10 scale. When directives conflict, higher priority wins. The `resolve_directives` endpoint merges global + skill + agent directives into a single ordered set.
+
+### 11. Skills
+
+Named operating modes that bundle domains, protocols, and directives into a loadable context. Skills are the orchestration layer of the knowledge system.
+
+**Relationships (many-to-many):**
+- **Domains** — which life areas this skill covers
+- **Protocols** — which procedures this skill follows
+- **Directives** — which behavioral rules constrain this skill
+
+**Key features:**
+- `get_skill_full` — bootstrap endpoint that loads the complete skill context (skill + all linked protocols, directives grouped by scope) in one call
+- `is_default` flag — marks a single system-wide default skill
+- Link/unlink endpoints for managing all three relationship types
+
+---
+
+## How the Entities Relate
 
 ```
 Domains
-  └── Goals
-        └── Projects
-              └── Tasks ←→ Tags (cross-cutting)
+  ├── Goals
+  │     └── Projects
+  │           └── Tasks ←→ Tags (cross-cutting)
   └── Routines
         └── Routine Schedules
 
 Check-ins (standalone — capture state at any time)
 
-Activity Log (references tasks, routines, and/or check-ins)
+Activity Log (references tasks, routines, and/or check-ins) ←→ Tags
+
+Artifacts ←→ Tags
+  └── Protocols ←→ Tags
+
+Directives ←→ Tags
+
+Skills ──┬── Domains (many-to-many)
+         ├── Protocols (many-to-many)
+         └── Directives (many-to-many)
 ```
 
-Domains contain goals and routines. Goals contain projects. Projects contain tasks. Tasks can be tagged for connections that cut across the hierarchy (e.g., "home-depot" tags tasks in multiple projects).
+The seven pillars handle life management — goals, tasks, routines, and behavioral tracking. The knowledge layer handles operational context — what documents to consult, what procedures to follow, what rules to obey, and how to bundle all of that into a named operating mode.
 
-Check-ins are standalone — they capture how you're feeling without being tied to a specific action.
+Tags cut across both layers. Any taggable entity (tasks, activity, artifacts, protocols, directives) can be tagged for cross-cutting queries. The `list_tagged_*` pattern provides reverse lookups from tag to entities.
 
-The activity log ties everything together. Each entry can reference a task, a routine, and/or a check-in, recording what happened and how it felt. The four reporting endpoints aggregate this data to surface patterns.
+The activity log ties the pillars together. Each entry can reference a task, a routine, and/or a check-in, recording what happened and how it felt. The four reporting endpoints aggregate this data to surface patterns.
 
 ---
 

--- a/docs/wiki/Development-Guide.md
+++ b/docs/wiki/Development-Guide.md
@@ -94,7 +94,7 @@ ruff check .           # Lint
 
 - Every API endpoint gets: happy path, validation, not found (404), and filter tests
 - Tests must be independent — each creates its own data
-- Use the helper fixtures in `tests/conftest.py` (`make_domain`, `make_goal`, `make_task`, etc.)
+- Use the helper fixtures in `tests/conftest.py` (`make_domain`, `make_goal`, `make_task`, `make_artifact`, `make_protocol`, `make_directive`, `make_skill`, etc.)
 
 ---
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -6,8 +6,8 @@ BRAIN 3.0 is a personal life management system designed to work with how an ADHD
 
 This is not a task manager. It's a system that has initiative, not just memory.
 
-**Version:** 1.0.0 (Phase 1 complete)
-**Status:** Core data loop — database, API, and MCP integration — is stable and deployed. 283+ tests passing, CI green, production running on TrueNAS.
+**Version:** 1.2.0
+**Status:** Core data loop plus knowledge layer — database, API, and MCP integration — stable and deployed. 621 tests passing, CI green, production running on TrueNAS.
 
 ---
 
@@ -15,11 +15,11 @@ This is not a task manager. It's a system that has initiative, not just memory.
 
 | Page | What's There |
 |------|-------------|
-| [Architecture](Architecture.md) | The seven pillars, how they relate, ADHD-specific design principles, and key design decisions |
-| [API Overview](API-Overview.md) | Endpoint groups, what each covers, query filters, reporting endpoints |
+| [Architecture](Architecture.md) | The seven pillars, knowledge layer, how they relate, ADHD-specific design principles, and key design decisions |
+| [API Overview](API-Overview.md) | Endpoint groups, what each covers, query filters, batch API, reporting endpoints |
 | [MCP Setup](MCP-Setup.md) | How to connect Claude to BRAIN 3.0 via the Model Context Protocol |
 | [Development Guide](Development-Guide.md) | Developer workflow, git conventions, PR process, testing |
-| [Roadmap](Roadmap.md) | Phase 1 (complete) through Phase 4+ (vision) — what's built, what's planned, what's speculative |
+| [Roadmap](Roadmap.md) | Release history through Phase 4+ (vision) — what's built, what's planned, what's speculative |
 
 ## Key Resources
 
@@ -34,7 +34,7 @@ This is not a task manager. It's a system that has initiative, not just memory.
 
 ## What's Not Here Yet
 
-Phase 1 delivers the core data loop: Claude can manage your goals, tasks, routines, and patterns through conversation. What's **not** in v1.0.0:
+v1.2.0 delivers the core data loop plus persistent knowledge: Claude can manage your goals, tasks, routines, patterns, reference documents, and operating contexts through conversation. What's **not** here yet:
 
 - No web UI (Phase 3)
 - No authentication — single-user system behind a firewall (Phase 3)

--- a/docs/wiki/MCP-Setup.md
+++ b/docs/wiki/MCP-Setup.md
@@ -16,16 +16,18 @@ The MCP server does not store data — it's a translation layer. All state lives
 
 ## What Claude Can Do
 
-With the MCP connected, Claude has access to:
+With the MCP connected, Claude has access to 109 tools covering the full API:
 
-- **Full CRUD** on all seven pillar entities — create, read, update, delete domains, goals, projects, tasks, routines, check-ins, and activity log entries
+- **Full CRUD** on all entities — domains, goals, projects, tasks, routines, check-ins, activity log, artifacts, protocols, directives, and skills
 - **Filtered queries** — find tasks by energy level, cognitive type, context, due date, and more
-- **Tag management** — create tags, attach/detach them from tasks, query tasks by tag
+- **Tag management** — create tags, attach/detach from multiple entity types, reverse lookup by tag
+- **Knowledge system** — load operating contexts via skills, resolve directives by scope, follow protocols
+- **Batch operations** — bulk create entities and attach tags in single calls
 - **Routine management** — complete routines, manage schedules, track streaks
 - **Reporting** — activity summaries, domain balance, routine adherence, friction analysis
 - **Health check** — verify the API and database are connected
 
-This gives Claude enough context to act as a partner: reasoning about priorities, noticing neglected areas, matching tasks to current capacity, and surfacing patterns from the activity log.
+This gives Claude enough context to act as a partner: reasoning about priorities, noticing neglected areas, matching tasks to current capacity, loading full operating contexts via skills, and surfacing patterns from the activity log.
 
 ---
 

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -14,14 +14,43 @@ The data foundation and conversational interface. Claude has full read/write acc
 
 - **PostgreSQL database** on Docker with all seven pillar tables and relationships
 - **FastAPI REST API** with full CRUD, composable query filters, and four reporting endpoints
-- **Claude MCP integration** via [brain3-mcp](https://github.com/WilliM233/brain3-mcp) — 50+ tools covering all entities
+- **Claude MCP integration** via [brain3-mcp](https://github.com/WilliM233/brain3-mcp) — 57 tools covering all entities
 - **ADHD-aware task metadata** — energy cost, cognitive type, activation friction, context requirements
 - **Routine system** with streak tracking, flexible scheduling, and pattern break detection
 - **Activity logging** with subjective metadata (energy before/after, actual friction, mood)
 - **Reporting** — activity summaries, domain balance, routine adherence, friction analysis
 - **Production deployment** on TrueNAS with Docker Compose, automated migrations, nightly backups
-- **CI pipeline** — 283+ tests, Ruff lint, GitHub Actions
+- **CI pipeline** — 293 tests, Ruff lint, GitHub Actions
 - **Documentation** — README, developer setup, deployment guide, environment reference, wiki
+
+---
+
+## v1.1.0 — Activity Tags ✓
+
+**Status: Complete**
+
+Tagging on activity log entries. Mirrors the existing task tags pattern — `activity_tags` association table, tag/untag endpoints, tag filter on `list_activity`, and reverse lookup via `list_tagged_activities`.
+
+---
+
+## v1.2.0 — The Knowledge Layer ✓
+
+**Status: Complete** (April 2026)
+
+Persistent knowledge entities, batch API, and seed framework. The system gains memory that persists across sessions.
+
+### What's Delivered
+
+- **Artifacts** — versioned reference documents with content storage (512KB), parent/child hierarchy, tagging, and 7 type categories
+- **Protocols** — structured step-by-step procedures (JSON steps, max 50), linked to optional source artifacts, versioned on update
+- **Directives** — behavioral rules with scoped priority (global/skill/agent), priority 1-10, and directive resolution endpoint
+- **Skills** — named operating modes with many-to-many links to domains, protocols, and directives; `get_skill_full` bootstrap endpoint
+- **Batch API** — atomic bulk create for 6 entity types (tasks, activity, artifacts, protocols, directives, skills) and batch tag attachment for 3 entity types
+- **Seed framework** — idempotent JSON-based data loading with cross-reference resolution, CLI flags for dry-run and entity filtering
+- **Content migration** — script for migrating existing reference documents into the Artifacts entity
+- **Expanded tagging** — tags on artifacts, protocols, and directives with reverse lookups from tag to entity
+- **MCP coverage** — 109 tools (52 new) covering all new entities and batch operations
+- **Quality** — 621 tests passing, lint clean, CI green, QA and security reviews complete
 
 ### What's Not Here
 
@@ -46,7 +75,6 @@ The system transitions from responsive to proactive. Claude reaches out rather t
 - **Morning briefings** — daily summary of what's on deck, routine status, and relevant context
 - **Accountability nudges** — missed routine alerts, deadline warnings, neglected domain flags
 - **MCP composite tools** — higher-level operations that combine multiple API calls (e.g., "complete routine + log activity + check in" as a single tool)
-- **Modular MCP refactoring** — splitting the monolithic `server.py` into per-entity tool modules as composite tools justify the structure
 
 ### What This Changes
 
@@ -97,10 +125,10 @@ All of it. Phase 4+ items are ideas that emerged from the design process and rep
 ## How Phases Build on Each Other
 
 ```
-Phase 1:  Data + API + Claude conversation
-Phase 2:  + Scheduler + Notifications + Home Assistant
-Phase 3:  + Web UI + Auth + Visual reporting
-Phase 4+: + New domains + Voice + Calendar + Ambient
+Phase 1 (v1.0–1.2): Data + API + Knowledge layer + Claude conversation
+Phase 2:            + Scheduler + Notifications + Home Assistant
+Phase 3:            + Web UI + Auth + Visual reporting
+Phase 4+:           + New domains + Voice + Calendar + Ambient
 ```
 
-Each phase adds a capability layer without modifying the previous one. The API and data model from Phase 1 serve all future phases. The MCP contract from Phase 1 extends in Phase 2 with composite tools. The reporting from Phase 1 gets a visual representation in Phase 3.
+Each phase adds a capability layer without modifying the previous one. The API and data model from Phase 1 serve all future phases. The MCP contract extends in Phase 2 with composite tools. The reporting gets a visual representation in Phase 3.


### PR DESCRIPTION
## Summary

Documentation update reflecting the v1.2.0 Knowledge Layer release across all developer-facing docs. A new developer cloning this repo should be able to understand the full system — seven pillars plus knowledge layer — from these docs alone.

## Changes

- **README.md** — Added Knowledge Layer architecture section (Artifacts, Protocols, Directives, Skills), Batch API and Seed Framework sections, updated MCP description with tool count (109), updated Project Status to v1.2.0 with 621 tests, updated migration description
- **CHANGELOG.md** — Restructured from single Unreleased block into versioned sections (v1.2.0, v1.1.0, v1.0.1, v1.0.0) with proper Added/Fixed/Changed categorization
- **ROADMAP.md** — Marked v1.0.1, v1.1.0, v1.2.0 as shipped with delivery summaries, updated last-modified date
- **docs/wiki/Home.md** — Updated version to 1.2.0, test count to 621, page descriptions to include knowledge layer
- **docs/wiki/Architecture.md** — Added full Knowledge Layer section (entities 8-11), updated relationship diagram to show knowledge layer and tag cross-cutting
- **docs/wiki/API-Overview.md** — Added Knowledge Layer endpoints section (Artifacts, Protocols, Directives, Skills), Batch API section, expanded Tags section with reverse lookups and batch tag pattern
- **docs/wiki/MCP-Setup.md** — Updated "What Claude Can Do" to reflect 109 tools, knowledge system, and batch operations
- **docs/wiki/Development-Guide.md** — Updated test fixture reference to include new entity helpers
- **docs/wiki/Roadmap.md** — Added v1.1.0 and v1.2.0 shipped sections, removed delivered Phase 2 item (MCP modularization), updated phase diagram

## How to Verify

1. Read the README — verify architecture section covers both pillars and knowledge layer, status shows v1.2.0, endpoint/test counts match reality (109 endpoints, 621 tests)
2. Check CHANGELOG has versioned sections with correct issue references
3. Check ROADMAP has v1.0.1/v1.1.0/v1.2.0 marked as shipped
4. Browse wiki pages — Architecture should describe all 11 entity types, API Overview should cover knowledge layer and batch endpoints

## Deviations

- CHANGELOG was restructured from a single "Unreleased" block into proper versioned sections. The v1.0.0 entries were preserved as-is; v1.0.1, v1.1.0, and v1.2.0 sections were added based on git history and PR records.
- The Architecture wiki page numbers the knowledge layer entities 8-11, continuing from the seven pillars, to give them first-class status rather than treating them as supplementary.

## Test Results

Documentation-only change. No tests affected.

## Acceptance Checklist

- [x] README reflects v1.2.0 entities, batch API, seed framework
- [x] Wiki Architecture page covers all entity types
- [x] Wiki API Overview covers knowledge layer and batch endpoints
- [x] Wiki MCP Setup reflects 109 tools
- [x] ROADMAP shows v1.2.0 as shipped
- [x] CHANGELOG has proper versioned sections
- [x] No application code modified

Closes #115