### PR TITLE
2A-06: Habit completion endpoint

### DIFF
--- a/app/routers/habits.py
+++ b/app/routers/habits.py
@@ -16,19 +16,23 @@
 
 """CRUD endpoints for Habits."""
 
+from datetime import date
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session, joinedload
 
 from app.database import get_db
-from app.models import Habit, Routine
+from app.models import Habit, HabitCompletion, Routine
 from app.schemas.habits import (
+    HabitCompleteRequest,
+    HabitCompleteResponse,
     HabitCreate,
     HabitDetailResponse,
     HabitResponse,
     HabitUpdate,
 )
+from app.services.streak import evaluate_streak
 
 router = APIRouter()
 
@@ -128,3 +132,121 @@ def delete_habit(habit_id: UUID, db: Session = Depends(get_db)) -> None:
 
     db.delete(habit)
     db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Completion — /api/habits/{habit_id}/complete
+# ---------------------------------------------------------------------------
+
+DAY_MAP = {
+    "monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3,
+    "friday": 4, "saturday": 5, "sunday": 6,
+}
+
+
+@router.post("/{habit_id}/complete", response_model=HabitCompleteResponse)
+def complete_habit(
+    habit_id: UUID,
+    payload: HabitCompleteRequest | None = None,
+    db: Session = Depends(get_db),
+) -> dict:
+    """Record a habit completion and evaluate the streak."""
+    habit = (
+        db.query(Habit)
+        .options(
+            joinedload(Habit.routine).joinedload(Routine.schedules),
+        )
+        .filter(Habit.id == habit_id)
+        .first()
+    )
+    if not habit:
+        raise HTTPException(status_code=404, detail="Habit not found")
+
+    if habit.status != "active":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot complete a habit with status '{habit.status}'. "
+            "Only active habits can be completed.",
+        )
+
+    completed_date = date.today()
+    if payload and payload.completed_date:
+        completed_date = payload.completed_date
+
+    notes = payload.notes if payload else None
+
+    # Idempotency check — return existing completion if one exists for this date
+    existing = (
+        db.query(HabitCompletion)
+        .filter(
+            HabitCompletion.habit_id == habit_id,
+            HabitCompletion.completed_at == completed_date,
+        )
+        .first()
+    )
+    if existing:
+        return {
+            "habit_id": habit.id,
+            "completion_id": existing.id,
+            "completed_date": existing.completed_at,
+            "current_streak": habit.current_streak,
+            "best_streak": habit.best_streak,
+            "streak_was_broken": False,
+            "source": existing.source,
+        }
+
+    # Resolve frequency: habit's own, then parent routine's, then error
+    frequency = habit.frequency
+    if frequency is None and habit.routine:
+        frequency = habit.routine.frequency
+    if frequency is None:
+        raise HTTPException(
+            status_code=422,
+            detail="Cannot determine frequency for this habit. "
+            "Set frequency on the habit or assign it to a routine.",
+        )
+
+    # Build scheduled_days for custom frequency
+    scheduled_days = None
+    if frequency == "custom" and habit.routine:
+        scheduled_days = [
+            DAY_MAP[s.day_of_week.lower()]
+            for s in habit.routine.schedules
+            if s.day_of_week and s.day_of_week.lower() in DAY_MAP
+        ]
+
+    result = evaluate_streak(
+        frequency=frequency,
+        current_streak=habit.current_streak,
+        best_streak=habit.best_streak,
+        last_completed=habit.last_completed,
+        completed_date=completed_date,
+        scheduled_days=scheduled_days,
+    )
+
+    # Update streak fields on the habit
+    habit.current_streak = result.current_streak
+    habit.best_streak = result.best_streak
+    if habit.last_completed is None or completed_date >= habit.last_completed:
+        habit.last_completed = completed_date
+
+    # Create the completion record
+    completion = HabitCompletion(
+        habit_id=habit.id,
+        completed_at=completed_date,
+        source="individual",
+        notes=notes,
+    )
+    db.add(completion)
+    db.commit()
+    db.refresh(completion)
+
+    return {
+        "habit_id": habit.id,
+        "completion_id": completion.id,
+        "completed_date": completed_date,
+        "current_streak": result.current_streak,
+        "best_streak": result.best_streak,
+        "streak_was_broken": result.streak_was_broken,
+        "source": "individual",
+    }

--- a/app/schemas/habits.py
+++ b/app/schemas/habits.py
@@ -119,6 +119,32 @@ class HabitDetailResponse(HabitResponse):
     routine: RoutineResponse | None = None
 
 
