### PR TITLE
2B-03: Response Recording & Silence Tracking

### DIFF
--- a/app/routers/notification.py
+++ b/app/routers/notification.py
@@ -16,7 +16,7 @@
 
 """CRUD endpoints for the Notification Queue."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -26,6 +26,7 @@ from app.database import get_db
 from app.models import NotificationQueue
 from app.schemas.notifications import (
     NotificationCreate,
+    NotificationRespondRequest,
     NotificationResponse,
     NotificationUpdate,
 )
@@ -146,6 +147,63 @@ def get_notification(
     )
     if not notification:
         raise HTTPException(status_code=404, detail="Notification not found")
+    return notification
+
+
+# ---------------------------------------------------------------------------
+# POST — record a response to a delivered notification
+# ---------------------------------------------------------------------------
+
+@router.post("/{notification_id}/respond", response_model=NotificationResponse)
+def respond_to_notification(
+    notification_id: UUID,
+    payload: NotificationRespondRequest,
+    db: Session = Depends(get_db),
+) -> NotificationQueue:
+    """Record a user response to a delivered notification."""
+    notification = (
+        db.query(NotificationQueue)
+        .filter(NotificationQueue.id == notification_id)
+        .first()
+    )
+    if not notification:
+        raise HTTPException(status_code=404, detail="Notification not found")
+
+    # Status-specific error responses
+    if notification.status == "pending":
+        raise HTTPException(
+            status_code=409,
+            detail="Notification has not been delivered yet",
+        )
+    if notification.status == "responded":
+        raise HTTPException(
+            status_code=409,
+            detail="Notification has already been responded to",
+        )
+    if notification.status == "expired":
+        raise HTTPException(
+            status_code=410,
+            detail="Notification has expired",
+        )
+
+    # Validate response against canned_responses (if defined)
+    if payload.response != "partial" and notification.canned_responses is not None:
+        if payload.response not in notification.canned_responses:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Invalid response: must be one of {notification.canned_responses} "
+                    'or "partial"'
+                ),
+            )
+
+    notification.response = payload.response
+    notification.response_note = payload.response_note
+    notification.responded_at = datetime.now(tz=UTC)
+    notification.status = "responded"
+
+    db.commit()
+    db.refresh(notification)
     return notification
 
 

--- a/app/schemas/notifications.py
+++ b/app/schemas/notifications.py
@@ -99,6 +99,13 @@ class NotificationUpdate(BaseModel):
         return v
 
 
+class NotificationRespondRequest(BaseModel):
+    """Request body for responding to a delivered notification."""
+
+    response: str = Field(min_length=1, max_length=200)
+    response_note: str | None = Field(default=None, max_length=1000)
+
+
 class NotificationResponse(BaseModel):
     """Notification returned from API — includes id and timestamps."""
 

--- a/tests/test_notification_respond.py
+++ b/tests/test_notification_respond.py
@@ -1,0 +1,327 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for POST /api/notifications/{id}/respond endpoint."""
+
+import uuid
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BASE_URL = "/api/notifications"
+
+NOTIFICATION_TYPES = [
+    "habit_nudge",
+    "routine_checklist",
+    "checkin_prompt",
+    "time_block_reminder",
+    "deadline_event_alert",
+    "pattern_observation",
+    "stale_work_nudge",
+]
+
+# Canned responses per notification type (representative examples from the design doc)
+TYPE_CANNED_RESPONSES = {
+    "habit_nudge": ["Already done", "Doing it now", "I forgot, on it", "Skip today"],
+    "routine_checklist": ["All done", "Partial", "Skipping tonight"],
+    "checkin_prompt": ["Feeling good", "Okay", "Struggling"],
+    "time_block_reminder": ["On it", "Need more time", "Skipping"],
+    "deadline_event_alert": ["Acknowledged", "Need help"],
+    "pattern_observation": ["Thanks", "Noted"],
+    "stale_work_nudge": ["On it", "Deprioritized", "Done already"],
+}
+
+
+def make_notification(client, **overrides) -> dict:
+    """Create a notification via the API and return the response JSON."""
+    data = {
+        "notification_type": "habit_nudge",
+        "delivery_type": "notification",
+        "scheduled_at": "2026-04-15T09:00:00Z",
+        "target_entity_type": "habit",
+        "target_entity_id": str(uuid.uuid4()),
+        "message": "Time to stretch!",
+        "scheduled_by": "system",
+        **overrides,
+    }
+    if "target_entity_id" not in overrides:
+        data["target_entity_id"] = str(uuid.uuid4())
+    resp = client.post(BASE_URL, json=data)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def deliver(client, notification_id: str) -> dict:
+    """Transition a notification from pending → delivered."""
+    resp = client.patch(
+        f"{BASE_URL}/{notification_id}", json={"status": "delivered"},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def expire(client, notification_id: str) -> dict:
+    """Transition a notification to expired (pending → expired)."""
+    resp = client.patch(
+        f"{BASE_URL}/{notification_id}", json={"status": "expired"},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Happy path — response for each notification type
+# ---------------------------------------------------------------------------
+
+class TestRespondHappyPath:
+    """POST /api/notifications/{id}/respond — success cases."""
+
+    @pytest.mark.parametrize("ntype", NOTIFICATION_TYPES)
+    def test_respond_each_notification_type(self, client, ntype):
+        """Response accepted for each of the 7 notification types."""
+        canned = TYPE_CANNED_RESPONSES[ntype]
+        n = make_notification(
+            client,
+            notification_type=ntype,
+            canned_responses=canned,
+        )
+        deliver(client, n["id"])
+
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": canned[0]},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "responded"
+        assert body["response"] == canned[0]
+        assert body["responded_at"] is not None
+
+    def test_respond_sets_responded_at_utc(self, client):
+        """responded_at is set to a UTC timestamp on success."""
+        n = make_notification(
+            client, canned_responses=["Done"],
+        )
+        deliver(client, n["id"])
+
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Done"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["responded_at"] is not None
+
+    def test_respond_with_response_note(self, client):
+        """response_note is stored when provided."""
+        n = make_notification(
+            client, canned_responses=["Done", "Skip"],
+        )
+        deliver(client, n["id"])
+
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Done", "response_note": "Did it early today"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["response_note"] == "Did it early today"
+
+
+# ---------------------------------------------------------------------------
+# Partial completion
+# ---------------------------------------------------------------------------
+
+class TestPartialCompletion:
+    """Partial response is always valid regardless of canned_responses."""
+
+    def test_partial_accepted_with_canned_responses(self, client):
+        """'partial' accepted even when not in canned_responses list."""
+        n = make_notification(
+            client,
+            canned_responses=["All done", "Skipping tonight"],
+        )
+        deliver(client, n["id"])
+
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "partial"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["response"] == "partial"
+        assert resp.json()["status"] == "responded"
+
+    def test_partial_with_response_note(self, client):
+        """'partial' with freeform response_note."""
+        n = make_notification(
+            client, canned_responses=["Done"],
+        )
+        deliver(client, n["id"])
+
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "partial", "response_note": "Did 3 of 5 items"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["response"] == "partial"
+        assert resp.json()["response_note"] == "Did 3 of 5 items"
+
+    def test_partial_without_response_note(self, client):
+        """'partial' without response_note is valid."""
+        n = make_notification(
+            client, canned_responses=["Done"],
+        )
+        deliver(client, n["id"])
+
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "partial"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["response_note"] is None
+
+
+# ---------------------------------------------------------------------------
+# Null canned_responses — any non-empty response accepted
+# ---------------------------------------------------------------------------
+
+class TestNullCannedResponses:
+    """Notifications with null canned_responses accept any non-empty response."""
+
+    def test_any_response_accepted(self, client):
+        """Any string accepted when canned_responses is null."""
+        n = make_notification(client)  # no canned_responses
+        assert n["canned_responses"] is None
+        deliver(client, n["id"])
+
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Freestyle answer"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["response"] == "Freestyle answer"
+
+    def test_partial_also_accepted(self, client):
+        """'partial' still works with null canned_responses."""
+        n = make_notification(client)
+        deliver(client, n["id"])
+
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "partial"},
+        )
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+class TestRespondErrors:
+    """POST /api/notifications/{id}/respond — error scenarios."""
+
+    def test_404_not_found(self, client):
+        """Invalid notification ID returns 404."""
+        resp = client.post(
+            f"{BASE_URL}/{uuid.uuid4()}/respond",
+            json={"response": "Done"},
+        )
+        assert resp.status_code == 404
+
+    def test_409_pending_not_delivered(self, client):
+        """Responding to a pending notification returns 409."""
+        n = make_notification(client, canned_responses=["Done"])
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Done"},
+        )
+        assert resp.status_code == 409
+        assert "not been delivered" in resp.json()["detail"]
+
+    def test_409_already_responded(self, client):
+        """Responding to an already-responded notification returns 409."""
+        n = make_notification(client, canned_responses=["Done"])
+        deliver(client, n["id"])
+        # First response
+        client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Done"},
+        )
+        # Second response attempt
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Done"},
+        )
+        assert resp.status_code == 409
+        assert "already been responded to" in resp.json()["detail"]
+
+    def test_410_expired(self, client):
+        """Responding to an expired notification returns 410."""
+        n = make_notification(client, canned_responses=["Done"])
+        expire(client, n["id"])
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Done"},
+        )
+        assert resp.status_code == 410
+        assert "expired" in resp.json()["detail"]
+
+    def test_422_invalid_response(self, client):
+        """Response not in canned_responses (and not 'partial') returns 422."""
+        n = make_notification(
+            client, canned_responses=["Done", "Skip"],
+        )
+        deliver(client, n["id"])
+
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Not a valid option"},
+        )
+        assert resp.status_code == 422
+
+    def test_422_empty_response(self, client):
+        """Empty string response returns 422 (Pydantic min_length=1)."""
+        n = make_notification(client, canned_responses=["Done"])
+        deliver(client, n["id"])
+
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": ""},
+        )
+        assert resp.status_code == 422
+
+    def test_422_response_too_long(self, client):
+        """Response over 200 chars returns 422."""
+        n = make_notification(client)
+        deliver(client, n["id"])
+
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "x" * 201},
+        )
+        assert resp.status_code == 422
+
+    def test_422_response_note_too_long(self, client):
+        """response_note over 1000 chars returns 422."""
+        n = make_notification(client, canned_responses=["Done"])
+        deliver(client, n["id"])
+
+        resp = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Done", "response_note": "x" * 1001},
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Adds `POST /api/notifications/{id}/respond` — the inbound half of the notification loop. When the Companion App delivers a notification and the user taps a canned response button, this endpoint records the structured response, sets `responded_at` to the current UTC time, and transitions the notification status from `delivered` → `responded`.

