### PR TITLE
2B-01: Notification queue table, model & migration

### DIFF
--- a/alembic/versions/012_create_notification_queue.py
+++ b/alembic/versions/012_create_notification_queue.py
@@ -1,0 +1,144 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Create notification_queue table.
+
+Revision ID: 12a1b2c3d4e5
+Revises: 11d4e5f6a7b8
+Create Date: 2026-04-13
+
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "12a1b2c3d4e5"
+down_revision: Union[str, None] = "11d4e5f6a7b8"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_queue",
+        sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
+        sa.Column("notification_type", sa.String(), nullable=False),
+        sa.Column(
+            "delivery_type",
+            sa.String(),
+            nullable=False,
+            server_default="notification",
+        ),
+        sa.Column(
+            "status", sa.String(), nullable=False, server_default="pending"
+        ),
+        sa.Column(
+            "scheduled_at", sa.DateTime(timezone=True), nullable=False
+        ),
+        sa.Column("target_entity_type", sa.String(), nullable=False),
+        sa.Column("target_entity_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.Column(
+            "canned_responses",
+            sa.JSON().with_variant(
+                sa.dialects.postgresql.JSONB, "postgresql"
+            ),
+            nullable=True,
+        ),
+        sa.Column("response", sa.String(), nullable=True),
+        sa.Column("response_note", sa.Text(), nullable=True),
+        sa.Column(
+            "responded_at", sa.DateTime(timezone=True), nullable=True
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("scheduled_by", sa.String(), nullable=False),
+        sa.Column("rule_id", sa.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "notification_type IN ("
+            "'habit_nudge', 'routine_checklist', 'checkin_prompt', "
+            "'time_block_reminder', 'deadline_event_alert', "
+            "'pattern_observation', 'stale_work_nudge')",
+            name="ck_notification_queue_notification_type",
+        ),
+        sa.CheckConstraint(
+            "delivery_type IN ('notification')",
+            name="ck_notification_queue_delivery_type",
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending', 'delivered', 'responded', 'expired')",
+            name="ck_notification_queue_status",
+        ),
+        sa.CheckConstraint(
+            "scheduled_by IN ('system', 'claude', 'rule')",
+            name="ck_notification_queue_scheduled_by",
+        ),
+    )
+
+    op.create_index(
+        "ix_nq_scheduler_poll",
+        "notification_queue",
+        ["status", "scheduled_at"],
+    )
+    op.create_index(
+        "ix_nq_expiry_check",
+        "notification_queue",
+        ["status", "expires_at"],
+    )
+    op.create_index(
+        "ix_nq_target_lookup",
+        "notification_queue",
+        ["target_entity_type", "target_entity_id"],
+    )
+    op.create_index(
+        "ix_nq_rule_traceability",
+        "notification_queue",
+        ["rule_id"],
+    )
+    op.create_index(
+        "ix_nq_type_filter",
+        "notification_queue",
+        ["notification_type"],
+    )
+    op.create_index(
+        "ix_nq_scheduled_by",
+        "notification_queue",
+        ["scheduled_by"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_nq_scheduled_by", table_name="notification_queue")
+    op.drop_index("ix_nq_type_filter", table_name="notification_queue")
+    op.drop_index("ix_nq_rule_traceability", table_name="notification_queue")
+    op.drop_index("ix_nq_target_lookup", table_name="notification_queue")
+    op.drop_index("ix_nq_expiry_check", table_name="notification_queue")
+    op.drop_index("ix_nq_scheduler_poll", table_name="notification_queue")
+    op.drop_table("notification_queue")

--- a/app/models.py
+++ b/app/models.py
@@ -913,3 +913,80 @@ class Skill(Base):
         secondary="skill_directives", back_populates="skills",
     )
     artifact: Mapped["Artifact | None"] = relationship(back_populates="skills")
+
+
+# ---------------------------------------------------------------------------
+# Notification Queue — proactive notification system
+# ---------------------------------------------------------------------------
+
+class NotificationQueue(Base):
+    """Queued notification awaiting delivery and optional user response."""
+
+    __tablename__ = "notification_queue"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4,
+    )
+    notification_type: Mapped[str] = mapped_column(String, nullable=False)
+    delivery_type: Mapped[str] = mapped_column(
+        String, nullable=False, server_default="notification",
+    )
+    status: Mapped[str] = mapped_column(
+        String, nullable=False, server_default="pending",
+    )
+    scheduled_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )
+    target_entity_type: Mapped[str] = mapped_column(String, nullable=False)
+    target_entity_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False,
+    )
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    canned_responses: Mapped[list | None] = mapped_column(
+        JSON().with_variant(JSONB, "postgresql"),
+    )
+    response: Mapped[str | None] = mapped_column(String)
+    response_note: Mapped[str | None] = mapped_column(Text)
+    responded_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+    )
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+    )
+    scheduled_by: Mapped[str] = mapped_column(String, nullable=False)
+    rule_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "notification_type IN ("
+            "'habit_nudge', 'routine_checklist', 'checkin_prompt', "
+            "'time_block_reminder', 'deadline_event_alert', "
+            "'pattern_observation', 'stale_work_nudge'"
+            ")",
+            name="ck_notification_queue_notification_type",
+        ),
+        CheckConstraint(
+            "delivery_type IN ('notification')",
+            name="ck_notification_queue_delivery_type",
+        ),
+        CheckConstraint(
+            "status IN ('pending', 'delivered', 'responded', 'expired')",
+            name="ck_notification_queue_status",
+        ),
+        CheckConstraint(
+            "scheduled_by IN ('system', 'claude', 'rule')",
+            name="ck_notification_queue_scheduled_by",
+        ),
+        Index("ix_nq_scheduler_poll", "status", "scheduled_at"),
+        Index("ix_nq_expiry_check", "status", "expires_at"),
+        Index("ix_nq_target_lookup", "target_entity_type", "target_entity_id"),
+        Index("ix_nq_rule_traceability", "rule_id"),
+        Index("ix_nq_type_filter", "notification_type"),
+        Index("ix_nq_scheduled_by", "scheduled_by"),
+    )

