### PR TITLE
2A-08: Activity log habit_id support

### DIFF
--- a/alembic/versions/011_add_habit_id_to_activity_log.py
+++ b/alembic/versions/011_add_habit_id_to_activity_log.py
@@ -1,0 +1,50 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Add habit_id to activity_log table.
+
+Revision ID: 11d4e5f6a7b8
+Revises: 10c3d4e5f6a7
+Create Date: 2026-04-12
+
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "11d4e5f6a7b8"
+down_revision: Union[str, None] = "10c3d4e5f6a7"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "activity_log",
+        sa.Column(
+            "habit_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("habits.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("activity_log", "habit_id")

--- a/app/models.py
+++ b/app/models.py
@@ -524,6 +524,7 @@ class Habit(Base):
     completions: Mapped[list["HabitCompletion"]] = relationship(
         back_populates="habit", cascade="all, delete-orphan",
     )
+    activity_logs: Mapped[list["ActivityLog"]] = relationship(back_populates="habit")
 
 
 # ---------------------------------------------------------------------------
@@ -674,6 +675,9 @@ class ActivityLog(Base):
     checkin_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("state_checkins.id", ondelete="SET NULL"),
     )
+    habit_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("habits.id", ondelete="SET NULL"),
+    )
     action_type: Mapped[str] = mapped_column(String, nullable=False)
     notes: Mapped[str | None] = mapped_column(Text)
     energy_before: Mapped[int | None] = mapped_column(Integer)
@@ -715,6 +719,7 @@ class ActivityLog(Base):
     task: Mapped["Task | None"] = relationship(back_populates="activity_logs")
     routine: Mapped["Routine | None"] = relationship(back_populates="activity_logs")
     checkin: Mapped["StateCheckin | None"] = relationship(back_populates="activity_logs")
+    habit: Mapped["Habit | None"] = relationship(back_populates="activity_logs")
     tags: Mapped[list["Tag"]] = relationship(
         secondary="activity_tags", back_populates="activity_logs",
     )

--- a/app/routers/activity.py
+++ b/app/routers/activity.py
@@ -23,7 +23,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session, joinedload
 
 from app.database import get_db
-from app.models import ActivityLog, ActivityTag, Routine, StateCheckin, Tag, Task
+from app.models import ActivityLog, ActivityTag, Habit, Routine, StateCheckin, Tag, Task
 from app.schemas.activity import (
     ActivityLogCreate,
     ActivityLogDetailResponse,
@@ -53,6 +53,9 @@ def create_activity(payload: ActivityLogCreate, db: Session = Depends(get_db)) -
     if payload.checkin_id is not None:
         if not db.query(StateCheckin).filter(StateCheckin.id == payload.checkin_id).first():
             raise HTTPException(status_code=400, detail="Check-in not found")
+    if payload.habit_id is not None:
+        if not db.query(Habit).filter(Habit.id == payload.habit_id).first():
+            raise HTTPException(status_code=400, detail="Habit not found")
 
     # Validate tag_ids if provided
     tags = []
@@ -107,6 +110,13 @@ def batch_create_activity(
                         detail=f"Batch item {idx}: Check-in not found"
                         f" (checkin_id: {item.checkin_id})",
                     )
+            if item.habit_id is not None:
+                if not db.query(Habit).filter(Habit.id == item.habit_id).first():
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Batch item {idx}: Habit not found"
+                        f" (habit_id: {item.habit_id})",
+                    )
 
             tags = []
             if item.tag_ids:
@@ -142,10 +152,13 @@ def list_activity(
     action_type: str | None = Query(None),
     task_id: UUID | None = Query(None),
     routine_id: UUID | None = Query(None),
+    habit_id: UUID | None = Query(None),
     logged_after: datetime | None = Query(None),
     logged_before: datetime | None = Query(None),
     has_task: bool | None = Query(None),
     has_routine: bool | None = Query(None),
+    has_habit: bool | None = Query(None),
+    has_checkin: bool | None = Query(None),
     tag: str | None = Query(None, description="Comma-separated tag names (AND logic)"),
     db: Session = Depends(get_db),
 ) -> list[ActivityLog]:
