### PR TITLE
2A-02: Habit completion records table

### DIFF
--- a/alembic/versions/008_create_habit_completions.py
+++ b/alembic/versions/008_create_habit_completions.py
@@ -16,7 +16,7 @@
 
 """create habit_completions table
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: 08a1b2c3d4e5
 Revises: f6a7b8c9d0e1
 Create Date: 2026-04-12 00:00:00.000000
 
@@ -29,7 +29,7 @@ from sqlalchemy.dialects import postgresql
 
 
 # revision identifiers, used by Alembic.
-revision: str = "a1b2c3d4e5f6"
+revision: str = "08a1b2c3d4e5"
 down_revision: Union[str, None] = "f6a7b8c9d0e1"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/alembic/versions/008_create_habit_completions.py
+++ b/alembic/versions/008_create_habit_completions.py
@@ -1,0 +1,60 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""create habit_completions table
+
+Revision ID: a1b2c3d4e5f6
+Revises: f6a7b8c9d0e1
+Create Date: 2026-04-12 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "f6a7b8c9d0e1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "habit_completions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("habit_id", postgresql.UUID(as_uuid=True),
+                  sa.ForeignKey("habits.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("completed_at", sa.Date(), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("habit_id", "completed_at",
+                            name="uq_habit_completions_habit_date"),
+        sa.CheckConstraint(
+            "source IN ('individual', 'routine_cascade', 'reconciliation')",
+            name="ck_habit_completions_source",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("habit_completions")

--- a/app/models.py
+++ b/app/models.py
@@ -32,6 +32,7 @@ from sqlalchemy import (
     Numeric,
     String,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -517,6 +518,48 @@ class Habit(Base):
 
     # Relationships
     routine: Mapped["Routine | None"] = relationship(back_populates="habits")
+    completions: Mapped[list["HabitCompletion"]] = relationship(
+        back_populates="habit", cascade="all, delete-orphan",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Habit Completions — per-event completion records
+# ---------------------------------------------------------------------------
+
+class HabitCompletion(Base):
+    """Record of a single habit completion event."""
+
+    __tablename__ = "habit_completions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4,
+    )
+    habit_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("habits.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    completed_at: Mapped[date] = mapped_column(Date, nullable=False)
+    source: Mapped[str] = mapped_column(String, nullable=False)
+    notes: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "habit_id", "completed_at",
+            name="uq_habit_completions_habit_date",
+        ),
+        CheckConstraint(
+            "source IN ('individual', 'routine_cascade', 'reconciliation')",
+            name="ck_habit_completions_source",
+        ),
+    )
+
+    # Relationships
+    habit: Mapped["Habit"] = relationship(back_populates="completions")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds the `habit_completions` table — a per-event record of each time a habit is completed. This is the foundation for idempotent completion enforcement (resolution #13), streak evaluation, and future graduated scaffolding rate calculations. Each record tracks the logical date and how the completion was recorded (individual, routine cascade, or reconciliation).

Closes #92

## Changes
- **`app/models.py`** — Added `HabitCompletion` model with UUID primary key, `habit_id` FK (CASCADE), `completed_at` date, `source` string with check constraint, optional `notes`, and `created_at` with server default. Added `UniqueConstraint("habit_id", "completed_at")` to enforce one completion per habit per calendar day. Added `completions` relationship on the `Habit` model with `cascade="all, delete-orphan"`. Imported `UniqueConstraint` from SQLAlchemy.
- **`alembic/versions/008_create_habit_completions.py`** — Forward migration creates `habit_completions` table with all columns, FK, unique constraint, and source check constraint. Downgrade drops the table.

## How to Verify
1. `git checkout feature/2A-02-habit-completion-records`
2. `alembic upgrade head` — migration 008 applies cleanly
3. Inspect the `habit_completions` table in Postgres — confirm columns, FK, unique constraint `uq_habit_completions_habit_date`, and check constraint `ck_habit_completions_source`
4. `alembic downgrade -1` — table drops cleanly
5. `alembic upgrade head` — re-apply to confirm round-trip
6. `pytest -v` — 621 tests pass, no regressions

## Deviations
None

## Test Results
```
============================= 621 passed in 8.14s =============================
```
`ruff check .` — All checks passed.

## Acceptance Checklist
- [x] Alembic migration `008_create_habit_completions.py` creates `habit_completions` table
- [x] FK `habit_id` → `habits.id` with ON DELETE CASCADE
- [x] Unique constraint on `(habit_id, completed_at)` — enforces one completion per habit per calendar day
- [x] `source` check constraint enforces: `individual`, `routine_cascade`, `reconciliation`
- [x] Composite index on `(habit_id, completed_at)` for rate calculation queries (implicitly created by unique constraint)
- [x] `created_at` has server_default=func.now()
- [x] Habit model updated with `completions` relationship (`cascade="all, delete-orphan"`)
- [x] Migration runs cleanly forward and backward