### PR TITLE
2A-01: Habits table, model, and enums

### DIFF
--- a/alembic/versions/007_create_habits_table.py
+++ b/alembic/versions/007_create_habits_table.py
@@ -1,0 +1,115 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""create habits table
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-04-12 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f6a7b8c9d0e1"
+down_revision: Union[str, None] = "e5f6a7b8c9d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "habits",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "routine_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("routines.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False, server_default="active"),
+        sa.Column("frequency", sa.String(), nullable=True),
+        sa.Column(
+            "notification_frequency", sa.String(), nullable=False, server_default="none",
+        ),
+        sa.Column(
+            "scaffolding_status", sa.String(), nullable=False, server_default="tracking",
+        ),
+        sa.Column("introduced_at", sa.Date(), nullable=True),
+        sa.Column("graduation_window", sa.Integer(), nullable=True, server_default="30"),
+        sa.Column(
+            "graduation_target",
+            sa.Numeric(precision=3, scale=2),
+            nullable=True,
+            server_default="0.85",
+        ),
+        sa.Column(
+            "graduation_threshold", sa.Integer(), nullable=True, server_default="30",
+        ),
+        sa.Column(
+            "current_streak", sa.Integer(), nullable=False, server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "best_streak", sa.Integer(), nullable=False, server_default=sa.text("0"),
+        ),
+        sa.Column("last_completed", sa.Date(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "status IN ('active', 'paused', 'graduated', 'abandoned')",
+            name="ck_habits_status",
+        ),
+        sa.CheckConstraint(
+            "frequency IN ('daily', 'weekdays', 'weekends', 'weekly', 'custom') "
+            "OR frequency IS NULL",
+            name="ck_habits_frequency",
+        ),
+        sa.CheckConstraint(
+            "notification_frequency IN ("
+            "'daily', 'every_other_day', 'twice_week', 'weekly', 'graduated', 'none')",
+            name="ck_habits_notification_frequency",
+        ),
+        sa.CheckConstraint(
+            "scaffolding_status IN ('tracking', 'accountable', 'graduated')",
+            name="ck_habits_scaffolding_status",
+        ),
+    )
+    op.create_index("ix_habits_status", "habits", ["status"])
+    op.create_index("ix_habits_routine_id", "habits", ["routine_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_habits_routine_id", table_name="habits")
+    op.drop_index("ix_habits_status", table_name="habits")
+    op.drop_table("habits")

--- a/app/models.py
+++ b/app/models.py
@@ -29,12 +29,13 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    Numeric,
     String,
     Text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from sqlalchemy.sql import func
+from sqlalchemy.sql import func, text
 
 from app.database import Base
 
@@ -419,6 +420,9 @@ class Routine(Base):
     schedules: Mapped[list["RoutineSchedule"]] = relationship(
         back_populates="routine", cascade="all, delete-orphan",
     )
+    habits: Mapped[list["Habit"]] = relationship(
+        back_populates="routine", cascade="all, delete-orphan",
+    )
     activity_logs: Mapped[list["ActivityLog"]] = relationship(back_populates="routine")
 
 
@@ -439,6 +443,80 @@ class RoutineSchedule(Base):
 
     # Relationships
     routine: Mapped["Routine"] = relationship(back_populates="schedules")
+
+
+# ---------------------------------------------------------------------------
+# Habits — atomic behavioral units (standalone or under a routine)
+# ---------------------------------------------------------------------------
+
+class Habit(Base):
+    """Atomic behavioral unit that can exist standalone or nested under a routine."""
+
+    __tablename__ = "habits"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4,
+    )
+    routine_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("routines.id", ondelete="CASCADE"),
+    )
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(
+        String, nullable=False, server_default="active",
+    )
+    frequency: Mapped[str | None] = mapped_column(String)
+    notification_frequency: Mapped[str] = mapped_column(
+        String, nullable=False, server_default="none",
+    )
+    scaffolding_status: Mapped[str] = mapped_column(
+        String, nullable=False, server_default="tracking",
+    )
+    introduced_at: Mapped[date | None] = mapped_column(Date)
+    graduation_window: Mapped[int | None] = mapped_column(Integer, default=30)
+    graduation_target: Mapped[float | None] = mapped_column(
+        Numeric(precision=3, scale=2), default=0.85,
+    )
+    graduation_threshold: Mapped[int | None] = mapped_column(Integer, default=30)
+    current_streak: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0"),
+    )
+    best_streak: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0"),
+    )
+    last_completed: Mapped[date | None] = mapped_column(Date)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('active', 'paused', 'graduated', 'abandoned')",
+            name="ck_habits_status",
+        ),
+        CheckConstraint(
+            "frequency IN ('daily', 'weekdays', 'weekends', 'weekly', 'custom') "
+            "OR frequency IS NULL",
+            name="ck_habits_frequency",
+        ),
+        CheckConstraint(
+            "notification_frequency IN ("
+            "'daily', 'every_other_day', 'twice_week', 'weekly', 'graduated', 'none')",
+            name="ck_habits_notification_frequency",
+        ),
+        CheckConstraint(
+            "scaffolding_status IN ('tracking', 'accountable', 'graduated')",
+            name="ck_habits_scaffolding_status",
+        ),
+        Index("ix_habits_status", "status"),
+        Index("ix_habits_routine_id", "routine_id"),
+    )
+
+    # Relationships
+    routine: Mapped["Routine | None"] = relationship(back_populates="habits")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds the `habits` table as the foundation for Phase 2 Stream A. Habits are atomic behavioral units that can exist standalone or nested under a routine (container/habit hierarchy). This ticket defines the schema, model, and all associated enums — no CRUD, no Pydantic schemas, no graduation logic.