Silence tracking is architecturally enabled by this ticket's boundary: a notification that reaches `expired` status with `response = NULL` and `responded_at = NULL` is the silence signal. The expiry mechanism itself is [2B-05]'s scope; this ticket ensures the data model is ready to distinguish "responded" from "silent."

## Changes

**`app/schemas/notifications.py`** — Added `NotificationRespondRequest` schema with `response` (str, 1–200 chars) and optional `response_note` (str, max 1000 chars).

**`app/routers/notification.py`** — Added `POST /{notification_id}/respond` endpoint with:
- Status-aware error handling: 409 for pending/already-responded, 410 for expired
- Response validation against the notification's `canned_responses` array
- `"partial"` always accepted as a special-case response regardless of canned_responses content
- Null `canned_responses` passthrough: any non-empty response accepted
- `responded_at` set to current UTC, status transitioned to `responded`

**`tests/test_notification_respond.py`** — 22 new tests organized into 4 classes:
- `TestRespondHappyPath` — parametrized across all 7 notification types, response_note, responded_at verification
- `TestPartialCompletion` — partial with/without response_note, partial bypassing canned_responses
- `TestNullCannedResponses` — freestyle response accepted, partial also works
- `TestRespondErrors` — 404, 409 pending, 409 responded, 410 expired, 422 invalid response, 422 empty, 422 response too long, 422 response_note too long