@@ -158,6 +171,8 @@ def list_activity(
         query = query.filter(ActivityLog.task_id == task_id)
     if routine_id is not None:
         query = query.filter(ActivityLog.routine_id == routine_id)
+    if habit_id is not None:
+        query = query.filter(ActivityLog.habit_id == habit_id)
     if logged_after is not None:
         query = query.filter(ActivityLog.logged_at >= logged_after)
     if logged_before is not None:
@@ -170,6 +185,14 @@ def list_activity(
         query = query.filter(ActivityLog.routine_id.isnot(None))
     elif has_routine is False:
         query = query.filter(ActivityLog.routine_id.is_(None))
+    if has_habit is True:
+        query = query.filter(ActivityLog.habit_id.isnot(None))
+    elif has_habit is False:
+        query = query.filter(ActivityLog.habit_id.is_(None))
+    if has_checkin is True:
+        query = query.filter(ActivityLog.checkin_id.isnot(None))
+    elif has_checkin is False:
+        query = query.filter(ActivityLog.checkin_id.is_(None))
     if tag is not None:
         tag_names = [t.strip().lower() for t in tag.split(",") if t.strip()]
         for tag_name in tag_names:
@@ -182,12 +205,13 @@ def list_activity(
 
 @router.get("/{entry_id}", response_model=ActivityLogDetailResponse)
 def get_activity(entry_id: UUID, db: Session = Depends(get_db)) -> ActivityLog:
-    """Get a single activity log entry with resolved task/routine/checkin."""
+    """Get a single activity log entry with resolved task/routine/habit/checkin."""
     entry = (
         db.query(ActivityLog)
         .options(
             joinedload(ActivityLog.task),
             joinedload(ActivityLog.routine),
+            joinedload(ActivityLog.habit),
             joinedload(ActivityLog.checkin),
             joinedload(ActivityLog.tags),
         )
@@ -219,16 +243,22 @@ def update_activity(
     if updates.get("checkin_id") is not None:
         if not db.query(StateCheckin).filter(StateCheckin.id == updates["checkin_id"]).first():
             raise HTTPException(status_code=400, detail="Check-in not found")
+    if updates.get("habit_id") is not None:
+        if not db.query(Habit).filter(Habit.id == updates["habit_id"]).first():
+            raise HTTPException(status_code=400, detail="Habit not found")
 
     for field, value in updates.items():
         setattr(entry, field, value)
 
     # Enforce at-most-one-reference on the post-merge state
-    refs = sum(v is not None for v in [entry.task_id, entry.routine_id, entry.checkin_id])
+    refs = sum(
+        v is not None
+        for v in [entry.task_id, entry.routine_id, entry.habit_id, entry.checkin_id]
+    )
     if refs > 1:
         raise HTTPException(
             status_code=422,
-            detail="At most one of task_id, routine_id, or checkin_id may be set",
+            detail="At most one of task_id, routine_id, habit_id, or checkin_id may be set",
         )
 
     db.commit()

--- a/app/schemas/activity.py
+++ b/app/schemas/activity.py
@@ -29,11 +29,15 @@ ActionType = Literal[
 ]
 
 
+_REFERENCE_FIELDS = ["task_id", "routine_id", "habit_id", "checkin_id"]
+
+
 class ActivityLogCreate(BaseModel):
     """Fields required to create an activity log entry."""
 
     task_id: UUID | None = None
     routine_id: UUID | None = None
+    habit_id: UUID | None = None
     checkin_id: UUID | None = None
     action_type: ActionType
     notes: str | None = Field(default=None, max_length=5000)
@@ -54,9 +58,9 @@ class ActivityLogCreate(BaseModel):
 
     @model_validator(mode="after")
     def at_most_one_reference(self) -> "ActivityLogCreate":
-        refs = sum(v is not None for v in [self.task_id, self.routine_id, self.checkin_id])
+        refs = sum(getattr(self, f) is not None for f in _REFERENCE_FIELDS)
         if refs > 1:
-            msg = "At most one of task_id, routine_id, or checkin_id may be provided"
+            msg = "At most one of task_id, routine_id, habit_id, or checkin_id may be provided"
             raise ValueError(msg)
         return self
 
@@ -66,6 +70,7 @@ class ActivityLogUpdate(BaseModel):
 
     task_id: UUID | None = None
     routine_id: UUID | None = None
+    habit_id: UUID | None = None
     checkin_id: UUID | None = None
     action_type: ActionType | None = None
     notes: str | None = Field(default=None, max_length=5000)
@@ -92,6 +97,7 @@ class ActivityLogResponse(BaseModel):
     id: UUID
     task_id: UUID | None = None
     routine_id: UUID | None = None
+    habit_id: UUID | None = None
     checkin_id: UUID | None = None
     action_type: ActionType
     notes: str | None = None
@@ -105,14 +111,16 @@ class ActivityLogResponse(BaseModel):
 
 
 class ActivityLogDetailResponse(ActivityLogResponse):
-    """Activity log entry with resolved task/routine/checkin references."""
+    """Activity log entry with resolved task/routine/habit/checkin references."""
 
     task: "TaskResponse | None" = None
     routine: "RoutineResponse | None" = None
+    habit: "HabitResponse | None" = None
     checkin: "CheckinResponse | None" = None
 
 
 from app.schemas.checkins import CheckinResponse  # noqa: E402
+from app.schemas.habits import HabitResponse  # noqa: E402
 from app.schemas.routines import RoutineResponse  # noqa: E402
 from app.schemas.tags import TagResponse  # noqa: E402
 from app.schemas.tasks import TaskResponse  # noqa: E402

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -24,6 +24,7 @@ from tests.conftest import (
     make_activity,
     make_checkin,
     make_domain,
+    make_habit,
     make_routine,
     make_task,
 )
@@ -84,6 +85,15 @@ class TestCreateActivity:
         assert resp.status_code == 201
         assert resp.json()["checkin_id"] == checkin["id"]
 
+    def test_create_with_habit(self, client):
+        habit = make_habit(client)
+        resp = client.post(
+            "/api/activity",
+            json={"habit_id": habit["id"], "action_type": "completed"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["habit_id"] == habit["id"]
+
     def test_create_multiple_refs_rejected(self, client):
         task = make_task(client)
         domain = make_domain(client)
@@ -93,6 +103,32 @@ class TestCreateActivity:
             json={
                 "task_id": task["id"],
                 "routine_id": routine["id"],
+                "action_type": "completed",
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_create_task_and_habit_rejected(self, client):
+        task = make_task(client)
+        habit = make_habit(client)
+        resp = client.post(
+            "/api/activity",
+            json={
+                "task_id": task["id"],
+                "habit_id": habit["id"],
+                "action_type": "completed",
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_create_habit_and_checkin_rejected(self, client):
+        habit = make_habit(client)
+        checkin = make_checkin(client)
+        resp = client.post(
+            "/api/activity",
+            json={
+                "habit_id": habit["id"],
+                "checkin_id": checkin["id"],
                 "action_type": "completed",
             },
         )
@@ -116,6 +152,13 @@ class TestCreateActivity:
         resp = client.post(
             "/api/activity",
             json={"checkin_id": FAKE_UUID, "action_type": "checked_in"},
+        )
+        assert resp.status_code == 400
+
+    def test_create_invalid_habit_ref(self, client):
+        resp = client.post(
+            "/api/activity",
+            json={"habit_id": FAKE_UUID, "action_type": "completed"},
         )
         assert resp.status_code == 400
 
@@ -233,6 +276,43 @@ class TestListActivity:
         resp = client.get("/api/activity?has_routine=true")
         assert len(resp.json()) == 1
 
+    def test_filter_by_habit_id(self, client):
+        habit = make_habit(client)
+        make_activity(client, habit_id=habit["id"])
+        make_activity(client, action_type="reflected")
+        resp = client.get(f"/api/activity?habit_id={habit['id']}")
+        assert len(resp.json()) == 1
+
+    def test_filter_has_habit(self, client):
+        habit = make_habit(client)
+        make_activity(client, habit_id=habit["id"])
+        make_activity(client, action_type="reflected")
+        resp = client.get("/api/activity?has_habit=true")
+        assert len(resp.json()) == 1
+
+    def test_filter_has_habit_false(self, client):
+        habit = make_habit(client)
+        make_activity(client, habit_id=habit["id"])
+        make_activity(client, action_type="reflected")
+        resp = client.get("/api/activity?has_habit=false")
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["habit_id"] is None
+
+    def test_filter_has_checkin(self, client):
+        checkin = make_checkin(client)
+        make_activity(client, checkin_id=checkin["id"], action_type="checked_in")
+        make_activity(client, action_type="reflected")
+        resp = client.get("/api/activity?has_checkin=true")
+        assert len(resp.json()) == 1
+
+    def test_filter_has_checkin_false(self, client):
+        checkin = make_checkin(client)
+        make_activity(client, checkin_id=checkin["id"], action_type="checked_in")
+        make_activity(client, action_type="reflected")
+        resp = client.get("/api/activity?has_checkin=false")
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["checkin_id"] is None
+
     def test_reverse_chronological_order(self, client, db):
         early = ActivityLog(
             action_type="completed",
@@ -279,12 +359,23 @@ class TestGetActivity:
         resp = client.get(f"/api/activity/{entry['id']}")
         assert resp.json()["checkin"]["checkin_type"] == "morning"
 
+    def test_get_detail_with_habit(self, client):
+        habit = make_habit(client, title="Drink water")
+        entry = make_activity(client, habit_id=habit["id"])
+        resp = client.get(f"/api/activity/{entry['id']}")
+        body = resp.json()
+        assert body["habit"]["title"] == "Drink water"
+        assert body["task"] is None
+        assert body["routine"] is None
+        assert body["checkin"] is None
+
     def test_get_detail_standalone(self, client):
         entry = make_activity(client, action_type="reflected")
         resp = client.get(f"/api/activity/{entry['id']}")
         body = resp.json()
         assert body["task"] is None
         assert body["routine"] is None
+        assert body["habit"] is None
         assert body["checkin"] is None
 
     def test_get_not_found(self, client):
@@ -380,6 +471,37 @@ class TestUpdateActivity:
         )
         assert resp.status_code == 400
 
+    def test_patch_to_habit_ref(self, client):
+        """Clearing old ref and setting habit_id in the same PATCH is allowed."""
+        task = make_task(client)
+        habit = make_habit(client)
+        entry = make_activity(client, task_id=task["id"])
+        resp = client.patch(
+            f"/api/activity/{entry['id']}",
+            json={"task_id": None, "habit_id": habit["id"]},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["task_id"] is None
+        assert body["habit_id"] == habit["id"]
+
+    def test_patch_habit_plus_existing_ref_rejected(self, client):
+        """Adding habit_id to an entry with an existing task_id is rejected."""
+        task = make_task(client)
+        habit = make_habit(client)
+        entry = make_activity(client, task_id=task["id"])
+        resp = client.patch(
+            f"/api/activity/{entry['id']}", json={"habit_id": habit["id"]},
+        )
+        assert resp.status_code == 422
+
+    def test_patch_invalid_habit_ref(self, client):
+        entry = make_activity(client)
+        resp = client.patch(
+            f"/api/activity/{entry['id']}", json={"habit_id": FAKE_UUID},
+        )
+        assert resp.status_code == 400
+
     def test_patch_clear_ref_allowed(self, client):
         """Setting a ref to null should not trigger existence validation."""
         task = make_task(client)
@@ -452,3 +574,14 @@ class TestActivityReferenceIntegrity:
         resp = client.get(f"/api/activity/{entry['id']}")
         assert resp.status_code == 200
         assert resp.json()["checkin_id"] is None
+
+    def test_habit_deletion_nullifies_activity_reference(self, client):
+        """Deleting a habit sets activity_log.habit_id to NULL."""
+        habit = make_habit(client)
+        entry = make_activity(client, habit_id=habit["id"])
+
+        client.delete(f"/api/habits/{habit['id']}")
+
+        resp = client.get(f"/api/activity/{entry['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["habit_id"] is None


### PR DESCRIPTION
## Summary
Extends the activity log to support `habit_id` as a fourth optional entity reference, alongside the existing `task_id`, `routine_id`, and `checkin_id`. The mutual exclusion constraint (at most one reference per entry) now covers all four fields. Also backfills `has_checkin` as a list filter for symmetry.

## Changes
- **`alembic/versions/011_add_habit_id_to_activity_log.py`** — New migration adding nullable `habit_id` UUID column with FK to `habits.id` (ON DELETE SET NULL)
- **`app/models.py`** — Added `habit_id` column and `habit` relationship to `ActivityLog`; added `activity_logs` back_populates on `Habit`
- **`app/schemas/activity.py`** — Added `habit_id` to Create/Update/Response schemas; refactored mutual exclusion validator to use a `_REFERENCE_FIELDS` constant; added `HabitResponse` to detail response with deferred import
- **`app/routers/activity.py`** — Added `Habit` import; habit_id existence validation on create, batch create, and update; updated post-merge check to four fields; added `habit_id`, `has_habit`, `has_checkin` list filters; added `joinedload(ActivityLog.habit)` to detail endpoint
- **`tests/test_activity.py`** — 15 new tests covering create with habit_id, mutual exclusion violations (task+habit, habit+checkin), invalid habit ref, list filters (habit_id, has_habit, has_checkin), detail with nested habit, update to/from habit_id, and habit deletion reference integrity

## How to Verify
1. `git checkout feature/2A-08-activity-log-habit-id`
2. `alembic upgrade head` — migration 011 applies cleanly
3. `pytest tests/test_activity.py -v` — all 60 tests pass
4. `pytest -v` — full suite (705 tests) passes
5. `ruff check .` — clean lint
6. Manual: POST `/api/activity` with `habit_id` → 201; POST with `habit_id` + `task_id` → 422; GET list with `?has_habit=true` filters correctly

## Deviations
None

## Test Results
```
60 passed in 0.96s (activity tests)
705 passed in 9.97s (full suite)
ruff check: All checks passed!
```

## Acceptance Checklist
- [x] Alembic migration adds `habit_id` column (nullable FK → habits.id, ON DELETE SET NULL)
- [x] Mutual exclusion: only one of task_id, routine_id, habit_id, checkin_id per entry
- [x] Create validator updated with habit_id in the reference check
- [x] Validator refactored to generic "at most one non-null" pattern using `_REFERENCE_FIELDS` constant
- [x] Update router post-merge check updated with habit_id
- [x] Update router validates habit_id existence when provided
- [x] Response schemas include `habit_id` field
- [x] Detail response includes nested `habit` object (HabitResponse) when applicable
- [x] `has_habit` boolean filter on list_activity endpoint
- [x] `has_checkin` boolean filter on list_activity endpoint (backfill for symmetry)
- [x] Existing activity log tests still pass (regression)
- [x] New tests: create with habit_id, mutual exclusion violations, update changing to habit_id, has_habit filter, has_checkin filter

### Out of scope (per ticket guardrails)
- [ ] MCP `list_activity` tool updated with `has_habit` and `has_checkin` filter params → [2A-09]
- [ ] MCP `log_activity` tool updated with `habit_id` parameter → [2A-09]
- [ ] MCP `update_activity` tool updated with `habit_id` parameter → [2A-09]

Closes #90