Closes #83

## Changes
- **`alembic/versions/007_create_habits_table.py`** — New migration creating the `habits` table with all 18 columns, 4 check constraints (`ck_habits_status`, `ck_habits_frequency`, `ck_habits_notification_frequency`, `ck_habits_scaffolding_status`), and 2 indexes (`ix_habits_status`, `ix_habits_routine_id`). Forward and backward operations defined.
- **`app/models.py`** — Added `Habit` model class with all columns matching the migration. Added `Numeric` and `text` imports. Added `habits` relationship to the existing `Routine` model with `cascade="all, delete-orphan"` and `back_populates="routine"`.

### Key design decisions per issue spec:
- **Two frequency fields**: `frequency` (behavioral, nullable — habits under a routine can inherit from parent) and `notification_frequency` (graduated cadence, defaults to `"none"`). Distinct concepts, not conflated.
- **Graduated scaffolding fields** (`scaffolding_status`, `graduation_window`, `graduation_target`, `graduation_threshold`) are schema-only — evaluation logic is Stream G.
- **All integer streak columns** use `server_default=text("0")` at DB level per acceptance criteria.
- **`introduced_at`** is `Date`, not `DateTime` (resolution #4).
- **`graduation_target`** is `Numeric(3,2)` (resolution #5).
- **Cascade pattern** matches Domain → Goal → Project → Task. Nullable FK allows standalone habits.

## How to Verify
1. `git checkout feature/2A-01-habits-table-model-enums`
2. `docker compose up -d` (or equivalent to start the DB)
3. `alembic upgrade head` — confirm migration 007 applies cleanly
4. `alembic downgrade -1` — confirm it rolls back cleanly
5. `alembic upgrade head` — re-apply
6. Inspect the `habits` table in psql: verify all columns, constraints, indexes, and the FK to `routines`
7. `pytest -v` — all 621 existing tests pass
8. `ruff check .` — clean lint

## Deviations
None

## Test Results
```
$ pytest -v
============================= 621 passed in 7.43s =============================

$ ruff check .
All checks passed!
```

Note: Alembic migration could not be tested directly from host (DB host `db` is Docker-internal). Migration forward/backward verification requires `docker compose exec` or equivalent. The SQLAlchemy model is validated by the full test suite which creates all tables via `Base.metadata.create_all`.

## Acceptance Checklist
- [x] Alembic migration `007_create_habits_table.py` creates `habits` table with all columns
- [x] FK `routine_id` → `routines.id` with ON DELETE CASCADE, nullable
- [x] All integer streak columns use `server_default=text("0")` at DB level
- [x] `status` check constraint: `active`, `paused`, `graduated`, `abandoned`
- [x] `frequency` check constraint: `daily`, `weekdays`, `weekends`, `weekly`, `custom` OR NULL
- [x] `notification_frequency` check constraint: `daily`, `every_other_day`, `twice_week`, `weekly`, `graduated`, `none` — default `none`
- [x] `scaffolding_status` check constraint: `tracking`, `accountable`, `graduated` — default `tracking`
- [x] `introduced_at` is Date type, NOT DateTime
- [x] `graduation_window` is Integer (days)
- [x] `graduation_target` is Numeric(3,2)
- [x] `graduation_threshold` is Integer (days)
- [x] `best_streak` and `last_completed` field names match routine convention
- [x] Habit model class added to `app/models.py` following existing patterns
- [x] Routine model updated with `habits` relationship (`cascade="all, delete-orphan"`)
- [x] Indexes created: `ix_habits_status`, `ix_habits_routine_id`
- [x] Migration runs cleanly forward and backward (structure verified; DB test requires Docker)