## How to Verify

```bash
git checkout feature/2B-03-response-recording-silence-tracking
pytest tests/test_notification_respond.py -v   # 22 pass
pytest -v                                       # 817 pass, no regressions
ruff check .                                    # clean
```

Manual verification:
1. Create a notification with canned_responses
2. PATCH status to `delivered`
3. POST `/{id}/respond` with a valid canned response — expect 200, status=responded, responded_at set
4. POST again — expect 409 "already been responded to"
5. Create another, leave as pending, POST respond — expect 409 "not been delivered yet"
6. Create another, expire it, POST respond — expect 410 "expired"

## Deviations

None. Implementation follows the spec as written.

## Test Results

```
22 passed in 0.38s (test_notification_respond.py)
817 passed in 10.51s (full suite)
ruff check: All checks passed!
```

## Acceptance Checklist

- [x] POST `/api/notifications/{id}/respond` implemented
- [x] Returns 200 with updated notification on success
- [x] Returns 404 for invalid notification ID
- [x] Returns 409 for pending notification (not yet delivered)
- [x] Returns 409 for already-responded notification
- [x] Returns 410 for expired notification
- [x] Returns 422 for response not in canned_responses (and not "partial")
- [x] `"partial"` accepted as valid response for any notification type
- [x] `response_note` accepted with partial responses
- [x] `responded_at` set to current UTC time on successful response
- [x] Status transitions to `responded` on success
- [x] Notifications with null canned_responses accept any non-empty response
- [x] Tests: happy path response for each of the 7 notification types
- [x] Tests: partial completion with and without response_note
- [x] Tests: each error case (404, 409 pending, 409 responded, 410 expired, 422 invalid response)
- [x] Tests: response_note max length validation
- [x] Tests: null canned_responses accepts any response

Closes #121