### PR TITLE
2A-05: Habits CRUD endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.routers import (
     directives,
     domains,
     goals,
+    habits,
     projects,
     protocols,
     reports,
@@ -77,6 +78,7 @@ app.include_router(projects.router, prefix="/api/projects", tags=["Projects"])
 app.include_router(tasks.router, prefix="/api/tasks", tags=["Tasks"])
 app.include_router(tags.router, prefix="/api/tags", tags=["Tags"])
 app.include_router(routines.router, prefix="/api/routines", tags=["Routines"])
+app.include_router(habits.router, prefix="/api/habits", tags=["Habits"])
 app.include_router(checkins.router, prefix="/api/checkins", tags=["Check-ins"])
 app.include_router(activity.router, prefix="/api/activity", tags=["Activity Log"])
 app.include_router(reports.router, prefix="/api/reports", tags=["Reports"])

--- a/app/routers/habits.py
+++ b/app/routers/habits.py
@@ -1,0 +1,130 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""CRUD endpoints for Habits."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session, joinedload
+
+from app.database import get_db
+from app.models import Habit, Routine
+from app.schemas.habits import (
+    HabitCreate,
+    HabitDetailResponse,
+    HabitResponse,
+    HabitUpdate,
+)
+
+router = APIRouter()
+
+
+@router.post("/", response_model=HabitResponse, status_code=status.HTTP_201_CREATED)
+def create_habit(payload: HabitCreate, db: Session = Depends(get_db)) -> Habit:
+    """Create a new habit. Validates routine_id if provided."""
+    if payload.routine_id is not None:
+        routine = db.query(Routine).filter(Routine.id == payload.routine_id).first()
+        if not routine:
+            raise HTTPException(status_code=400, detail="Routine not found")
+
+    habit = Habit(**payload.model_dump())
+    db.add(habit)
+    db.commit()
+    db.refresh(habit)
+    return habit
+
+
+@router.get("/", response_model=list[HabitResponse])
+def list_habits(
+    routine_id: UUID | None = Query(None),
+    habit_status: str | None = Query(None, alias="status"),
+    scaffolding_status: str | None = Query(None),
+    db: Session = Depends(get_db),
+) -> list[Habit]:
+    """List habits with composable filters."""
+    query = db.query(Habit)
+
+    if routine_id is not None:
+        query = query.filter(Habit.routine_id == routine_id)
+    if habit_status is not None:
+        query = query.filter(Habit.status == habit_status)
+    if scaffolding_status is not None:
+        query = query.filter(Habit.scaffolding_status == scaffolding_status)
+
+    return query.order_by(Habit.created_at).all()
+
+
+@router.get("/{habit_id}", response_model=HabitDetailResponse)
+def get_habit(habit_id: UUID, db: Session = Depends(get_db)) -> Habit:
+    """Get a single habit with its nested parent routine."""
+    habit = (
+        db.query(Habit)
+        .options(joinedload(Habit.routine))
+        .filter(Habit.id == habit_id)
+        .first()
+    )
+    if not habit:
+        raise HTTPException(status_code=404, detail="Habit not found")
+    return habit
+
+
+@router.patch("/{habit_id}", response_model=HabitResponse)
+def update_habit(
+    habit_id: UUID, payload: HabitUpdate, db: Session = Depends(get_db)
+) -> Habit:
+    """Partial update of a habit."""
+    habit = db.query(Habit).filter(Habit.id == habit_id).first()
+    if not habit:
+        raise HTTPException(status_code=404, detail="Habit not found")
+
+    updates = payload.model_dump(exclude_unset=True)
+
+    # If detaching from routine (routine_id → None), ensure frequency is set
+    # either in the request payload or already on the habit.
+    if "routine_id" in updates and updates["routine_id"] is None:
+        new_frequency = updates.get("frequency", habit.frequency)
+        if new_frequency is None:
+            raise HTTPException(
+                status_code=422,
+                detail="frequency is required when detaching from a routine",
+            )
+
+    # If changing routine_id to a new value, validate it exists
+    if "routine_id" in updates and updates["routine_id"] is not None:
+        routine = (
+            db.query(Routine).filter(Routine.id == updates["routine_id"]).first()
+        )
+        if not routine:
+            raise HTTPException(status_code=400, detail="Routine not found")
+
+    for field, value in updates.items():
+        setattr(habit, field, value)
+
+    db.commit()
+    db.refresh(habit)
+    return habit
+
+
+@router.delete("/{habit_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_habit(habit_id: UUID, db: Session = Depends(get_db)) -> None:
+    """Delete a habit."""
+    habit = db.query(Habit).filter(Habit.id == habit_id).first()
+    if not habit:
+        raise HTTPException(status_code=404, detail="Habit not found")
+
+    db.delete(habit)
+    db.commit()

--- a/app/schemas/habits.py
+++ b/app/schemas/habits.py
@@ -1,0 +1,124 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Pydantic schemas for Habit CRUD operations."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+HabitStatus = Literal["active", "paused", "graduated", "abandoned"]
+HabitFrequency = Literal["daily", "weekdays", "weekends", "weekly", "custom"]
+NotificationFrequency = Literal[
+    "daily", "every_other_day", "twice_week", "weekly", "graduated", "none"
+]
+ScaffoldingStatus = Literal["tracking", "accountable", "graduated"]
+
+
+class HabitCreate(BaseModel):
+    """Fields required to create a habit."""
+
+    routine_id: UUID | None = None
+    title: str = Field(max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
+    status: HabitStatus = "active"
+    frequency: HabitFrequency | None = None
+    notification_frequency: NotificationFrequency = "none"
+    scaffolding_status: ScaffoldingStatus = "tracking"
+    introduced_at: date | None = None
+    graduation_window: int | None = None
+    graduation_target: float | None = None
+    graduation_threshold: int | None = None
+
+    @field_validator("graduation_target")
+    @classmethod
+    def validate_graduation_target(cls, v: float | None) -> float | None:
+        if v is not None and (v < 0.0 or v > 1.0):
+            msg = "graduation_target must be between 0.0 and 1.0"
+            raise ValueError(msg)
+        return v
+
+    @model_validator(mode="after")
+    def standalone_requires_frequency(self) -> HabitCreate:
+        """Standalone habits (no routine_id) must specify a frequency."""
+        if self.routine_id is None and self.frequency is None:
+            raise ValueError(
+                "frequency is required for standalone habits (no routine_id)"
+            )
+        return self
+
+
+class HabitUpdate(BaseModel):
+    """All fields optional — supports partial PATCH updates."""
+
+    routine_id: UUID | None = None
+    title: str | None = Field(default=None, max_length=200)
+    description: str | None = Field(default=None, max_length=5000)
+    status: HabitStatus | None = None
+    frequency: HabitFrequency | None = None
+    notification_frequency: NotificationFrequency | None = None
+    scaffolding_status: ScaffoldingStatus | None = None
+    introduced_at: date | None = None
+    graduation_window: int | None = None
+    graduation_target: float | None = None
+    graduation_threshold: int | None = None
+
+    @field_validator("graduation_target")
+    @classmethod
+    def validate_graduation_target(cls, v: float | None) -> float | None:
+        if v is not None and (v < 0.0 or v > 1.0):
+            msg = "graduation_target must be between 0.0 and 1.0"
+            raise ValueError(msg)
+        return v
+
+
+class HabitResponse(BaseModel):
+    """Habit returned from API — includes id and timestamps."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    routine_id: UUID | None = None
+    title: str
+    description: str | None = None
+    status: HabitStatus
+    frequency: HabitFrequency | None = None
+    notification_frequency: NotificationFrequency
+    scaffolding_status: ScaffoldingStatus
+    introduced_at: date | None = None
+    graduation_window: int | None = None
+    graduation_target: float | None = None
+    graduation_threshold: int | None = None
+    current_streak: int
+    best_streak: int
+    last_completed: date | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class HabitDetailResponse(HabitResponse):
+    """Habit with nested parent routine — returned by GET /api/habits/{id}."""
+
+    routine: RoutineResponse | None = None
+
+
+from app.schemas.routines import RoutineResponse  # noqa: E402
+
+HabitDetailResponse.model_rebuild()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,4 +203,12 @@ def make_skill(client: TestClient, **overrides) -> dict:
     return resp.json()
 
 
+def make_habit(client: TestClient, **overrides) -> dict:
+    """Create a habit via the API and return the response JSON."""
+    data = {"title": "Test Habit", "frequency": "daily", **overrides}
+    resp = client.post("/api/habits", json=data)
+    assert resp.status_code == 201
+    return resp.json()
+
+
 FAKE_UUID = str(uuid.uuid4())

--- a/tests/test_habits.py
+++ b/tests/test_habits.py
@@ -1,0 +1,397 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for Habit CRUD endpoints."""
+
+from tests.conftest import FAKE_UUID, make_domain, make_habit, make_routine
+
+# ---------------------------------------------------------------------------
+# POST /api/habits
+# ---------------------------------------------------------------------------
+
+
+class TestCreateHabit:
+
+    def test_create_standalone_habit(self, client):
+        resp = client.post(
+            "/api/habits",
+            json={"title": "Drink water", "frequency": "daily"},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["title"] == "Drink water"
+        assert body["frequency"] == "daily"
+        assert body["status"] == "active"
+        assert body["routine_id"] is None
+        assert body["notification_frequency"] == "none"
+        assert body["scaffolding_status"] == "tracking"
+        assert body["current_streak"] == 0
+        assert body["best_streak"] == 0
+        assert body["last_completed"] is None
+
+    def test_create_routine_linked_habit(self, client):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        resp = client.post(
+            "/api/habits",
+            json={"title": "Stretch", "routine_id": routine["id"]},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["routine_id"] == routine["id"]
+        assert body["frequency"] is None
+
+    def test_create_routine_linked_habit_with_frequency(self, client):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Stretch",
+                "routine_id": routine["id"],
+                "frequency": "weekdays",
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json()["frequency"] == "weekdays"
+
+    def test_create_standalone_missing_frequency(self, client):
+        resp = client.post(
+            "/api/habits",
+            json={"title": "No freq"},
+        )
+        assert resp.status_code == 422
+
+    def test_create_with_optional_fields(self, client):
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Meditate",
+                "frequency": "daily",
+                "description": "10 min mindfulness",
+                "notification_frequency": "daily",
+                "scaffolding_status": "accountable",
+                "introduced_at": "2026-04-01",
+                "graduation_window": 60,
+                "graduation_target": 0.9,
+                "graduation_threshold": 45,
+            },
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["description"] == "10 min mindfulness"
+        assert body["notification_frequency"] == "daily"
+        assert body["scaffolding_status"] == "accountable"
+        assert body["introduced_at"] == "2026-04-01"
+        assert body["graduation_window"] == 60
+        assert body["graduation_target"] == 0.9
+        assert body["graduation_threshold"] == 45
+
+    def test_create_invalid_routine_id(self, client):
+        resp = client.post(
+            "/api/habits",
+            json={"title": "Orphan", "routine_id": FAKE_UUID},
+        )
+        assert resp.status_code == 400
+
+    def test_create_missing_title(self, client):
+        resp = client.post(
+            "/api/habits",
+            json={"frequency": "daily"},
+        )
+        assert resp.status_code == 422
+
+    def test_create_title_too_long(self, client):
+        resp = client.post(
+            "/api/habits",
+            json={"title": "x" * 201, "frequency": "daily"},
+        )
+        assert resp.status_code == 422
+
+    def test_create_invalid_frequency(self, client):
+        resp = client.post(
+            "/api/habits",
+            json={"title": "Bad", "frequency": "INVALID"},
+        )
+        assert resp.status_code == 422
+
+    def test_create_invalid_status(self, client):
+        resp = client.post(
+            "/api/habits",
+            json={"title": "Bad", "frequency": "daily", "status": "INVALID"},
+        )
+        assert resp.status_code == 422
+
+    def test_create_graduation_target_too_high(self, client):
+        resp = client.post(
+            "/api/habits",
+            json={"title": "Bad", "frequency": "daily", "graduation_target": 1.5},
+        )
+        assert resp.status_code == 422
+
+    def test_create_graduation_target_negative(self, client):
+        resp = client.post(
+            "/api/habits",
+            json={"title": "Bad", "frequency": "daily", "graduation_target": -0.1},
+        )
+        assert resp.status_code == 422
+
+    def test_create_graduation_target_boundary_values(self, client):
+        resp_zero = client.post(
+            "/api/habits",
+            json={"title": "Zero", "frequency": "daily", "graduation_target": 0.0},
+        )
+        assert resp_zero.status_code == 201
+
+        resp_one = client.post(
+            "/api/habits",
+            json={"title": "One", "frequency": "daily", "graduation_target": 1.0},
+        )
+        assert resp_one.status_code == 201
+
+
+# ---------------------------------------------------------------------------
+# GET /api/habits
+# ---------------------------------------------------------------------------
+
+
+class TestListHabits:
+
+    def test_list_habits_empty(self, client):
+        resp = client.get("/api/habits")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_habits(self, client):
+        make_habit(client, title="A")
+        make_habit(client, title="B")
+        resp = client.get("/api/habits")
+        assert len(resp.json()) == 2
+
+    def test_filter_by_routine_id(self, client):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        make_habit(client, title="Linked", routine_id=routine["id"])
+        make_habit(client, title="Standalone")
+        resp = client.get(f"/api/habits?routine_id={routine['id']}")
+        habits = resp.json()
+        assert len(habits) == 1
+        assert habits[0]["title"] == "Linked"
+
+    def test_filter_by_status(self, client):
+        make_habit(client, title="Active", status="active")
+        make_habit(client, title="Paused", status="paused")
+        resp = client.get("/api/habits?status=paused")
+        habits = resp.json()
+        assert len(habits) == 1
+        assert habits[0]["title"] == "Paused"
+
+    def test_filter_by_scaffolding_status(self, client):
+        make_habit(client, title="Tracking", scaffolding_status="tracking")
+        make_habit(client, title="Accountable", scaffolding_status="accountable")
+        resp = client.get("/api/habits?scaffolding_status=accountable")
+        habits = resp.json()
+        assert len(habits) == 1
+        assert habits[0]["title"] == "Accountable"
+
+    def test_filter_combined(self, client):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        make_habit(
+            client, title="Match",
+            routine_id=routine["id"], status="active",
+            scaffolding_status="accountable",
+        )
+        make_habit(
+            client, title="Wrong status",
+            routine_id=routine["id"], status="paused",
+            scaffolding_status="accountable",
+        )
+        make_habit(
+            client, title="Wrong routine",
+            status="active", scaffolding_status="accountable",
+        )
+        resp = client.get(
+            f"/api/habits?routine_id={routine['id']}"
+            "&status=active&scaffolding_status=accountable"
+        )
+        habits = resp.json()
+        assert len(habits) == 1
+        assert habits[0]["title"] == "Match"
+
+    def test_list_ordered_by_created_at(self, client):
+        make_habit(client, title="First")
+        make_habit(client, title="Second")
+        resp = client.get("/api/habits")
+        titles = [h["title"] for h in resp.json()]
+        assert titles == ["First", "Second"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/habits/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetHabit:
+
+    def test_get_habit_detail_standalone(self, client):
+        habit = make_habit(client)
+        resp = client.get(f"/api/habits/{habit['id']}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["title"] == habit["title"]
+        assert body["routine"] is None
+
+    def test_get_habit_detail_with_routine(self, client):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        habit = make_habit(client, routine_id=routine["id"])
+        resp = client.get(f"/api/habits/{habit['id']}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["routine"] is not None
+        assert body["routine"]["id"] == routine["id"]
+        assert body["routine"]["title"] == routine["title"]
+
+    def test_get_habit_not_found(self, client):
+        resp = client.get(f"/api/habits/{FAKE_UUID}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/habits/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateHabit:
+
+    def test_patch_habit(self, client):
+        habit = make_habit(client, title="Old")
+        resp = client.patch(
+            f"/api/habits/{habit['id']}", json={"title": "New"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "New"
+
+    def test_patch_habit_partial(self, client):
+        habit = make_habit(client, title="Keep", scaffolding_status="tracking")
+        resp = client.patch(
+            f"/api/habits/{habit['id']}",
+            json={"scaffolding_status": "accountable"},
+        )
+        body = resp.json()
+        assert body["title"] == "Keep"
+        assert body["scaffolding_status"] == "accountable"
+
+    def test_patch_attach_to_routine(self, client):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        habit = make_habit(client)
+        resp = client.patch(
+            f"/api/habits/{habit['id']}",
+            json={"routine_id": routine["id"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["routine_id"] == routine["id"]
+
+    def test_patch_detach_from_routine_with_frequency(self, client):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        habit = make_habit(
+            client, routine_id=routine["id"], frequency="daily",
+        )
+        resp = client.patch(
+            f"/api/habits/{habit['id']}",
+            json={"routine_id": None},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["routine_id"] is None
+
+    def test_patch_detach_with_frequency_in_payload(self, client):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        # Create habit under routine with no frequency
+        habit = make_habit(client, routine_id=routine["id"], frequency=None)
+        resp = client.patch(
+            f"/api/habits/{habit['id']}",
+            json={"routine_id": None, "frequency": "weekly"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["routine_id"] is None
+        assert resp.json()["frequency"] == "weekly"
+
+    def test_patch_detach_without_frequency_fails(self, client):
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"])
+        # Create habit under routine with no frequency
+        habit = make_habit(client, routine_id=routine["id"], frequency=None)
+        resp = client.patch(
+            f"/api/habits/{habit['id']}",
+            json={"routine_id": None},
+        )
+        assert resp.status_code == 422
+
+    def test_patch_invalid_routine_id(self, client):
+        habit = make_habit(client)
+        resp = client.patch(
+            f"/api/habits/{habit['id']}",
+            json={"routine_id": FAKE_UUID},
+        )
+        assert resp.status_code == 400
+
+    def test_patch_habit_not_found(self, client):
+        resp = client.patch(f"/api/habits/{FAKE_UUID}", json={"title": "X"})
+        assert resp.status_code == 404
+
+    def test_patch_invalid_status(self, client):
+        habit = make_habit(client)
+        resp = client.patch(
+            f"/api/habits/{habit['id']}", json={"status": "INVALID"},
+        )
+        assert resp.status_code == 422
+
+    def test_patch_invalid_frequency(self, client):
+        habit = make_habit(client)
+        resp = client.patch(
+            f"/api/habits/{habit['id']}", json={"frequency": "INVALID"},
+        )
+        assert resp.status_code == 422
+
+    def test_patch_graduation_target_out_of_range(self, client):
+        habit = make_habit(client)
+        resp = client.patch(
+            f"/api/habits/{habit['id']}", json={"graduation_target": 2.0},
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/habits/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteHabit:
+
+    def test_delete_habit(self, client):
+        habit = make_habit(client)
+        resp = client.delete(f"/api/habits/{habit['id']}")
+        assert resp.status_code == 204
+        resp = client.get(f"/api/habits/{habit['id']}")
+        assert resp.status_code == 404
+
+    def test_delete_habit_not_found(self, client):
+        resp = client.delete(f"/api/habits/{FAKE_UUID}")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Full CRUD endpoints for the habits entity following existing project patterns. Five endpoints (create, list, get, update, delete) with Pydantic schemas, composable filters, and comprehensive tests. Standalone habits enforce `frequency` requirement; routine-linked habits allow NULL frequency (inherits from parent). Detaching a habit from its routine validates that frequency is set.

Closes #86

## Changes
- **`app/schemas/habits.py`** — New schema file with `HabitCreate`, `HabitUpdate`, `HabitResponse`, and `HabitDetailResponse`. Type aliases for `HabitStatus`, `HabitFrequency`, `NotificationFrequency`, and `ScaffoldingStatus`. Model validator on `HabitCreate` enforces standalone frequency requirement. Field validator on `graduation_target` enforces 0.0–1.0 range.
- **`app/routers/habits.py`** — New router with five endpoints: POST (create with routine_id FK validation), GET list (composable filters: routine_id, status, scaffolding_status), GET detail (joinedload for nested parent routine), PATCH (detach-from-routine frequency validation, routine_id FK validation), DELETE. Follows task/routine patterns exactly.
- **`app/main.py`** — Added `habits` import and `include_router` registration after routines for logical grouping.
- **`tests/conftest.py`** — Added `make_habit()` helper with standalone defaults (`title="Test Habit"`, `frequency="daily"`).
- **`tests/test_habits.py`** — 36 tests covering all five endpoints: happy path, validation (missing title, title too long, invalid frequency/status, graduation_target bounds), not found (404), invalid FK (400), standalone frequency requirement (422), detach frequency requirement (422), all filter combinations, and ordering.

## How to Verify
```bash
# Run habit tests only
pytest tests/test_habits.py -v

# Run full suite to confirm no regressions
pytest -v

# Lint
ruff check .
```

## Deviations
None

## Test Results
```
tests/test_habits.py — 36 passed in 0.55s
Full suite — 657 passed in 8.37s
ruff check . — All checks passed!
```

## Acceptance Checklist
- [x] POST /api/habits creates a habit (standalone or under a routine)
- [x] Standalone habit creation requires `frequency` field — 422 if missing
- [x] Routine-linked habit creation allows `frequency` to be NULL
- [x] GET /api/habits returns filtered list (routine_id, status, scaffolding_status)
- [x] GET /api/habits/{id} returns habit with nested parent routine (detail response)
- [x] PATCH /api/habits/{id} updates habit fields
- [x] PATCH detaching from routine (routine_id → NULL) validates frequency is set — 422 if not
- [x] DELETE /api/habits/{id} deletes a habit
- [x] Invalid `routine_id` on create returns 400
- [x] Invalid habit UUID on get/update/delete returns 404
- [x] Pydantic validation errors return 422
- [x] All filter combinations work on list endpoint
- [x] `make_habit()` helper added to `tests/conftest.py`
- [x] Tests cover: happy path, validation, not found, filters, standalone frequency, detach frequency