--- a/tests/test_notification_queue.py
+++ b/tests/test_notification_queue.py
@@ -1,0 +1,261 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for the NotificationQueue model — instantiation, defaults, and constraints."""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models import NotificationQueue
+
+# ---------------------------------------------------------------------------
+# Valid notification types, statuses, delivery types, and scheduled_by values
+# ---------------------------------------------------------------------------
+
+VALID_NOTIFICATION_TYPES = [
+    "habit_nudge",
+    "routine_checklist",
+    "checkin_prompt",
+    "time_block_reminder",
+    "deadline_event_alert",
+    "pattern_observation",
+    "stale_work_nudge",
+]
+
+VALID_STATUSES = ["pending", "delivered", "responded", "expired"]
+
+VALID_DELIVERY_TYPES = ["notification"]
+
+VALID_SCHEDULED_BY = ["system", "claude", "rule"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_notification(**overrides) -> NotificationQueue:
+    """Build a NotificationQueue instance with sensible defaults."""
+    defaults = {
+        "id": uuid.uuid4(),
+        "notification_type": "habit_nudge",
+        "delivery_type": "notification",
+        "status": "pending",
+        "scheduled_at": datetime.now(timezone.utc),
+        "target_entity_type": "habit",
+        "target_entity_id": uuid.uuid4(),
+        "message": "Time to stretch!",
+        "scheduled_by": "system",
+    }
+    defaults.update(overrides)
+    return NotificationQueue(**defaults)
+
+
+def _persist(db, notification: NotificationQueue) -> NotificationQueue:
+    """Add, commit, and refresh a notification in the test DB."""
+    db.add(notification)
+    db.commit()
+    db.refresh(notification)
+    return notification
+
+
+# ---------------------------------------------------------------------------
+# Model instantiation tests
+# ---------------------------------------------------------------------------
+
+class TestNotificationQueueModel:
+    """NotificationQueue model can be instantiated and persisted."""
+
+    def test_create_minimal_notification(self, db):
+        """A notification with only required fields persists correctly."""
+        n = _make_notification()
+        result = _persist(db, n)
+
+        assert result.id is not None
+        assert result.notification_type == "habit_nudge"
+        assert result.delivery_type == "notification"
+        assert result.status == "pending"
+        assert result.message == "Time to stretch!"
+        assert result.scheduled_by == "system"
+        assert result.target_entity_type == "habit"
+        assert result.target_entity_id is not None
+
+    def test_create_notification_with_all_fields(self, db):
+        """A notification with every optional field set persists correctly."""
+        now = datetime.now(timezone.utc)
+        rule_id = uuid.uuid4()
+        n = _make_notification(
+            canned_responses=["Done", "Skip", "Snooze"],
+            response="Done",
+            response_note="Felt good today",
+            responded_at=now,
+            expires_at=now,
+            rule_id=rule_id,
+        )
+        result = _persist(db, n)
+
+        assert result.canned_responses == ["Done", "Skip", "Snooze"]
+        assert result.response == "Done"
+        assert result.response_note == "Felt good today"
+        assert result.responded_at is not None
+        assert result.expires_at is not None
+        assert result.rule_id == rule_id
+
+    def test_nullable_fields_default_to_none(self, db):
+        """Optional fields are None when not provided."""
+        n = _make_notification()
+        result = _persist(db, n)
+
+        assert result.canned_responses is None
+        assert result.response is None
+        assert result.response_note is None
+        assert result.responded_at is None
+        assert result.expires_at is None
+        assert result.rule_id is None
+
+    def test_server_defaults_applied(self, db):
+        """Server defaults for delivery_type, status, created_at, updated_at are set."""
+        n = NotificationQueue(
+            id=uuid.uuid4(),
+            notification_type="checkin_prompt",
+            scheduled_at=datetime.now(timezone.utc),
+            target_entity_type="checkin",
+            target_entity_id=uuid.uuid4(),
+            message="How are you feeling?",
+            scheduled_by="claude",
+        )
+        result = _persist(db, n)
+
+        assert result.delivery_type == "notification"
+        assert result.status == "pending"
+        assert result.created_at is not None
+        assert result.updated_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Enum membership tests
+# ---------------------------------------------------------------------------
+
+class TestNotificationTypeValues:
+    """All 7 notification types are accepted."""
+
+    @pytest.mark.parametrize("ntype", VALID_NOTIFICATION_TYPES)
+    def test_valid_notification_type(self, db, ntype):
+        n = _make_notification(notification_type=ntype)
+        result = _persist(db, n)
+        assert result.notification_type == ntype
+
+    def test_invalid_notification_type_rejected(self, db):
+        n = _make_notification(notification_type="invalid_type")
+        db.add(n)
+        with pytest.raises(IntegrityError):
+            db.commit()
+
+
+class TestNotificationStatusValues:
+    """All 4 statuses are accepted."""
+
+    @pytest.mark.parametrize("status", VALID_STATUSES)
+    def test_valid_status(self, db, status):
+        n = _make_notification(status=status)
+        result = _persist(db, n)
+        assert result.status == status
+
+    def test_invalid_status_rejected(self, db):
+        n = _make_notification(status="cancelled")
+        db.add(n)
+        with pytest.raises(IntegrityError):
+            db.commit()
+
+
+class TestDeliveryTypeValues:
+    """DeliveryType enum — currently single value."""
+
+    @pytest.mark.parametrize("dtype", VALID_DELIVERY_TYPES)
+    def test_valid_delivery_type(self, db, dtype):
+        n = _make_notification(delivery_type=dtype)
+        result = _persist(db, n)
+        assert result.delivery_type == dtype
+
+    def test_invalid_delivery_type_rejected(self, db):
+        n = _make_notification(delivery_type="email")
+        db.add(n)
+        with pytest.raises(IntegrityError):
+            db.commit()
+
+
+class TestScheduledByValues:
+    """ScheduledBy enum — system, claude, or rule."""
+
+    @pytest.mark.parametrize("sched", VALID_SCHEDULED_BY)
+    def test_valid_scheduled_by(self, db, sched):
+        n = _make_notification(scheduled_by=sched)
+        result = _persist(db, n)
+        assert result.scheduled_by == sched
+
+    def test_invalid_scheduled_by_rejected(self, db):
+        n = _make_notification(scheduled_by="cron")
+        db.add(n)
+        with pytest.raises(IntegrityError):
+            db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Target entity type tests (plain string — not enum-constrained)
+# ---------------------------------------------------------------------------
+
+class TestTargetEntityType:
+    """target_entity_type is a plain string, accepts any entity kind."""
+
+    @pytest.mark.parametrize(
+        "entity_type",
+        ["habit", "routine", "task", "checkin", "goal", "project"],
+    )
+    def test_known_entity_types(self, db, entity_type):
+        n = _make_notification(target_entity_type=entity_type)
+        result = _persist(db, n)
+        assert result.target_entity_type == entity_type
+
+    def test_future_entity_type_accepted(self, db):
+        """Plain string column accepts new entity types without migration."""
+        n = _make_notification(target_entity_type="milestone")
+        result = _persist(db, n)
+        assert result.target_entity_type == "milestone"
+
+
+# ---------------------------------------------------------------------------
+# JSONB canned_responses tests
+# ---------------------------------------------------------------------------
+
+class TestCannedResponses:
+    """canned_responses stores and retrieves JSON arrays correctly."""
+
+    def test_string_array(self, db):
+        n = _make_notification(canned_responses=["Yes", "No", "Maybe"])
+        result = _persist(db, n)
+        assert result.canned_responses == ["Yes", "No", "Maybe"]
+
+    def test_empty_array(self, db):
+        n = _make_notification(canned_responses=[])
+        result = _persist(db, n)
+        assert result.canned_responses == []
+
+    def test_null_canned_responses(self, db):
+        n = _make_notification()
+        result = _persist(db, n)
+        assert result.canned_responses is None


### PR DESCRIPTION
## Summary
Adds the `notification_queue` table — the foundation for BRAIN's proactive notification system. This is the handoff point between Claude's session intelligence and BRAIN's delivery pipeline. Claude (or system rules) writes to the queue; BRAIN reads from it and delivers.

## Changes
- **`app/models.py`** — Added `NotificationQueue` model with 18 columns: UUID PK, 4 enum-constrained String fields (`notification_type`, `status`, `delivery_type`, `scheduled_by`), polymorphic target reference (`target_entity_type` + `target_entity_id`), JSONB `canned_responses`, response fields, `rule_id` (no FK — rules table deferred to Stream F), and standard timestamps with server defaults.
- **`alembic/versions/012_create_notification_queue.py`** — Migration creating the table with all 4 CheckConstraints and 6 indexes (`ix_nq_scheduler_poll`, `ix_nq_expiry_check`, `ix_nq_target_lookup`, `ix_nq_rule_traceability`, `ix_nq_type_filter`, `ix_nq_scheduled_by`). Fully reversible — downgrade drops indexes then table.
- **`tests/test_notification_queue.py`** — 33 tests covering model instantiation (minimal + full), server defaults, parametrized validation for all 4 constrained enums (valid values accepted, invalid values rejected via IntegrityError), target entity type flexibility, and JSONB canned_responses round-trip.

## How to Verify
1. `git checkout feature/2B-01-notification-queue-table-model`
2. `python -m pytest tests/test_notification_queue.py -v` — 33 tests pass
3. `python -m pytest -v` — full suite: 738 pass, 0 fail
4. `ruff check .` — clean
5. Against a Postgres instance: `alembic upgrade head` then `alembic downgrade -1` to verify reversibility

## Deviations
1. **CheckConstraints instead of PostgreSQL enum types.** The spec calls for creating PostgreSQL enum types (`notificationtype`, `notificationstatus`, etc.) in the migration. The existing codebase consistently uses String columns with CheckConstraints for all enum-like fields (see Goal.status, Task.status, Habit.status, etc.). Additionally, the test suite uses SQLite in-memory — PostgreSQL enum types are incompatible with SQLite, so switching patterns would break the test harness. Followed existing patterns for consistency and test compatibility.
2. **Model in `app/models.py`, not `models/notification.py`.** The spec suggests `models/notification.py` but the project uses a single `app/models.py` file for all models. Followed existing structure.
3. **No `models/enums.py` file.** Spec suggests a separate enum file, but with CheckConstraint-based validation, enum values live in the model's `__table_args__`. Consistent with existing patterns.
4. **Pydantic schemas deferred.** The spec includes schemas in acceptance criteria, but per implementation guardrails schemas are scoped to [2B-02]. No schemas created.
5. **`scheduled_by` uses `rule` instead of `failsafe`.** The issue spec defines `ScheduledBy` with values `system`, `claude`, `rule`. The assignment context mentions `failsafe` — followed the issue spec as authoritative.

## Test Results
```
============================= 738 passed in 9.89s =============================
```

All 33 notification queue tests pass. Full suite: 738 passed, 0 failed.
`ruff check .` — All checks passed.

## Acceptance Checklist
- [x] `notification_queue` table created via Alembic migration
- [x] All 4 enum-equivalent constraints defined (CheckConstraint pattern)
- [x] SQLAlchemy model with all columns, types, and defaults
- [ ] Pydantic schemas for create, update, and response — **deferred to [2B-02] per guardrails**
- [x] All 6 indexes created in migration
- [x] `rule_id` column present (no FK constraint — deferred to Stream F)
- [x] Migration is reversible (downgrade drops table and indexes)
- [x] Model follows existing codebase patterns
- [x] Tests: model instantiation, constraint validation (valid + invalid inputs), enum membership

Closes #119