+# ---------------------------------------------------------------------------
+# Habit Completion — POST /api/habits/{id}/complete
+# ---------------------------------------------------------------------------
+
+
+class HabitCompleteRequest(BaseModel):
+    """Optional payload for habit completion."""
+
+    completed_date: date | None = None
+    notes: str | None = Field(default=None, max_length=5000)
+
+
+class HabitCompleteResponse(BaseModel):
+    """Response from completing a habit."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    habit_id: UUID
+    completion_id: UUID
+    completed_date: date
+    current_streak: int
+    best_streak: int
+    streak_was_broken: bool
+    source: str
+
+
 from app.schemas.routines import RoutineResponse  # noqa: E402
 
 HabitDetailResponse.model_rebuild()

--- a/tests/test_habits.py
+++ b/tests/test_habits.py
@@ -395,3 +395,147 @@ class TestDeleteHabit:
     def test_delete_habit_not_found(self, client):
         resp = client.delete(f"/api/habits/{FAKE_UUID}")
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/habits/{id}/complete
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteHabit:
+
+    def test_complete_standalone_habit(self, client):
+        """Happy path — complete a standalone daily habit."""
+        habit = make_habit(client, frequency="daily")
+        resp = client.post(f"/api/habits/{habit['id']}/complete")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["habit_id"] == habit["id"]
+        assert data["completion_id"] is not None
+        assert data["current_streak"] == 1
+        assert data["best_streak"] == 1
+        assert data["streak_was_broken"] is False
+        assert data["source"] == "individual"
+
+    def test_complete_routine_linked_habit_no_cascade(self, client):
+        """Completing a routine-linked habit does NOT complete the routine."""
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"], frequency="daily")
+        habit = make_habit(client, routine_id=routine["id"], frequency=None)
+
+        resp = client.post(f"/api/habits/{habit['id']}/complete")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["current_streak"] == 1
+
+        # Routine streak should be untouched
+        routine_resp = client.get(f"/api/routines/{routine['id']}")
+        assert routine_resp.json()["current_streak"] == 0
+
+    def test_complete_habit_frequency_fallback_to_routine(self, client):
+        """Habit without own frequency resolves from parent routine."""
+        domain = make_domain(client)
+        routine = make_routine(client, domain["id"], frequency="weekly")
+        habit = make_habit(client, routine_id=routine["id"], frequency=None)
+
+        resp = client.post(f"/api/habits/{habit['id']}/complete")
+        assert resp.status_code == 200
+        assert resp.json()["current_streak"] == 1
+
+    def test_complete_with_backdating(self, client):
+        """Backdating via completed_date field works."""
+        habit = make_habit(client, frequency="daily")
+        resp = client.post(
+            f"/api/habits/{habit['id']}/complete",
+            json={"completed_date": "2026-04-01"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["completed_date"] == "2026-04-01"
+
+    def test_complete_with_notes(self, client):
+        """Notes field is accepted and stored."""
+        habit = make_habit(client, frequency="daily")
+        resp = client.post(
+            f"/api/habits/{habit['id']}/complete",
+            json={"notes": "Felt great today!"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["completion_id"] is not None
+
+    def test_complete_idempotent_same_day(self, client):
+        """Same habit + same date returns existing record, no duplicate."""
+        habit = make_habit(client, frequency="daily")
+        resp1 = client.post(
+            f"/api/habits/{habit['id']}/complete",
+            json={"completed_date": "2026-04-10"},
+        )
+        resp2 = client.post(
+            f"/api/habits/{habit['id']}/complete",
+            json={"completed_date": "2026-04-10"},
+        )
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+        assert resp1.json()["completion_id"] == resp2.json()["completion_id"]
+
+    def test_complete_paused_habit_rejected(self, client):
+        """Paused habits cannot be completed."""
+        habit = make_habit(client, frequency="daily")
+        client.patch(f"/api/habits/{habit['id']}", json={"status": "paused"})
+        resp = client.post(f"/api/habits/{habit['id']}/complete")
+        assert resp.status_code == 400
+        assert "paused" in resp.json()["detail"]
+
+    def test_complete_graduated_habit_rejected(self, client):
+        """Graduated habits cannot be completed."""
+        habit = make_habit(client, frequency="daily")
+        client.patch(f"/api/habits/{habit['id']}", json={"status": "graduated"})
+        resp = client.post(f"/api/habits/{habit['id']}/complete")
+        assert resp.status_code == 400
+        assert "graduated" in resp.json()["detail"]
+
+    def test_complete_abandoned_habit_rejected(self, client):
+        """Abandoned habits cannot be completed."""
+        habit = make_habit(client, frequency="daily")
+        client.patch(f"/api/habits/{habit['id']}", json={"status": "abandoned"})
+        resp = client.post(f"/api/habits/{habit['id']}/complete")
+        assert resp.status_code == 400
+        assert "abandoned" in resp.json()["detail"]
+
+    def test_complete_not_found(self, client):
+        """404 for invalid habit UUID."""
+        resp = client.post(f"/api/habits/{FAKE_UUID}/complete")
+        assert resp.status_code == 404
+
+    def test_streak_builds_consecutively(self, client):
+        """Streak increments on consecutive daily completions."""
+        habit = make_habit(client, frequency="daily")
+        client.post(
+            f"/api/habits/{habit['id']}/complete",
+            json={"completed_date": "2026-04-10"},
+        )
+        resp = client.post(
+            f"/api/habits/{habit['id']}/complete",
+            json={"completed_date": "2026-04-11"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["current_streak"] == 2
+        assert data["best_streak"] == 2
+        assert data["streak_was_broken"] is False
+
+    def test_streak_breaks_on_gap(self, client):
+        """Streak resets when gap exceeds frequency tolerance."""
+        habit = make_habit(client, frequency="daily")
+        client.post(
+            f"/api/habits/{habit['id']}/complete",
+            json={"completed_date": "2026-04-10"},
+        )
+        resp = client.post(
+            f"/api/habits/{habit['id']}/complete",
+            json={"completed_date": "2026-04-13"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["current_streak"] == 1
+        assert data["best_streak"] == 1
+        assert data["streak_was_broken"] is True


### PR DESCRIPTION
## Summary
Implements `POST /api/habits/{id}/complete` — the endpoint that records an individual habit completion, creates a `habit_completions` record, evaluates the streak, and updates the habit's streak fields. Designed so [2A-07] can call the same logic internally for routine cascade.

## Changes
- **app/schemas/habits.py** — Added `HabitCompleteRequest` (optional `completed_date` and `notes`) and `HabitCompleteResponse` (habit_id, completion_id, completed_date, current_streak, best_streak, streak_was_broken, source).
- **app/routers/habits.py** — Added `POST /{habit_id}/complete` endpoint with:
  - Status validation (only `active` habits, 400 otherwise)
  - Idempotency check (query-first, returns existing completion if same habit+date)
  - Frequency resolution fallback (`habit.frequency` → `habit.routine.frequency`)
  - Custom frequency `scheduled_days` resolution from parent routine schedules
  - Streak evaluation via `evaluate_streak()`
  - `last_completed` only advances forward (backdate doesn't regress)
  - Atomic commit of habit streak updates + completion record
  - `source="individual"` on all records from this endpoint
- **tests/test_habits.py** — 12 new tests covering: happy path (standalone), routine-linked (no upward cascade), frequency fallback, backdating, notes, idempotency, status validation (paused/graduated/abandoned), 404, streak continuation, streak break.

## How to Verify
```bash
git checkout feature/2A-06-habit-completion-endpoint
pytest tests/test_habits.py -v
ruff check .
```

## Deviations
None — implementation follows the issue spec.

## Test Results
```
48 passed in 0.71s (12 new completion tests + 36 existing)
669 passed full suite, 0 regressions
ruff check: All checks passed!
```

## Acceptance Checklist
- [x] POST /api/habits/{id}/complete creates a completion record in habit_completions
- [x] Streak updates correctly on the individual habit (current_streak, best_streak, last_completed)
- [x] Only `active` habits can be completed — paused/graduated/abandoned return 400 with clear message
- [x] Idempotent: same habit + same date returns existing record, no duplicate created
- [x] Completion record has `source="individual"`
- [x] Backdating via `completed_date` field works
- [x] Notes field stored on completion record when provided
- [x] Frequency resolution: `habit.frequency` → `habit.routine.frequency` fallback
- [x] If habit belongs to a routine, does NOT auto-complete the routine (no upward cascade)
- [x] Works for standalone habits (no routine_id, requires habit.frequency to be set)
- [x] 404 for invalid habit UUID
- [x] Tests: happy path, standalone, routine-linked (no cascade), backdating, notes, idempotency, status validation, streak continuation, streak break

Closes #89