### PR TITLE
TICKET-122: Canned response defaults and validation

### DIFF
--- a/app/routers/notification.py
+++ b/app/routers/notification.py
@@ -30,6 +30,7 @@ from app.schemas.notifications import (
     NotificationResponse,
     NotificationUpdate,
 )
+from app.services.notification_defaults import get_default_responses
 
 router = APIRouter()
 
@@ -70,9 +71,14 @@ def validate_status_transition(current: str, requested: str) -> bool:
 def create_notification(
     payload: NotificationCreate, db: Session = Depends(get_db),
 ) -> NotificationQueue:
-    """Create a notification. Status is always set to pending."""
+    """Create a notification. Status is always set to pending.
+
+    When canned_responses is null/omitted, auto-populates from type defaults.
+    """
     data = payload.model_dump()
     data["status"] = "pending"
+    if data.get("canned_responses") is None:
+        data["canned_responses"] = get_default_responses(data["notification_type"])
     notification = NotificationQueue(**data)
     db.add(notification)
     db.commit()

--- a/app/schemas/notifications.py
+++ b/app/schemas/notifications.py
@@ -24,6 +24,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from app.services.notification_defaults import validate_canned_responses
+
 NotificationType = Literal[
     "habit_nudge",
     "routine_checklist",
@@ -57,18 +59,12 @@ class NotificationCreate(BaseModel):
 
     @field_validator("canned_responses")
     @classmethod
-    def validate_canned_responses(
+    def check_canned_responses(
         cls, v: list[str] | None,
     ) -> list[str] | None:
         if v is None:
             return v
-        if len(v) < 1 or len(v) > 10:
-            msg = "canned_responses must contain 1-10 items"
-            raise ValueError(msg)
-        for item in v:
-            if not isinstance(item, str) or len(item) < 1 or len(item) > 200:
-                msg = "Each canned response must be a non-empty string up to 200 characters"
-                raise ValueError(msg)
+        validate_canned_responses(v)
         return v
 
 
@@ -84,18 +80,12 @@ class NotificationUpdate(BaseModel):
 
     @field_validator("canned_responses")
     @classmethod
-    def validate_canned_responses(
+    def check_canned_responses(
         cls, v: list[str] | None,
     ) -> list[str] | None:
         if v is None:
             return v
-        if len(v) < 1 or len(v) > 10:
-            msg = "canned_responses must contain 1-10 items"
-            raise ValueError(msg)
-        for item in v:
-            if not isinstance(item, str) or len(item) < 1 or len(item) > 200:
-                msg = "Each canned response must be a non-empty string up to 200 characters"
-                raise ValueError(msg)
+        validate_canned_responses(v)
         return v
 
 

--- a/app/services/notification_defaults.py
+++ b/app/services/notification_defaults.py
@@ -1,0 +1,101 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Default canned responses and validation for the notification queue."""
+
+from __future__ import annotations
+
+CANNED_RESPONSE_DEFAULTS: dict[str, list[str]] = {
+    "habit_nudge": [
+        "Already done",
+        "Doing it now",
+        "I forgot, on it",
+        "Skip today",
+    ],
+    "routine_checklist": [
+        "All done",
+        "Partial",
+        "Skipping tonight",
+    ],
+    "checkin_prompt": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+    ],
+    "time_block_reminder": [
+        "On it",
+        "Need 10 more minutes",
+        "Skipping",
+    ],
+    "deadline_event_alert": [
+        "Acknowledged",
+        "Reschedule",
+    ],
+    "pattern_observation": [
+        "Thanks, I'll look at it",
+        "Noted",
+        "Let's talk about it",
+    ],
+    "stale_work_nudge": [
+        "I'll look",
+        "Not today",
+        "Remove from my list",
+    ],
+}
+
+
+def get_default_responses(notification_type: str) -> list[str] | None:
+    """Return the default canned responses for a notification type, or None."""
+    defaults = CANNED_RESPONSE_DEFAULTS.get(notification_type)
+    if defaults is not None:
+        return list(defaults)
+    return None
+
+
+def validate_canned_responses(responses: list[str]) -> None:
+    """Validate a canned_responses list. Raises ValueError on failure."""
+    if not isinstance(responses, list):
+        msg = "canned_responses must be an array of strings"
+        raise ValueError(msg)
+
+    if len(responses) < 1:
+        msg = "canned_responses must have at least 1 option"
+        raise ValueError(msg)
+
+    if len(responses) > 10:
+        msg = "canned_responses cannot exceed 10 options"
+        raise ValueError(msg)
+
+    seen: set[str] = set()
+    for item in responses:
+        if not isinstance(item, str):
+            msg = "canned_responses must be an array of strings"
+            raise ValueError(msg)
+
+        if not item.strip():
+            msg = "Canned response options cannot be blank"
+            raise ValueError(msg)
+
+        if len(item) < 1 or len(item) > 200:
+            msg = "Each canned response must be 1-200 characters"
+            raise ValueError(msg)
+
+        if item in seen:
+            msg = "canned_responses contains duplicate entries"
+            raise ValueError(msg)
+        seen.add(item)

--- a/tests/test_notification_defaults.py
+++ b/tests/test_notification_defaults.py
@@ -1,0 +1,281 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for [2B-04] canned response defaults and validation."""
+
+import uuid
+
+import pytest
+
+from app.services.notification_defaults import (
+    CANNED_RESPONSE_DEFAULTS,
+    get_default_responses,
+    validate_canned_responses,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BASE_URL = "/api/notifications"
+
+NOTIFICATION_TYPES = [
+    "habit_nudge",
+    "routine_checklist",
+    "checkin_prompt",
+    "time_block_reminder",
+    "deadline_event_alert",
+    "pattern_observation",
+    "stale_work_nudge",
+]
+
+
+def make_notification(client, **overrides) -> dict:
+    """Create a notification via the API and return the response JSON."""
+    data = {
+        "notification_type": "habit_nudge",
+        "delivery_type": "notification",
+        "scheduled_at": "2026-04-15T09:00:00Z",
+        "target_entity_type": "habit",
+        "target_entity_id": str(uuid.uuid4()),
+        "message": "Time to stretch!",
+        "scheduled_by": "system",
+        **overrides,
+    }
+    resp = client.post(BASE_URL, json=data)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ===========================================================================
+# Unit tests — CANNED_RESPONSE_DEFAULTS constant
+# ===========================================================================
+
+
+class TestCannedResponseDefaults:
+    """The defaults dict covers all 7 notification types."""
+
+    def test_all_types_present(self):
+        for ntype in NOTIFICATION_TYPES:
+            assert ntype in CANNED_RESPONSE_DEFAULTS
+
+    def test_no_extra_types(self):
+        assert set(CANNED_RESPONSE_DEFAULTS.keys()) == set(NOTIFICATION_TYPES)
+
+    @pytest.mark.parametrize("ntype", NOTIFICATION_TYPES)
+    def test_defaults_are_non_empty_string_lists(self, ntype):
+        defaults = CANNED_RESPONSE_DEFAULTS[ntype]
+        assert isinstance(defaults, list)
+        assert len(defaults) >= 1
+        for item in defaults:
+            assert isinstance(item, str)
+            assert len(item) >= 1
+
+
+# ===========================================================================
+# Unit tests — get_default_responses
+# ===========================================================================
+
+
+class TestGetDefaultResponses:
+    """get_default_responses returns a copy of defaults, or None."""
+
+    @pytest.mark.parametrize("ntype", NOTIFICATION_TYPES)
+    def test_returns_defaults_for_known_types(self, ntype):
+        result = get_default_responses(ntype)
+        assert result == CANNED_RESPONSE_DEFAULTS[ntype]
+
+    def test_returns_none_for_unknown_type(self):
+        assert get_default_responses("nonexistent_type") is None
+
+    def test_returns_copy_not_reference(self):
+        result = get_default_responses("habit_nudge")
+        result.append("mutated")
+        assert "mutated" not in CANNED_RESPONSE_DEFAULTS["habit_nudge"]
+
+
+# ===========================================================================
+# Unit tests — validate_canned_responses
+# ===========================================================================
+
+
+class TestValidateCannedResponses:
+    """Validation rules from the spec."""
+
+    def test_valid_single_item(self):
+        validate_canned_responses(["OK"])
+
+    def test_valid_ten_items(self):
+        validate_canned_responses([f"Option {i}" for i in range(10)])
+
+    def test_valid_200_char_string(self):
+        validate_canned_responses(["x" * 200])
+
+    def test_rejects_empty_list(self):
+        with pytest.raises(ValueError, match="at least 1 option"):
+            validate_canned_responses([])
+
+    def test_rejects_more_than_10(self):
+        with pytest.raises(ValueError, match="cannot exceed 10"):
+            validate_canned_responses([f"Option {i}" for i in range(11)])
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="cannot be blank"):
+            validate_canned_responses([""])
+
+    def test_rejects_whitespace_only_string(self):
+        with pytest.raises(ValueError, match="cannot be blank"):
+            validate_canned_responses(["   "])
+
+    def test_rejects_string_over_200_chars(self):
+        with pytest.raises(ValueError, match="1-200 characters"):
+            validate_canned_responses(["x" * 201])
+
+    def test_rejects_duplicates(self):
+        with pytest.raises(ValueError, match="duplicate entries"):
+            validate_canned_responses(["Same", "Same"])
+
+    def test_rejects_non_string_item(self):
+        with pytest.raises(ValueError, match="array of strings"):
+            validate_canned_responses([123])  # type: ignore[list-item]
+
+    def test_rejects_non_list(self):
+        with pytest.raises(ValueError, match="array of strings"):
+            validate_canned_responses("not a list")  # type: ignore[arg-type]
+
+
+# ===========================================================================
+# Integration tests — auto-population on create
+# ===========================================================================
+
+
+class TestAutoPopulationOnCreate:
+    """When canned_responses is omitted, defaults are auto-populated."""
+
+    @pytest.mark.parametrize("ntype", NOTIFICATION_TYPES)
+    def test_auto_populates_defaults_when_omitted(self, client, ntype):
+        notif = make_notification(client, notification_type=ntype)
+        assert notif["canned_responses"] == CANNED_RESPONSE_DEFAULTS[ntype]
+
+    @pytest.mark.parametrize("ntype", NOTIFICATION_TYPES)
+    def test_auto_populates_defaults_when_null(self, client, ntype):
+        notif = make_notification(
+            client, notification_type=ntype, canned_responses=None,
+        )
+        assert notif["canned_responses"] == CANNED_RESPONSE_DEFAULTS[ntype]
+
+    def test_explicit_canned_responses_preserved(self, client):
+        custom = ["Yes", "No", "Maybe"]
+        notif = make_notification(client, canned_responses=custom)
+        assert notif["canned_responses"] == custom
+
+    def test_explicit_single_item_preserved(self, client):
+        custom = ["Acknowledged"]
+        notif = make_notification(client, canned_responses=custom)
+        assert notif["canned_responses"] == custom
+
+
+# ===========================================================================
+# Integration tests — validation through the API
+# ===========================================================================
+
+
+class TestValidationThroughAPI:
+    """Validation errors return 422 through create and update endpoints."""
+
+    def test_create_rejects_empty_list(self, client):
+        resp = client.post(BASE_URL, json={
+            "notification_type": "habit_nudge",
+            "scheduled_at": "2026-04-15T09:00:00Z",
+            "target_entity_type": "habit",
+            "target_entity_id": str(uuid.uuid4()),
+            "message": "Test",
+            "scheduled_by": "system",
+            "canned_responses": [],
+        })
+        assert resp.status_code == 422
+
+    def test_create_rejects_more_than_10(self, client):
+        resp = client.post(BASE_URL, json={
+            "notification_type": "habit_nudge",
+            "scheduled_at": "2026-04-15T09:00:00Z",
+            "target_entity_type": "habit",
+            "target_entity_id": str(uuid.uuid4()),
+            "message": "Test",
+            "scheduled_by": "system",
+            "canned_responses": [f"Opt {i}" for i in range(11)],
+        })
+        assert resp.status_code == 422
+
+    def test_create_rejects_blank_string(self, client):
+        resp = client.post(BASE_URL, json={
+            "notification_type": "habit_nudge",
+            "scheduled_at": "2026-04-15T09:00:00Z",
+            "target_entity_type": "habit",
+            "target_entity_id": str(uuid.uuid4()),
+            "message": "Test",
+            "scheduled_by": "system",
+            "canned_responses": ["   "],
+        })
+        assert resp.status_code == 422
+
+    def test_create_rejects_string_over_200(self, client):
+        resp = client.post(BASE_URL, json={
+            "notification_type": "habit_nudge",
+            "scheduled_at": "2026-04-15T09:00:00Z",
+            "target_entity_type": "habit",
+            "target_entity_id": str(uuid.uuid4()),
+            "message": "Test",
+            "scheduled_by": "system",
+            "canned_responses": ["x" * 201],
+        })
+        assert resp.status_code == 422
+
+    def test_create_rejects_duplicates(self, client):
+        resp = client.post(BASE_URL, json={
+            "notification_type": "habit_nudge",
+            "scheduled_at": "2026-04-15T09:00:00Z",
+            "target_entity_type": "habit",
+            "target_entity_id": str(uuid.uuid4()),
+            "message": "Test",
+            "scheduled_by": "system",
+            "canned_responses": ["Same", "Same"],
+        })
+        assert resp.status_code == 422
+
+    def test_update_rejects_empty_list(self, client):
+        notif = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{notif['id']}", json={"canned_responses": []},
+        )
+        assert resp.status_code == 422
+
+    def test_update_rejects_duplicates(self, client):
+        notif = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{notif['id']}",
+            json={"canned_responses": ["Dup", "Dup"]},
+        )
+        assert resp.status_code == 422
+
+    def test_update_accepts_valid_canned_responses(self, client):
+        notif = make_notification(client)
+        resp = client.patch(
+            f"{BASE_URL}/{notif['id']}",
+            json={"canned_responses": ["New A", "New B"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["canned_responses"] == ["New A", "New B"]

--- a/tests/test_notification_respond.py
+++ b/tests/test_notification_respond.py
@@ -202,10 +202,15 @@ class TestPartialCompletion:
 class TestNullCannedResponses:
     """Notifications with null canned_responses accept any non-empty response."""
 
-    def test_any_response_accepted(self, client):
-        """Any string accepted when canned_responses is null."""
-        n = make_notification(client)  # no canned_responses
-        assert n["canned_responses"] is None
+    def test_any_response_accepted_when_canned_responses_cleared(self, client):
+        """Any string accepted when canned_responses is explicitly cleared to null."""
+        n = make_notification(client)
+        # Auto-populated defaults are present; clear them via PATCH
+        resp = client.patch(
+            f"{BASE_URL}/{n['id']}", json={"canned_responses": None},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["canned_responses"] is None
         deliver(client, n["id"])
 
         resp = client.post(
@@ -215,9 +220,17 @@ class TestNullCannedResponses:
         assert resp.status_code == 200
         assert resp.json()["response"] == "Freestyle answer"
 
+    def test_defaults_auto_populated_when_omitted(self, client):
+        """Omitting canned_responses auto-populates from type defaults."""
+        n = make_notification(client)  # habit_nudge, no explicit canned_responses
+        assert n["canned_responses"] is not None
+        assert "Already done" in n["canned_responses"]
+
     def test_partial_also_accepted(self, client):
         """'partial' still works with null canned_responses."""
         n = make_notification(client)
+        # Clear auto-populated defaults
+        client.patch(f"{BASE_URL}/{n['id']}", json={"canned_responses": None})
         deliver(client, n["id"])
 
         resp = client.post(


### PR DESCRIPTION
## Summary

- Defines `CANNED_RESPONSE_DEFAULTS` constant with the 7 notification types' default one-tap response options from the design doc
- Auto-populates `canned_responses` on notification create when omitted or null
- Centralizes validation logic (min/max items, length, duplicates, blanks) in a shared service function, replacing the duplicated Pydantic validators

Closes #122

## Changes

**New file: `app/services/notification_defaults.py`**
Contains the `CANNED_RESPONSE_DEFAULTS` dict, `get_default_responses()` lookup function, and `validate_canned_responses()` validation function. Pure business logic, no database access — follows the existing service pattern from `streak.py`.

**Modified: `app/schemas/notifications.py`**
Both `NotificationCreate` and `NotificationUpdate` field validators now delegate to the shared `validate_canned_responses()` function instead of duplicating the logic. Validation error messages now match the spec exactly (e.g. "canned_responses must have at least 1 option", "canned_responses contains duplicate entries", "Canned response options cannot be blank").

**Modified: `app/routers/notification.py`**
The create endpoint now calls `get_default_responses()` when `canned_responses` is null/omitted, populating the field from type defaults before persisting.

**Modified: `tests/test_notification_respond.py`**
Updated the `TestNullCannedResponses` class to account for auto-population. The "any response accepted" test now explicitly clears defaults via PATCH to test the null-canned-responses path. Added a test confirming defaults are auto-populated when omitted.

**New file: `tests/test_notification_defaults.py`**
53 tests covering:
- Defaults dict completeness (all 7 types, no extras)
- `get_default_responses()` return values and copy safety
- Validation: all 6 rejection rules + edge cases (1-item, 10-item, 200-char boundary)
- Auto-population integration: parametrized across all 7 types for both omitted and explicit-null
- Explicit canned_responses preservation (not overwritten by defaults)
- API-level validation through create and update endpoints

## How to Verify

```bash
# Run the new test file
pytest tests/test_notification_defaults.py -v

# Run the updated respond tests
pytest tests/test_notification_respond.py -v

# Full suite — no regressions
pytest -v

# Lint
ruff check .
```

## Deviations

The spec defines `CANNED_RESPONSE_DEFAULTS` using `NotificationType` enum keys. The implementation uses plain strings (`"habit_nudge"` etc.) since `NotificationType` in this codebase is a `Literal` type alias, not a Python enum — it cannot be used as dict keys in the same way. The string values match exactly.

## Test Results

```
871 passed in 12.24s
All checks passed! (ruff)
```

## Acceptance Checklist

- [x] `CANNED_RESPONSE_DEFAULTS` dict defined with all 7 notification types
- [x] `get_default_responses(notification_type)` returns correct defaults
- [x] Auto-population on create: null/omitted canned_responses gets defaults
- [x] Auto-population on create: explicitly provided canned_responses is preserved
- [x] Validation rejects: non-array, empty array, >10 items, empty strings, strings >200 chars, duplicates
- [x] Validation passes for valid arrays within constraints
- [x] Tests: auto-population for each notification type
- [x] Tests: explicit canned_responses preserved over defaults
- [x] Tests: each validation failure case
- [x] Tests: edge cases (1 item array, 10 item array, 200-char string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)