### PR TITLE
2B-02: Notification Queue CRUD API Endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -31,6 +31,7 @@ from app.routers import (
     domains,
     goals,
     habits,
+    notification,
     projects,
     protocols,
     reports,
@@ -99,6 +100,9 @@ app.include_router(
     directives.directive_tags_router, prefix="/api/directives", tags=["Directive Tags"],
 )
 app.include_router(skills.router, prefix="/api/skills", tags=["Skills"])
+app.include_router(
+    notification.router, prefix="/api/notifications", tags=["Notifications"],
+)
 app.include_router(
     skills.skill_domains_router, prefix="/api/skills", tags=["Skill Domains"],
 )

--- a/app/routers/notification.py
+++ b/app/routers/notification.py
@@ -1,0 +1,219 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""CRUD endpoints for the Notification Queue."""
+
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import NotificationQueue
+from app.schemas.notifications import (
+    NotificationCreate,
+    NotificationResponse,
+    NotificationUpdate,
+)
+
+router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# Status state machine
+# ---------------------------------------------------------------------------
+
+VALID_TRANSITIONS: dict[str, set[str]] = {
+    "pending": {"delivered", "expired"},
+    "delivered": {"responded", "expired"},
+    "responded": set(),
+    "expired": set(),
+}
+
+# Fields that cannot be changed via PATCH
+IMMUTABLE_FIELDS = {
+    "notification_type",
+    "target_entity_type",
+    "target_entity_id",
+    "scheduled_by",
+    "response",
+    "responded_at",
+}
+
+
+def validate_status_transition(current: str, requested: str) -> bool:
+    """Return True if the status transition is allowed."""
+    return requested in VALID_TRANSITIONS.get(current, set())
+
+
+# ---------------------------------------------------------------------------
+# POST — create notification
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/", response_model=NotificationResponse, status_code=status.HTTP_201_CREATED,
+)
+def create_notification(
+    payload: NotificationCreate, db: Session = Depends(get_db),
+) -> NotificationQueue:
+    """Create a notification. Status is always set to pending."""
+    data = payload.model_dump()
+    data["status"] = "pending"
+    notification = NotificationQueue(**data)
+    db.add(notification)
+    db.commit()
+    db.refresh(notification)
+    return notification
+
+
+# ---------------------------------------------------------------------------
+# GET list — with composable filters
+# ---------------------------------------------------------------------------
+
+@router.get("/", response_model=list[NotificationResponse])
+def list_notifications(
+    notification_type: str | None = Query(None),
+    notification_status: str | None = Query(None, alias="status"),
+    delivery_type: str | None = Query(None),
+    target_entity_type: str | None = Query(None),
+    target_entity_id: UUID | None = Query(None),
+    scheduled_by: str | None = Query(None),
+    scheduled_after: datetime | None = Query(None),
+    scheduled_before: datetime | None = Query(None),
+    has_response: bool | None = Query(None),
+    rule_id: UUID | None = Query(None),
+    db: Session = Depends(get_db),
+) -> list[NotificationQueue]:
+    """List notifications with composable filters."""
+    query = db.query(NotificationQueue)
+
+    if notification_type is not None:
+        query = query.filter(NotificationQueue.notification_type == notification_type)
+    if notification_status is not None:
+        query = query.filter(NotificationQueue.status == notification_status)
+    if delivery_type is not None:
+        query = query.filter(NotificationQueue.delivery_type == delivery_type)
+    if target_entity_type is not None:
+        query = query.filter(
+            NotificationQueue.target_entity_type == target_entity_type,
+        )
+    if target_entity_id is not None:
+        query = query.filter(
+            NotificationQueue.target_entity_id == target_entity_id,
+        )
+    if scheduled_by is not None:
+        query = query.filter(NotificationQueue.scheduled_by == scheduled_by)
+    if scheduled_after is not None:
+        query = query.filter(NotificationQueue.scheduled_at >= scheduled_after)
+    if scheduled_before is not None:
+        query = query.filter(NotificationQueue.scheduled_at < scheduled_before)
+    if has_response is True:
+        query = query.filter(NotificationQueue.status == "responded")
+    elif has_response is False:
+        query = query.filter(NotificationQueue.status != "responded")
+    if rule_id is not None:
+        query = query.filter(NotificationQueue.rule_id == rule_id)
+
+    return query.order_by(NotificationQueue.scheduled_at.desc()).all()
+
+
+# ---------------------------------------------------------------------------
+# GET detail
+# ---------------------------------------------------------------------------
+
+@router.get("/{notification_id}", response_model=NotificationResponse)
+def get_notification(
+    notification_id: UUID, db: Session = Depends(get_db),
+) -> NotificationQueue:
+    """Get a single notification by ID."""
+    notification = (
+        db.query(NotificationQueue)
+        .filter(NotificationQueue.id == notification_id)
+        .first()
+    )
+    if not notification:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return notification
+
+
+# ---------------------------------------------------------------------------
+# PATCH — partial update with status transition enforcement
+# ---------------------------------------------------------------------------
+
+@router.patch("/{notification_id}", response_model=NotificationResponse)
+async def update_notification(
+    notification_id: UUID,
+    request: Request,
+    payload: NotificationUpdate,
+    db: Session = Depends(get_db),
+) -> NotificationQueue:
+    """Partial update of a notification with status state machine enforcement."""
+    notification = (
+        db.query(NotificationQueue)
+        .filter(NotificationQueue.id == notification_id)
+        .first()
+    )
+    if not notification:
+        raise HTTPException(status_code=404, detail="Notification not found")
+
+    # Check raw request body for immutable fields (Pydantic strips unknown keys)
+    raw_body = await request.json()
+    immutable_in_request = set(raw_body.keys()) & IMMUTABLE_FIELDS
+    if immutable_in_request:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Cannot update immutable fields: {', '.join(sorted(immutable_in_request))}",
+        )
+
+    updates = payload.model_dump(exclude_unset=True)
+
+    # Enforce status state machine
+    if "status" in updates:
+        requested = updates["status"]
+        current = notification.status
+        if not validate_status_transition(current, requested):
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid status transition: {current} → {requested}",
+            )
+
+    for field, value in updates.items():
+        setattr(notification, field, value)
+
+    db.commit()
+    db.refresh(notification)
+    return notification
+
+
+# ---------------------------------------------------------------------------
+# DELETE
+# ---------------------------------------------------------------------------
+
+@router.delete("/{notification_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_notification(
+    notification_id: UUID, db: Session = Depends(get_db),
+) -> None:
+    """Delete a notification."""
+    notification = (
+        db.query(NotificationQueue)
+        .filter(NotificationQueue.id == notification_id)
+        .first()
+    )
+    if not notification:
+        raise HTTPException(status_code=404, detail="Notification not found")
+
+    db.delete(notification)
+    db.commit()

--- a/app/schemas/notifications.py
+++ b/app/schemas/notifications.py
@@ -1,0 +1,123 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Pydantic schemas for Notification Queue CRUD operations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+NotificationType = Literal[
+    "habit_nudge",
+    "routine_checklist",
+    "checkin_prompt",
+    "time_block_reminder",
+    "deadline_event_alert",
+    "pattern_observation",
+    "stale_work_nudge",
+]
+
+NotificationStatus = Literal["pending", "delivered", "responded", "expired"]
+
+DeliveryType = Literal["notification"]
+
+ScheduledBy = Literal["system", "claude", "rule"]
+
+
+class NotificationCreate(BaseModel):
+    """Fields required to create a notification."""
+
+    notification_type: NotificationType
+    delivery_type: DeliveryType = "notification"
+    scheduled_at: datetime
+    target_entity_type: str = Field(min_length=1)
+    target_entity_id: UUID
+    message: str = Field(min_length=1, max_length=2000)
+    canned_responses: list[str] | None = None
+    expires_at: datetime | None = None
+    scheduled_by: ScheduledBy
+    rule_id: UUID | None = None
+
+    @field_validator("canned_responses")
+    @classmethod
+    def validate_canned_responses(
+        cls, v: list[str] | None,
+    ) -> list[str] | None:
+        if v is None:
+            return v
+        if len(v) < 1 or len(v) > 10:
+            msg = "canned_responses must contain 1-10 items"
+            raise ValueError(msg)
+        for item in v:
+            if not isinstance(item, str) or len(item) < 1 or len(item) > 200:
+                msg = "Each canned response must be a non-empty string up to 200 characters"
+                raise ValueError(msg)
+        return v
+
+
+class NotificationUpdate(BaseModel):
+    """Partial update fields for a notification. Immutable fields excluded."""
+
+    delivery_type: DeliveryType | None = None
+    status: NotificationStatus | None = None
+    scheduled_at: datetime | None = None
+    message: str | None = Field(default=None, min_length=1, max_length=2000)
+    canned_responses: list[str] | None = None
+    expires_at: datetime | None = None
+
+    @field_validator("canned_responses")
+    @classmethod
+    def validate_canned_responses(
+        cls, v: list[str] | None,
+    ) -> list[str] | None:
+        if v is None:
+            return v
+        if len(v) < 1 or len(v) > 10:
+            msg = "canned_responses must contain 1-10 items"
+            raise ValueError(msg)
+        for item in v:
+            if not isinstance(item, str) or len(item) < 1 or len(item) > 200:
+                msg = "Each canned response must be a non-empty string up to 200 characters"
+                raise ValueError(msg)
+        return v
+
+
+class NotificationResponse(BaseModel):
+    """Notification returned from API — includes id and timestamps."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    notification_type: str
+    delivery_type: str
+    status: str
+    scheduled_at: datetime
+    target_entity_type: str
+    target_entity_id: UUID
+    message: str
+    canned_responses: list[str] | None = None
+    response: str | None = None
+    response_note: str | None = None
+    responded_at: datetime | None = None
+    expires_at: datetime | None = None
+    scheduled_by: str
+    rule_id: UUID | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/tests/test_notification_crud.py
+++ b/tests/test_notification_crud.py
@@ -1,0 +1,565 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for Notification Queue CRUD API endpoints."""
+
+import uuid
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BASE_URL = "/api/notifications"
+
+VALID_NOTIFICATION = {
+    "notification_type": "habit_nudge",
+    "delivery_type": "notification",
+    "scheduled_at": "2026-04-15T09:00:00Z",
+    "target_entity_type": "habit",
+    "target_entity_id": str(uuid.uuid4()),
+    "message": "Time to stretch!",
+    "scheduled_by": "system",
+}
+
+
+def make_notification(client, **overrides) -> dict:
+    """Create a notification via the API and return the response JSON."""
+    data = {**VALID_NOTIFICATION, **overrides}
+    # Ensure target_entity_id is unique per call unless overridden
+    if "target_entity_id" not in overrides:
+        data["target_entity_id"] = str(uuid.uuid4())
+    resp = client.post(BASE_URL, json=data)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# POST — Create
+# ---------------------------------------------------------------------------
+
+class TestCreateNotification:
+    """POST /api/notifications"""
+
+    def test_create_minimal(self, client):
+        """Create a notification with only required fields."""
+        result = make_notification(client)
+        assert result["notification_type"] == "habit_nudge"
+        assert result["status"] == "pending"
+        assert result["message"] == "Time to stretch!"
+        assert result["id"] is not None
+        assert result["created_at"] is not None
+
+    def test_create_with_canned_responses(self, client):
+        """Create with valid canned_responses array."""
+        result = make_notification(
+            client, canned_responses=["Done", "Skip", "Snooze"],
+        )
+        assert result["canned_responses"] == ["Done", "Skip", "Snooze"]
+
+    def test_create_with_all_optional_fields(self, client):
+        """Create with every optional field populated."""
+        rule_id = str(uuid.uuid4())
+        result = make_notification(
+            client,
+            canned_responses=["Yes", "No"],
+            expires_at="2026-04-16T09:00:00Z",
+            rule_id=rule_id,
+        )
+        assert result["canned_responses"] == ["Yes", "No"]
+        assert result["expires_at"] is not None
+        assert result["rule_id"] == rule_id
+
+    def test_create_always_sets_pending(self, client):
+        """Status is always pending on create, regardless of input."""
+        # NotificationCreate schema doesn't include status field,
+        # so even if we pass it, it's ignored by Pydantic.
+        data = {**VALID_NOTIFICATION, "target_entity_id": str(uuid.uuid4())}
+        resp = client.post(BASE_URL, json=data)
+        assert resp.status_code == 201
+        assert resp.json()["status"] == "pending"
+
+    def test_create_empty_message_rejected(self, client):
+        """Empty message returns 422."""
+        data = {**VALID_NOTIFICATION, "message": "", "target_entity_id": str(uuid.uuid4())}
+        resp = client.post(BASE_URL, json=data)
+        assert resp.status_code == 422
+
+    def test_create_oversized_message_rejected(self, client):
+        """Message over 2000 chars returns 422."""
+        data = {
+            **VALID_NOTIFICATION,
+            "message": "x" * 2001,
+            "target_entity_id": str(uuid.uuid4()),
+        }
+        resp = client.post(BASE_URL, json=data)
+        assert resp.status_code == 422
+
+    def test_create_invalid_notification_type(self, client):
+        """Invalid notification_type returns 422."""
+        data = {
+            **VALID_NOTIFICATION,
+            "notification_type": "invalid_type",
+            "target_entity_id": str(uuid.uuid4()),
+        }
+        resp = client.post(BASE_URL, json=data)
+        assert resp.status_code == 422
+
+    def test_create_invalid_scheduled_by(self, client):
+        """Invalid scheduled_by returns 422."""
+        data = {
+            **VALID_NOTIFICATION,
+            "scheduled_by": "cron",
+            "target_entity_id": str(uuid.uuid4()),
+        }
+        resp = client.post(BASE_URL, json=data)
+        assert resp.status_code == 422
+
+    def test_create_canned_responses_too_many(self, client):
+        """More than 10 canned responses returns 422."""
+        data = {
+            **VALID_NOTIFICATION,
+            "canned_responses": [f"opt{i}" for i in range(11)],
+            "target_entity_id": str(uuid.uuid4()),
+        }
+        resp = client.post(BASE_URL, json=data)
+        assert resp.status_code == 422
+
+    def test_create_canned_responses_empty_string(self, client):
+        """Canned response with empty string returns 422."""
+        data = {
+            **VALID_NOTIFICATION,
+            "canned_responses": ["Valid", ""],
+            "target_entity_id": str(uuid.uuid4()),
+        }
+        resp = client.post(BASE_URL, json=data)
+        assert resp.status_code == 422
+
+    def test_create_canned_responses_oversized_item(self, client):
+        """Canned response item over 200 chars returns 422."""
+        data = {
+            **VALID_NOTIFICATION,
+            "canned_responses": ["x" * 201],
+            "target_entity_id": str(uuid.uuid4()),
+        }
+        resp = client.post(BASE_URL, json=data)
+        assert resp.status_code == 422
+
+    @pytest.mark.parametrize(
+        "ntype",
+        [
+            "habit_nudge", "routine_checklist", "checkin_prompt",
+            "time_block_reminder", "deadline_event_alert",
+            "pattern_observation", "stale_work_nudge",
+        ],
+    )
+    def test_create_all_notification_types(self, client, ntype):
+        """All 7 notification types are accepted."""
+        result = make_notification(client, notification_type=ntype)
+        assert result["notification_type"] == ntype
+
+    @pytest.mark.parametrize("sched", ["system", "claude", "rule"])
+    def test_create_all_scheduled_by(self, client, sched):
+        """All scheduled_by values are accepted."""
+        result = make_notification(client, scheduled_by=sched)
+        assert result["scheduled_by"] == sched
+
+
+# ---------------------------------------------------------------------------
+# GET detail
+# ---------------------------------------------------------------------------
+
+class TestGetNotification:
+    """GET /api/notifications/{id}"""
+
+    def test_get_existing(self, client):
+        """Get a notification by valid ID."""
+        created = make_notification(client)
+        resp = client.get(f"{BASE_URL}/{created['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == created["id"]
+
+    def test_get_not_found(self, client):
+        """Get with invalid UUID returns 404."""
+        resp = client.get(f"{BASE_URL}/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET list — composable filters
+# ---------------------------------------------------------------------------
+
+class TestListNotifications:
+    """GET /api/notifications"""
+
+    def test_list_empty(self, client):
+        """Empty list when no notifications exist."""
+        resp = client.get(BASE_URL)
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_returns_all(self, client):
+        """List returns all created notifications."""
+        make_notification(client)
+        make_notification(client, notification_type="checkin_prompt")
+        resp = client.get(BASE_URL)
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_filter_by_notification_type(self, client):
+        """Filter by notification_type."""
+        make_notification(client, notification_type="habit_nudge")
+        make_notification(client, notification_type="checkin_prompt")
+        resp = client.get(BASE_URL, params={"notification_type": "habit_nudge"})
+        results = resp.json()
+        assert len(results) == 1
+        assert results[0]["notification_type"] == "habit_nudge"
+
+    def test_filter_by_status(self, client):
+        """Filter by status."""
+        n = make_notification(client)
+        # Transition to delivered
+        client.patch(f"{BASE_URL}/{n['id']}", json={"status": "delivered"})
+        make_notification(client)  # stays pending
+
+        resp = client.get(BASE_URL, params={"status": "delivered"})
+        results = resp.json()
+        assert len(results) == 1
+        assert results[0]["status"] == "delivered"
+
+    def test_filter_by_target_entity_type(self, client):
+        """Filter by target_entity_type."""
+        make_notification(client, target_entity_type="habit")
+        make_notification(client, target_entity_type="routine")
+        resp = client.get(BASE_URL, params={"target_entity_type": "routine"})
+        results = resp.json()
+        assert len(results) == 1
+        assert results[0]["target_entity_type"] == "routine"
+
+    def test_filter_by_target_entity_id(self, client):
+        """Filter by target_entity_id."""
+        entity_id = str(uuid.uuid4())
+        make_notification(client, target_entity_id=entity_id)
+        make_notification(client)  # different entity_id
+        resp = client.get(BASE_URL, params={"target_entity_id": entity_id})
+        results = resp.json()
+        assert len(results) == 1
+        assert results[0]["target_entity_id"] == entity_id
+
+    def test_filter_by_scheduled_by(self, client):
+        """Filter by scheduled_by."""
+        make_notification(client, scheduled_by="system")
+        make_notification(client, scheduled_by="claude")
+        resp = client.get(BASE_URL, params={"scheduled_by": "claude"})
+        results = resp.json()
+        assert len(results) == 1
+        assert results[0]["scheduled_by"] == "claude"
+
+    def test_filter_by_date_range(self, client):
+        """Filter by scheduled_after and scheduled_before."""
+        make_notification(client, scheduled_at="2026-04-10T09:00:00Z")
+        make_notification(client, scheduled_at="2026-04-20T09:00:00Z")
+
+        resp = client.get(
+            BASE_URL,
+            params={
+                "scheduled_after": "2026-04-15T00:00:00Z",
+                "scheduled_before": "2026-04-25T00:00:00Z",
+            },
+        )
+        results = resp.json()
+        assert len(results) == 1
+        assert "2026-04-20" in results[0]["scheduled_at"]
+
+    def test_filter_has_response_true(self, client):
+        """has_response=true returns only responded notifications."""
+        n = make_notification(client)
+        # Transition pending → delivered → responded
+        client.patch(f"{BASE_URL}/{n['id']}", json={"status": "delivered"})
+        client.patch(f"{BASE_URL}/{n['id']}", json={"status": "responded"})
+        make_notification(client)  # stays pending
+
+        resp = client.get(BASE_URL, params={"has_response": True})
+        results = resp.json()
+        assert len(results) == 1
+        assert results[0]["status"] == "responded"
+
+    def test_filter_has_response_false(self, client):
+        """has_response=false returns non-responded notifications."""
+        n = make_notification(client)
+        client.patch(f"{BASE_URL}/{n['id']}", json={"status": "delivered"})
+        client.patch(f"{BASE_URL}/{n['id']}", json={"status": "responded"})
+        make_notification(client)  # stays pending
+
+        resp = client.get(BASE_URL, params={"has_response": False})
+        results = resp.json()
+        assert len(results) == 1
+        assert results[0]["status"] == "pending"
+
+    def test_filter_by_rule_id(self, client):
+        """Filter by rule_id."""
+        rid = str(uuid.uuid4())
+        make_notification(client, rule_id=rid)
+        make_notification(client)  # no rule_id
+        resp = client.get(BASE_URL, params={"rule_id": rid})
+        results = resp.json()
+        assert len(results) == 1
+        assert results[0]["rule_id"] == rid
+
+    def test_filter_by_delivery_type(self, client):
+        """Filter by delivery_type."""
+        make_notification(client)
+        resp = client.get(BASE_URL, params={"delivery_type": "notification"})
+        results = resp.json()
+        assert len(results) == 1
+
+    def test_combined_filters(self, client):
+        """Multiple filters combine with AND logic."""
+        target_id = str(uuid.uuid4())
+        make_notification(
+            client,
+            notification_type="habit_nudge",
+            scheduled_by="claude",
+            target_entity_id=target_id,
+        )
+        make_notification(
+            client,
+            notification_type="habit_nudge",
+            scheduled_by="system",
+        )
+        make_notification(
+            client,
+            notification_type="checkin_prompt",
+            scheduled_by="claude",
+        )
+
+        resp = client.get(
+            BASE_URL,
+            params={
+                "notification_type": "habit_nudge",
+                "scheduled_by": "claude",
+            },
+        )
+        results = resp.json()
+        assert len(results) == 1
+        assert results[0]["target_entity_id"] == target_id
+
+    def test_list_sorted_by_scheduled_at_desc(self, client):
+        """List is sorted by scheduled_at descending."""
+        make_notification(client, scheduled_at="2026-04-10T09:00:00Z")
+        make_notification(client, scheduled_at="2026-04-20T09:00:00Z")
+        make_notification(client, scheduled_at="2026-04-15T09:00:00Z")
+
+        resp = client.get(BASE_URL)
+        results = resp.json()
+        assert len(results) == 3
+        # Most recent first
+        assert "2026-04-20" in results[0]["scheduled_at"]
+        assert "2026-04-15" in results[1]["scheduled_at"]
+        assert "2026-04-10" in results[2]["scheduled_at"]
+
+
+# ---------------------------------------------------------------------------
+# PATCH — Update
+# ---------------------------------------------------------------------------
+
+class TestUpdateNotification:
+    """PATCH /api/notifications/{id}"""
+
+    def test_update_message(self, client):
+        """Update the message field."""
+        n = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}", json={"message": "Updated message"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["message"] == "Updated message"
+
+    def test_update_not_found(self, client):
+        """Update with invalid UUID returns 404."""
+        resp = client.patch(
+            f"{BASE_URL}/{uuid.uuid4()}", json={"message": "nope"},
+        )
+        assert resp.status_code == 404
+
+    # --- Valid status transitions ---
+
+    def test_transition_pending_to_delivered(self, client):
+        n = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}", json={"status": "delivered"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "delivered"
+
+    def test_transition_pending_to_expired(self, client):
+        n = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}", json={"status": "expired"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "expired"
+
+    def test_transition_delivered_to_responded(self, client):
+        n = make_notification(client)
+        client.patch(f"{BASE_URL}/{n['id']}", json={"status": "delivered"})
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}", json={"status": "responded"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "responded"
+
+    def test_transition_delivered_to_expired(self, client):
+        n = make_notification(client)
+        client.patch(f"{BASE_URL}/{n['id']}", json={"status": "delivered"})
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}", json={"status": "expired"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "expired"
+
+    # --- Invalid status transitions ---
+
+    def test_invalid_transition_responded_to_any(self, client):
+        """responded is terminal — cannot transition out."""
+        n = make_notification(client)
+        client.patch(f"{BASE_URL}/{n['id']}", json={"status": "delivered"})
+        client.patch(f"{BASE_URL}/{n['id']}", json={"status": "responded"})
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}", json={"status": "pending"},
+        )
+        assert resp.status_code == 422
+        assert "Invalid status transition" in resp.json()["detail"]
+
+    def test_invalid_transition_expired_to_any(self, client):
+        """expired is terminal — cannot transition out."""
+        n = make_notification(client)
+        client.patch(f"{BASE_URL}/{n['id']}", json={"status": "expired"})
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}", json={"status": "pending"},
+        )
+        assert resp.status_code == 422
+        assert "Invalid status transition" in resp.json()["detail"]
+
+    def test_invalid_transition_delivered_to_pending(self, client):
+        """Cannot go back from delivered to pending."""
+        n = make_notification(client)
+        client.patch(f"{BASE_URL}/{n['id']}", json={"status": "delivered"})
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}", json={"status": "pending"},
+        )
+        assert resp.status_code == 422
+
+    def test_invalid_transition_pending_to_responded(self, client):
+        """Cannot respond to something not yet delivered."""
+        n = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}", json={"status": "responded"},
+        )
+        assert resp.status_code == 422
+
+    # --- Immutable fields ---
+
+    def test_reject_immutable_notification_type(self, client):
+        n = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}",
+            json={"notification_type": "checkin_prompt"},
+        )
+        assert resp.status_code == 422
+        assert "immutable" in resp.json()["detail"].lower()
+
+    def test_reject_immutable_target_entity_type(self, client):
+        n = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}",
+            json={"target_entity_type": "routine"},
+        )
+        assert resp.status_code == 422
+
+    def test_reject_immutable_target_entity_id(self, client):
+        n = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}",
+            json={"target_entity_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 422
+
+    def test_reject_immutable_scheduled_by(self, client):
+        n = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}", json={"scheduled_by": "claude"},
+        )
+        assert resp.status_code == 422
+
+    def test_reject_immutable_response(self, client):
+        n = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}", json={"response": "Done"},
+        )
+        assert resp.status_code == 422
+
+    def test_reject_immutable_responded_at(self, client):
+        n = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}",
+            json={"responded_at": "2026-04-15T10:00:00Z"},
+        )
+        assert resp.status_code == 422
+
+    def test_update_canned_responses(self, client):
+        """Canned responses can be updated."""
+        n = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}",
+            json={"canned_responses": ["A", "B"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["canned_responses"] == ["A", "B"]
+
+    def test_update_scheduled_at(self, client):
+        """scheduled_at can be updated."""
+        n = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}",
+            json={"scheduled_at": "2026-05-01T12:00:00Z"},
+        )
+        assert resp.status_code == 200
+        assert "2026-05-01" in resp.json()["scheduled_at"]
+
+
+# ---------------------------------------------------------------------------
+# DELETE
+# ---------------------------------------------------------------------------
+
+class TestDeleteNotification:
+    """DELETE /api/notifications/{id}"""
+
+    def test_delete_existing(self, client):
+        """Delete returns 204 and notification is gone."""
+        n = make_notification(client)
+        resp = client.delete(f"{BASE_URL}/{n['id']}")
+        assert resp.status_code == 204
+
+        # Confirm gone
+        resp = client.get(f"{BASE_URL}/{n['id']}")
+        assert resp.status_code == 404
+
+    def test_delete_not_found(self, client):
+        """Delete with invalid UUID returns 404."""
+        resp = client.delete(f"{BASE_URL}/{uuid.uuid4()}")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Implements the full CRUD API for the `notification_queue` table — 5 endpoints at `/api/notifications` with composable list filters and status state machine enforcement.

Closes #120

## Changes

**New files:**
- `app/schemas/notifications.py` — Pydantic schemas: `NotificationCreate`, `NotificationUpdate`, `NotificationResponse`. Includes validation for `canned_responses` (1–10 items, each 1–200 chars) and message length (1–2000 chars). Enum literals for `notification_type`, `status`, `delivery_type`, `scheduled_by`.
- `app/routers/notification.py` — Router with all 5 endpoints:
  - **POST** `/api/notifications` — creates with `status=pending` always, validates enums and canned_responses structure
  - **GET** `/api/notifications` — 10 composable filters (notification_type, status, delivery_type, target_entity_type, target_entity_id, scheduled_by, scheduled_after, scheduled_before, has_response, rule_id), AND logic, sorted by `scheduled_at` descending
  - **GET** `/api/notifications/{id}` — single notification detail, 404 if not found
  - **PATCH** `/api/notifications/{id}` — partial update with status state machine enforcement (422 on invalid transitions) and immutable field rejection (notification_type, target_entity_type, target_entity_id, scheduled_by, response, responded_at)
  - **DELETE** `/api/notifications/{id}` — hard delete, 204 on success, 404 if not found
- `tests/test_notification_crud.py` — 57 tests covering all acceptance criteria
- `validate_status_transition()` extracted as a reusable function for [2B-03]

**Modified files:**
- `app/main.py` — registered the notifications router

## How to Verify
1. `git checkout feature/2B-02-notification-queue-crud`
2. `python -m pytest tests/test_notification_crud.py -v` — 57 tests pass
3. `python -m pytest -v` — full suite: 795 tests pass, no regressions
4. `ruff check .` — clean

## Deviations
- The spec mentions "If `canned_responses` is null/omitted, auto-populate from type defaults (see [2B-04])." Since [2B-04] hasn't shipped yet and no default mapping exists, `canned_responses` is left as null when not provided. [2B-04] will add the auto-populate logic.
- Immutable field rejection inspects the raw request body via `Request.json()` rather than relying on Pydantic schema exclusion — Pydantic silently strips unknown fields, so raw body inspection is needed to catch attempts to set immutable fields and return a clear 422.

## Test Results
```
57 passed in 0.81s (notification CRUD)
795 passed in 11.23s (full suite)
ruff check: All checks passed!
```

## Acceptance Checklist
- [x] All 5 endpoints implemented and returning correct status codes
- [x] Composable filters on list endpoint (all 10 filter parameters)
- [x] Status state machine enforced — invalid transitions return 422
- [x] Immutable fields rejected on update
- [x] Create auto-sets `status=pending` regardless of input
- [x] Tests: happy path CRUD (create, get, list, update, delete)
- [x] Tests: each valid status transition succeeds
- [x] Tests: each invalid status transition returns 422
- [x] Tests: immutable field update rejected
- [x] Tests: validation errors (empty message, invalid enum, oversized canned_responses)
- [x] Tests: composable filters (by type, status, target_entity, scheduled_by, date range, delivery_type, rule_id, has_response, combined)
- [x] Tests: 404 on get/update/delete with invalid UUID