### PR TITLE
2A-03: Routine completion records table

### DIFF
--- a/alembic/versions/009_create_routine_completions.py
+++ b/alembic/versions/009_create_routine_completions.py
@@ -1,0 +1,71 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""create routine_completions table
+
+Revision ID: 09b2c3d4e5f6
+Revises: 08a1b2c3d4e5
+Create Date: 2026-04-12 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "09b2c3d4e5f6"
+down_revision: Union[str, None] = "08a1b2c3d4e5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "routine_completions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("routine_id", postgresql.UUID(as_uuid=True),
+                  sa.ForeignKey("routines.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("completed_at", sa.Date(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("freeform_note", sa.Text(), nullable=True),
+        sa.Column("reconciled", sa.Boolean(), nullable=False,
+                  server_default=sa.text("false")),
+        sa.Column("reconciled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('all_done', 'partial', 'skipped')",
+            name="ck_routine_completions_status",
+        ),
+    )
+    op.create_index(
+        "ix_routine_completions_routine_completed",
+        "routine_completions",
+        ["routine_id", "completed_at"],
+    )
+    op.create_index(
+        "ix_routine_completions_reconciled",
+        "routine_completions",
+        ["reconciled"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_routine_completions_reconciled", table_name="routine_completions")
+    op.drop_index("ix_routine_completions_routine_completed", table_name="routine_completions")
+    op.drop_table("routine_completions")

--- a/app/models.py
+++ b/app/models.py
@@ -424,6 +424,9 @@ class Routine(Base):
     habits: Mapped[list["Habit"]] = relationship(
         back_populates="routine", cascade="all, delete-orphan",
     )
+    completions: Mapped[list["RoutineCompletion"]] = relationship(
+        back_populates="routine", cascade="all, delete-orphan",
+    )
     activity_logs: Mapped[list["ActivityLog"]] = relationship(back_populates="routine")
 
 
@@ -560,6 +563,49 @@ class HabitCompletion(Base):
 
     # Relationships
     habit: Mapped["Habit"] = relationship(back_populates="completions")
+
+
+# ---------------------------------------------------------------------------
+# Routine Completions — per-event routine completion records
+# ---------------------------------------------------------------------------
+
+class RoutineCompletion(Base):
+    """Record of a single routine completion event."""
+
+    __tablename__ = "routine_completions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4,
+    )
+    routine_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("routines.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    completed_at: Mapped[date] = mapped_column(Date, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    freeform_note: Mapped[str | None] = mapped_column(Text)
+    reconciled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false"),
+    )
+    reconciled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('all_done', 'partial', 'skipped')",
+            name="ck_routine_completions_status",
+        ),
+        Index(
+            "ix_routine_completions_routine_completed",
+            "routine_id", "completed_at",
+        ),
+        Index("ix_routine_completions_reconciled", "reconciled"),
+    )
+
+    # Relationships
+    routine: Mapped["Routine"] = relationship(back_populates="completions")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds the `routine_completions` table — a per-event record of each time a routine is completed (or partially completed / skipped). This is the foundation for the partial/reconciliation design (escalation resolution #8), enabling Claude to query unreconciled partial completions and follow up with the user about what was missed.

Closes #91

## Changes
- **`app/models.py`** — Added `RoutineCompletion` model with UUID primary key, `routine_id` FK (CASCADE), `completed_at` date, `status` string with check constraint (`all_done`/`partial`/`skipped`), optional `freeform_note` for reconciliation context, `reconciled` boolean (server_default=false), and nullable `reconciled_at` timestamp. Added composite index on `(routine_id, completed_at)` and index on `reconciled`. Added `completions` relationship on the `Routine` model with `cascade="all, delete-orphan"`.
- **`alembic/versions/009_create_routine_completions.py`** — Forward migration creates `routine_completions` table with all columns, FK, check constraint, and both indexes. Downgrade drops indexes then the table.

## How to Verify
1. `git checkout feature/2A-03-routine-completion-records`
2. `alembic upgrade head` — migration 009 applies cleanly
3. Inspect the `routine_completions` table in Postgres — confirm columns, FK, check constraint `ck_routine_completions_status`, composite index `ix_routine_completions_routine_completed`, and reconciled index `ix_routine_completions_reconciled`
4. Verify `reconciled` column defaults to `false`
5. `alembic downgrade -1` — table and indexes drop cleanly
6. `alembic upgrade head` — re-apply to confirm round-trip
7. `pytest -v` — 621 tests pass, no regressions

## Deviations
None

## Test Results
```
============================= 621 passed in 9.38s =============================
```
`ruff check .` — All checks passed.

## Acceptance Checklist
- [x] Alembic migration `009_create_routine_completions.py` creates `routine_completions` table
- [x] FK `routine_id` → `routines.id` with ON DELETE CASCADE
- [x] `status` check constraint enforces: `all_done`, `partial`, `skipped`
- [x] `reconciled` defaults to false at server level (`server_default`)
- [x] Composite index on `(routine_id, completed_at)` for query performance
- [x] Index on `reconciled` for unreconciled partial queries
- [x] Routine model updated with `completions` relationship (`cascade="all, delete-orphan"`)
- [x] Migration runs cleanly forward and backward