### PR TITLE
2F-01: Rules table model, migration, and enum definitions

### DIFF
--- a/alembic/versions/013_add_rules_table.py
+++ b/alembic/versions/013_add_rules_table.py
@@ -1,0 +1,135 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Add rules table and FK on notification_queue.rule_id.
+
+Revision ID: 13a1b2c3d4e5
+Revises: 12a1b2c3d4e5
+Create Date: 2026-04-15
+
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "13a1b2c3d4e5"
+down_revision: Union[str, None] = "12a1b2c3d4e5"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+# Postgres enum types for the rules engine
+rule_entity_type = sa.Enum(
+    "habit", "task", "routine", "checkin",
+    name="ruleentitytype",
+    create_constraint=False,
+)
+rule_metric = sa.Enum(
+    "consecutive_skips", "days_untouched", "non_responses", "streak_length",
+    name="rulemetric",
+    create_constraint=False,
+)
+rule_operator = sa.Enum(
+    ">=", "<=", "==",
+    name="ruleoperator",
+    create_constraint=False,
+)
+rule_action = sa.Enum(
+    "create_notification",
+    name="ruleaction",
+    create_constraint=False,
+)
+
+
+def upgrade() -> None:
+    # Create the rules table (Postgres enum types are created automatically)
+    op.create_table(
+        "rules",
+        sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(200), nullable=False),
+        sa.Column("entity_type", rule_entity_type, nullable=False),
+        sa.Column("entity_id", sa.UUID(as_uuid=True), nullable=True),
+        sa.Column("metric", rule_metric, nullable=False),
+        sa.Column("operator", rule_operator, nullable=False),
+        sa.Column("threshold", sa.Integer(), nullable=False),
+        sa.Column(
+            "action", rule_action, nullable=False,
+            server_default="create_notification",
+        ),
+        sa.Column("notification_type", sa.String(), nullable=False),
+        sa.Column("message_template", sa.Text(), nullable=False),
+        sa.Column(
+            "enabled", sa.Boolean(), nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "cooldown_hours", sa.Integer(), nullable=False,
+            server_default=sa.text("24"),
+        ),
+        sa.Column(
+            "last_triggered_at", sa.DateTime(timezone=True), nullable=True,
+        ),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "notification_type IN ("
+            "'habit_nudge', 'routine_checklist', 'checkin_prompt', "
+            "'time_block_reminder', 'deadline_event_alert', "
+            "'pattern_observation', 'stale_work_nudge')",
+            name="ck_rules_notification_type",
+        ),
+    )
+
+    op.create_index(
+        "ix_rules_entity_lookup", "rules",
+        ["entity_type", "enabled"],
+    )
+    op.create_index(
+        "ix_rules_entity_scoped", "rules",
+        ["entity_type", "entity_id"],
+    )
+
+    # 3. Add FK constraint on notification_queue.rule_id → rules.id
+    op.create_foreign_key(
+        "fk_nq_rule_id",
+        "notification_queue", "rules",
+        ["rule_id"], ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    # 1. Drop the FK constraint
+    op.drop_constraint("fk_nq_rule_id", "notification_queue", type_="foreignkey")
+
+    # 2. Drop indexes and the rules table
+    op.drop_index("ix_rules_entity_scoped", table_name="rules")
+    op.drop_index("ix_rules_entity_lookup", table_name="rules")
+    op.drop_table("rules")
+
+    # 3. Drop the Postgres enum types
+    rule_action.drop(op.get_bind(), checkfirst=True)
+    rule_operator.drop(op.get_bind(), checkfirst=True)
+    rule_metric.drop(op.get_bind(), checkfirst=True)
+    rule_entity_type.drop(op.get_bind(), checkfirst=True)

--- a/app/models.py
+++ b/app/models.py
@@ -34,11 +34,15 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
+from sqlalchemy import (
+    Enum as SAEnum,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func, text
 
 from app.database import Base
+from app.schemas.rule import RuleAction, RuleEntityType, RuleMetric, RuleOperator
 
 # ---------------------------------------------------------------------------
 # Association table: task_tags
@@ -954,7 +958,9 @@ class NotificationQueue(Base):
         DateTime(timezone=True),
     )
     scheduled_by: Mapped[str] = mapped_column(String, nullable=False)
-    rule_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
+    rule_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("rules.id", ondelete="SET NULL"),
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(),
     )
@@ -989,4 +995,65 @@ class NotificationQueue(Base):
         Index("ix_nq_rule_traceability", "rule_id"),
         Index("ix_nq_type_filter", "notification_type"),
         Index("ix_nq_scheduled_by", "scheduled_by"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rules Engine — conditional logic layer for automated notifications
+# ---------------------------------------------------------------------------
+
+class Rule(Base):
+    """A rule that watches an entity metric and fires a notification."""
+
+    __tablename__ = "rules"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4,
+    )
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    entity_type: Mapped[RuleEntityType] = mapped_column(
+        SAEnum(RuleEntityType, native_enum=False), nullable=False,
+    )
+    entity_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
+    metric: Mapped[RuleMetric] = mapped_column(
+        SAEnum(RuleMetric, native_enum=False), nullable=False,
+    )
+    operator: Mapped[RuleOperator] = mapped_column(
+        SAEnum(RuleOperator, native_enum=False), nullable=False,
+    )
+    threshold: Mapped[int] = mapped_column(Integer, nullable=False)
+    action: Mapped[RuleAction] = mapped_column(
+        SAEnum(RuleAction, native_enum=False),
+        nullable=False,
+        server_default="create_notification",
+    )
+    notification_type: Mapped[str] = mapped_column(String, nullable=False)
+    message_template: Mapped[str] = mapped_column(Text, nullable=False)
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("true"),
+    )
+    cooldown_hours: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("24"),
+    )
+    last_triggered_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "notification_type IN ("
+            "'habit_nudge', 'routine_checklist', 'checkin_prompt', "
+            "'time_block_reminder', 'deadline_event_alert', "
+            "'pattern_observation', 'stale_work_nudge'"
+            ")",
+            name="ck_rules_notification_type",
+        ),
+        Index("ix_rules_entity_lookup", "entity_type", "enabled"),
+        Index("ix_rules_entity_scoped", "entity_type", "entity_id"),
     )

--- a/app/schemas/rule.py
+++ b/app/schemas/rule.py
@@ -1,0 +1,173 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Pydantic schemas for Rules Engine CRUD operations."""
+
+from __future__ import annotations
+
+import string
+from datetime import datetime
+from enum import Enum
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# ---------------------------------------------------------------------------
+# Enums — Python str enums, mirrored as Postgres enums in the migration
+# ---------------------------------------------------------------------------
+
+NotificationType = Literal[
+    "habit_nudge",
+    "routine_checklist",
+    "checkin_prompt",
+    "time_block_reminder",
+    "deadline_event_alert",
+    "pattern_observation",
+    "stale_work_nudge",
+]
+
+
+class RuleEntityType(str, Enum):
+    habit = "habit"
+    task = "task"
+    routine = "routine"
+    checkin = "checkin"
+
+
+class RuleMetric(str, Enum):
+    consecutive_skips = "consecutive_skips"
+    days_untouched = "days_untouched"
+    non_responses = "non_responses"
+    streak_length = "streak_length"
+
+
+class RuleOperator(str, Enum):
+    """Comparison operators. Names are shorthand; values are DB-stored symbols."""
+    gte = ">="
+    lte = "<="
+    eq = "=="
+
+
+class RuleAction(str, Enum):
+    create_notification = "create_notification"
+
+
+# ---------------------------------------------------------------------------
+# Template placeholder validation
+# ---------------------------------------------------------------------------
+
+ALLOWED_PLACEHOLDERS = frozenset({
+    "entity_name",
+    "entity_type",
+    "metric_value",
+    "threshold",
+    "rule_name",
+})
+
+_formatter = string.Formatter()
+
+
+def validate_message_template(template: str) -> str:
+    """Parse a message template and reject unknown placeholders."""
+    try:
+        parsed = list(_formatter.parse(template))
+    except (ValueError, KeyError) as exc:
+        msg = f"Invalid template syntax: {exc}"
+        raise ValueError(msg) from exc
+
+    for _, field_name, _, _ in parsed:
+        if field_name is None:
+            continue
+        # field_name may be "entity_name.attr" — only validate the root
+        root = field_name.split(".")[0].split("[")[0]
+        if root not in ALLOWED_PLACEHOLDERS:
+            msg = (
+                f"Unknown placeholder '{{{field_name}}}'. "
+                f"Allowed: {sorted(ALLOWED_PLACEHOLDERS)}"
+            )
+            raise ValueError(msg)
+    return template
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
+
+class RuleCreate(BaseModel):
+    """Fields required to create a rule."""
+
+    name: str = Field(min_length=1, max_length=200)
+    entity_type: RuleEntityType
+    entity_id: UUID | None = None
+    metric: RuleMetric
+    operator: RuleOperator
+    threshold: int
+    action: RuleAction = RuleAction.create_notification
+    notification_type: NotificationType
+    message_template: str = Field(min_length=1)
+    enabled: bool = True
+    cooldown_hours: int = 24
+
+    @field_validator("message_template")
+    @classmethod
+    def check_template(cls, v: str) -> str:
+        return validate_message_template(v)
+
+
+class RuleUpdate(BaseModel):
+    """All fields optional — supports partial PATCH updates."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    entity_type: RuleEntityType | None = None
+    entity_id: UUID | None = None
+    metric: RuleMetric | None = None
+    operator: RuleOperator | None = None
+    threshold: int | None = None
+    action: RuleAction | None = None
+    notification_type: NotificationType | None = None
+    message_template: str | None = Field(default=None, min_length=1)
+    enabled: bool | None = None
+    cooldown_hours: int | None = None
+
+    @field_validator("message_template")
+    @classmethod
+    def check_template(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        return validate_message_template(v)
+
+
+class RuleRead(BaseModel):
+    """Rule returned from API — includes id and timestamps."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    entity_type: RuleEntityType
+    entity_id: UUID | None = None
+    metric: RuleMetric
+    operator: RuleOperator
+    threshold: int
+    action: RuleAction
+    notification_type: str
+    message_template: str
+    enabled: bool
+    cooldown_hours: int
+    last_triggered_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/tests/test_notification_crud.py
+++ b/tests/test_notification_crud.py
@@ -20,6 +20,9 @@ import uuid
 
 import pytest
 
+from app.models import Rule
+from app.schemas.rule import RuleAction, RuleEntityType, RuleMetric, RuleOperator
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -71,9 +74,17 @@ class TestCreateNotification:
         )
         assert result["canned_responses"] == ["Done", "Skip", "Snooze"]
 
-    def test_create_with_all_optional_fields(self, client):
+    def test_create_with_all_optional_fields(self, client, db):
         """Create with every optional field populated."""
-        rule_id = str(uuid.uuid4())
+        rule = Rule(
+            id=uuid.uuid4(), name="test rule", entity_type=RuleEntityType.habit,
+            metric=RuleMetric.consecutive_skips, operator=RuleOperator.gte,
+            threshold=3, action=RuleAction.create_notification,
+            notification_type="habit_nudge", message_template="test",
+        )
+        db.add(rule)
+        db.commit()
+        rule_id = str(rule.id)
         result = make_notification(
             client,
             canned_responses=["Yes", "No"],
@@ -310,9 +321,17 @@ class TestListNotifications:
         assert len(results) == 1
         assert results[0]["status"] == "pending"
 
-    def test_filter_by_rule_id(self, client):
+    def test_filter_by_rule_id(self, client, db):
         """Filter by rule_id."""
-        rid = str(uuid.uuid4())
+        rule = Rule(
+            id=uuid.uuid4(), name="filter rule", entity_type=RuleEntityType.habit,
+            metric=RuleMetric.consecutive_skips, operator=RuleOperator.gte,
+            threshold=3, action=RuleAction.create_notification,
+            notification_type="habit_nudge", message_template="test",
+        )
+        db.add(rule)
+        db.commit()
+        rid = str(rule.id)
         make_notification(client, rule_id=rid)
         make_notification(client)  # no rule_id
         resp = client.get(BASE_URL, params={"rule_id": rid})

--- a/tests/test_notification_queue.py
+++ b/tests/test_notification_queue.py
@@ -22,7 +22,8 @@ from datetime import datetime, timezone
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from app.models import NotificationQueue
+from app.models import NotificationQueue, Rule
+from app.schemas.rule import RuleAction, RuleEntityType, RuleMetric, RuleOperator
 
 # ---------------------------------------------------------------------------
 # Valid notification types, statuses, delivery types, and scheduled_by values
@@ -98,14 +99,21 @@ class TestNotificationQueueModel:
     def test_create_notification_with_all_fields(self, db):
         """A notification with every optional field set persists correctly."""
         now = datetime.now(timezone.utc)
-        rule_id = uuid.uuid4()
+        rule = Rule(
+            id=uuid.uuid4(), name="test rule", entity_type=RuleEntityType.habit,
+            metric=RuleMetric.consecutive_skips, operator=RuleOperator.gte,
+            threshold=3, action=RuleAction.create_notification,
+            notification_type="habit_nudge", message_template="test",
+        )
+        db.add(rule)
+        db.commit()
         n = _make_notification(
             canned_responses=["Done", "Skip", "Snooze"],
             response="Done",
             response_note="Felt good today",
             responded_at=now,
             expires_at=now,
-            rule_id=rule_id,
+            rule_id=rule.id,
         )
         result = _persist(db, n)
 
@@ -114,7 +122,7 @@ class TestNotificationQueueModel:
         assert result.response_note == "Felt good today"
         assert result.responded_at is not None
         assert result.expires_at is not None
-        assert result.rule_id == rule_id
+        assert result.rule_id == rule.id
 
     def test_nullable_fields_default_to_none(self, db):
         """Optional fields are None when not provided."""

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,452 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for the Rule model, schemas, and FK constraint on notification_queue."""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
+
+from app.models import NotificationQueue, Rule
+from app.schemas.rule import (
+    ALLOWED_PLACEHOLDERS,
+    RuleAction,
+    RuleCreate,
+    RuleEntityType,
+    RuleMetric,
+    RuleOperator,
+    RuleRead,
+    RuleUpdate,
+    validate_message_template,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_rule(**overrides) -> Rule:
+    """Build a Rule ORM instance with sensible defaults."""
+    defaults = {
+        "id": uuid.uuid4(),
+        "name": "Skip alert",
+        "entity_type": RuleEntityType.habit,
+        "metric": RuleMetric.consecutive_skips,
+        "operator": RuleOperator.gte,
+        "threshold": 3,
+        "action": RuleAction.create_notification,
+        "notification_type": "habit_nudge",
+        "message_template": "{entity_name} has been skipped {metric_value} times",
+        "enabled": True,
+        "cooldown_hours": 24,
+    }
+    defaults.update(overrides)
+    return Rule(**defaults)
+
+
+def _persist(db, obj):
+    """Add, commit, and refresh an ORM object."""
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+def _make_notification(db, **overrides) -> NotificationQueue:
+    """Create and persist a NotificationQueue row."""
+    defaults = {
+        "id": uuid.uuid4(),
+        "notification_type": "habit_nudge",
+        "delivery_type": "notification",
+        "status": "pending",
+        "scheduled_at": datetime.now(timezone.utc),
+        "target_entity_type": "habit",
+        "target_entity_id": uuid.uuid4(),
+        "message": "Test notification",
+        "scheduled_by": "system",
+    }
+    defaults.update(overrides)
+    nq = NotificationQueue(**defaults)
+    db.add(nq)
+    db.commit()
+    db.refresh(nq)
+    return nq
+
+
+# ---------------------------------------------------------------------------
+# Enum value tests
+# ---------------------------------------------------------------------------
+
+class TestEnumValues:
+    """Verify enum members and their values match the spec."""
+
+    def test_rule_entity_type_members(self):
+        assert set(RuleEntityType) == {
+            RuleEntityType.habit,
+            RuleEntityType.task,
+            RuleEntityType.routine,
+            RuleEntityType.checkin,
+        }
+        assert RuleEntityType.habit.value == "habit"
+        assert RuleEntityType.task.value == "task"
+        assert RuleEntityType.routine.value == "routine"
+        assert RuleEntityType.checkin.value == "checkin"
+
+    def test_rule_metric_members(self):
+        assert set(RuleMetric) == {
+            RuleMetric.consecutive_skips,
+            RuleMetric.days_untouched,
+            RuleMetric.non_responses,
+            RuleMetric.streak_length,
+        }
+        assert RuleMetric.consecutive_skips.value == "consecutive_skips"
+        assert RuleMetric.days_untouched.value == "days_untouched"
+        assert RuleMetric.non_responses.value == "non_responses"
+        assert RuleMetric.streak_length.value == "streak_length"
+
+    def test_rule_operator_members(self):
+        assert set(RuleOperator) == {
+            RuleOperator.gte,
+            RuleOperator.lte,
+            RuleOperator.eq,
+        }
+        assert RuleOperator.gte.value == ">="
+        assert RuleOperator.lte.value == "<="
+        assert RuleOperator.eq.value == "=="
+
+    def test_rule_action_members(self):
+        assert set(RuleAction) == {RuleAction.create_notification}
+        assert RuleAction.create_notification.value == "create_notification"
+
+
+# ---------------------------------------------------------------------------
+# Model instantiation and round-trip tests
+# ---------------------------------------------------------------------------
+
+class TestRuleModel:
+    """Rule ORM model — instantiation, defaults, and database round-trips."""
+
+    def test_create_rule_with_all_fields(self, db):
+        rule = _make_rule()
+        persisted = _persist(db, rule)
+
+        assert persisted.name == "Skip alert"
+        assert persisted.entity_type == RuleEntityType.habit
+        assert persisted.entity_id is None
+        assert persisted.metric == RuleMetric.consecutive_skips
+        assert persisted.operator == RuleOperator.gte
+        assert persisted.threshold == 3
+        assert persisted.action == RuleAction.create_notification
+        assert persisted.notification_type == "habit_nudge"
+        assert persisted.enabled is True
+        assert persisted.cooldown_hours == 24
+        assert persisted.last_triggered_at is None
+
+    def test_round_trip_all_fields(self, db):
+        """Create, persist, re-query — all fields survive."""
+        rule_id = uuid.uuid4()
+        entity_id = uuid.uuid4()
+        rule = _make_rule(
+            id=rule_id,
+            entity_id=entity_id,
+            operator=RuleOperator.lte,
+            threshold=5,
+            metric=RuleMetric.days_untouched,
+            notification_type="stale_work_nudge",
+        )
+        _persist(db, rule)
+
+        fetched = db.get(Rule, rule_id)
+        assert fetched is not None
+        assert fetched.entity_id == entity_id
+        assert fetched.operator == RuleOperator.lte
+        assert fetched.threshold == 5
+        assert fetched.metric == RuleMetric.days_untouched
+        assert fetched.notification_type == "stale_work_nudge"
+
+    def test_entity_id_nullable(self, db):
+        """entity_id can be NULL (global rule)."""
+        rule = _make_rule(entity_id=None)
+        persisted = _persist(db, rule)
+        assert persisted.entity_id is None
+
+    def test_entity_id_with_value(self, db):
+        """entity_id can reference a specific entity."""
+        eid = uuid.uuid4()
+        rule = _make_rule(entity_id=eid)
+        persisted = _persist(db, rule)
+        assert persisted.entity_id == eid
+
+    def test_all_entity_types_persist(self, db):
+        """Each RuleEntityType value round-trips."""
+        for et in RuleEntityType:
+            rule = _make_rule(id=uuid.uuid4(), entity_type=et)
+            persisted = _persist(db, rule)
+            assert persisted.entity_type == et
+
+    def test_all_metrics_persist(self, db):
+        """Each RuleMetric value round-trips."""
+        for m in RuleMetric:
+            rule = _make_rule(id=uuid.uuid4(), metric=m)
+            persisted = _persist(db, rule)
+            assert persisted.metric == m
+
+    def test_all_operators_persist(self, db):
+        """Each RuleOperator value round-trips."""
+        for op in RuleOperator:
+            rule = _make_rule(id=uuid.uuid4(), operator=op)
+            persisted = _persist(db, rule)
+            assert persisted.operator == op
+
+
+# ---------------------------------------------------------------------------
+# FK constraint: notification_queue.rule_id → rules.id
+# ---------------------------------------------------------------------------
+
+class TestNotificationRuleFK:
+    """FK constraint between notification_queue.rule_id and rules.id."""
+
+    def test_notification_with_null_rule_id(self, db):
+        """Inserting a notification with NULL rule_id succeeds."""
+        nq = _make_notification(db, rule_id=None)
+        assert nq.rule_id is None
+
+    def test_notification_with_valid_rule_id(self, db):
+        """Inserting a notification referencing an existing rule succeeds."""
+        rule = _make_rule()
+        _persist(db, rule)
+
+        nq = _make_notification(db, rule_id=rule.id)
+        assert nq.rule_id == rule.id
+
+    def test_notification_with_nonexistent_rule_id_fails(self, db):
+        """Inserting a notification with a non-existent rule_id raises."""
+        fake_id = uuid.uuid4()
+        nq = NotificationQueue(
+            id=uuid.uuid4(),
+            notification_type="habit_nudge",
+            delivery_type="notification",
+            status="pending",
+            scheduled_at=datetime.now(timezone.utc),
+            target_entity_type="habit",
+            target_entity_id=uuid.uuid4(),
+            message="Test",
+            scheduled_by="system",
+            rule_id=fake_id,
+        )
+        db.add(nq)
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+    def test_delete_rule_sets_notification_rule_id_null(self, db):
+        """Deleting a rule sets linked notifications' rule_id to NULL."""
+        rule = _make_rule()
+        _persist(db, rule)
+        nq = _make_notification(db, rule_id=rule.id)
+        assert nq.rule_id == rule.id
+
+        db.delete(rule)
+        db.commit()
+        db.refresh(nq)
+        assert nq.rule_id is None
+
+
+# ---------------------------------------------------------------------------
+# Template placeholder validation (schema-level)
+# ---------------------------------------------------------------------------
+
+class TestTemplatePlaceholderValidation:
+    """validate_message_template rejects unknown placeholders."""
+
+    def test_valid_template_all_placeholders(self):
+        template = (
+            "{rule_name}: {entity_type} '{entity_name}' hit "
+            "{metric_value} (threshold {threshold})"
+        )
+        result = validate_message_template(template)
+        assert result == template
+
+    def test_valid_template_no_placeholders(self):
+        """Plain text with no placeholders is valid."""
+        result = validate_message_template("Something happened")
+        assert result == "Something happened"
+
+    def test_valid_template_subset_of_placeholders(self):
+        result = validate_message_template("{entity_name} skipped")
+        assert result == "{entity_name} skipped"
+
+    def test_invalid_placeholder_rejected(self):
+        with pytest.raises(ValueError, match="Unknown placeholder"):
+            validate_message_template("{bad_field} is not allowed")
+
+    def test_mixed_valid_and_invalid_rejected(self):
+        with pytest.raises(ValueError, match="Unknown placeholder"):
+            validate_message_template("{entity_name} {nope}")
+
+    def test_each_allowed_placeholder_individually(self):
+        for ph in ALLOWED_PLACEHOLDERS:
+            result = validate_message_template(f"{{{ph}}}")
+            assert result == f"{{{ph}}}"
+
+    def test_escaped_braces_ignored(self):
+        """Literal {{ and }} are not treated as placeholders."""
+        result = validate_message_template("Literal {{braces}} are fine")
+        assert result == "Literal {{braces}} are fine"
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schema tests — RuleCreate
+# ---------------------------------------------------------------------------
+
+class TestRuleCreateSchema:
+    """RuleCreate validation."""
+
+    def test_valid_create(self):
+        data = {
+            "name": "Skip alert",
+            "entity_type": "habit",
+            "metric": "consecutive_skips",
+            "operator": ">=",
+            "threshold": 3,
+            "notification_type": "habit_nudge",
+            "message_template": "{entity_name} skipped {metric_value} times",
+        }
+        schema = RuleCreate(**data)
+        assert schema.name == "Skip alert"
+        assert schema.entity_type == RuleEntityType.habit
+        assert schema.operator == RuleOperator.gte
+        assert schema.action == RuleAction.create_notification
+        assert schema.enabled is True
+        assert schema.cooldown_hours == 24
+
+    def test_defaults_applied(self):
+        data = {
+            "name": "Test",
+            "entity_type": "task",
+            "metric": "days_untouched",
+            "operator": "<=",
+            "threshold": 7,
+            "notification_type": "stale_work_nudge",
+            "message_template": "Hello",
+        }
+        schema = RuleCreate(**data)
+        assert schema.action == RuleAction.create_notification
+        assert schema.enabled is True
+        assert schema.cooldown_hours == 24
+        assert schema.entity_id is None
+
+    def test_invalid_template_rejected(self):
+        data = {
+            "name": "Bad template",
+            "entity_type": "habit",
+            "metric": "consecutive_skips",
+            "operator": ">=",
+            "threshold": 3,
+            "notification_type": "habit_nudge",
+            "message_template": "{unknown_placeholder}",
+        }
+        with pytest.raises(ValidationError, match="Unknown placeholder"):
+            RuleCreate(**data)
+
+    def test_empty_name_rejected(self):
+        data = {
+            "name": "",
+            "entity_type": "habit",
+            "metric": "consecutive_skips",
+            "operator": ">=",
+            "threshold": 3,
+            "notification_type": "habit_nudge",
+            "message_template": "Hello",
+        }
+        with pytest.raises(ValidationError):
+            RuleCreate(**data)
+
+    def test_invalid_entity_type_rejected(self):
+        data = {
+            "name": "Test",
+            "entity_type": "invalid",
+            "metric": "consecutive_skips",
+            "operator": ">=",
+            "threshold": 3,
+            "notification_type": "habit_nudge",
+            "message_template": "Hello",
+        }
+        with pytest.raises(ValidationError):
+            RuleCreate(**data)
+
+    def test_invalid_notification_type_rejected(self):
+        data = {
+            "name": "Test",
+            "entity_type": "habit",
+            "metric": "consecutive_skips",
+            "operator": ">=",
+            "threshold": 3,
+            "notification_type": "invalid_type",
+            "message_template": "Hello",
+        }
+        with pytest.raises(ValidationError):
+            RuleCreate(**data)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schema tests — RuleUpdate
+# ---------------------------------------------------------------------------
+
+class TestRuleUpdateSchema:
+    """RuleUpdate validation — all fields optional."""
+
+    def test_empty_update(self):
+        schema = RuleUpdate()
+        assert schema.name is None
+        assert schema.entity_type is None
+
+    def test_partial_update(self):
+        schema = RuleUpdate(name="New name", threshold=5)
+        assert schema.name == "New name"
+        assert schema.threshold == 5
+        assert schema.metric is None
+
+    def test_update_template_validated(self):
+        with pytest.raises(ValidationError, match="Unknown placeholder"):
+            RuleUpdate(message_template="{invalid}")
+
+    def test_update_valid_template(self):
+        schema = RuleUpdate(message_template="{entity_name} updated")
+        assert schema.message_template == "{entity_name} updated"
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schema tests — RuleRead
+# ---------------------------------------------------------------------------
+
+class TestRuleReadSchema:
+    """RuleRead from_attributes mapping."""
+
+    def test_from_orm_object(self, db):
+        rule = _make_rule()
+        persisted = _persist(db, rule)
+
+        read = RuleRead.model_validate(persisted)
+        assert read.id == persisted.id
+        assert read.name == "Skip alert"
+        assert read.entity_type == RuleEntityType.habit
+        assert read.operator == RuleOperator.gte
+        assert read.threshold == 3
+        assert read.enabled is True
+        assert read.last_triggered_at is None


### PR DESCRIPTION
## Summary
Implements the rules engine data layer foundation — the `rules` table, 4 Postgres enum types, Pydantic schemas with template placeholder validation, and FK constraint linking `notification_queue.rule_id` to the new table.

## Changes
- **`app/schemas/rule.py`** — New file. Defines 4 Python `str, Enum` classes (`RuleEntityType`, `RuleMetric`, `RuleOperator`, `RuleAction`), template placeholder validation via `str.format_map()` parsing, and 3 Pydantic schemas (`RuleCreate`, `RuleUpdate`, `RuleRead`). `RuleOperator` stores DB values `>=`/`<=`/`==` with Python names `gte`/`lte`/`eq`.
- **`app/models.py`** — Added `Rule` model class with all 14 columns per spec. Uses `SAEnum(native_enum=False)` for enum columns (portable across Postgres and SQLite tests). Added `ForeignKey("rules.id", ondelete="SET NULL")` to `NotificationQueue.rule_id`. Added composite indexes `ix_rules_entity_lookup` and `ix_rules_entity_scoped`.
- **`alembic/versions/013_add_rules_table.py`** — Creates 4 native Postgres enum types, the `rules` table with all columns/indexes/constraints, and adds FK constraint `fk_nq_rule_id` on `notification_queue.rule_id`. Reversible: downgrade drops FK, table, and all enum types.
- **`tests/test_rules.py`** — 33 tests covering enum values, model round-trips, FK enforcement (null rule_id, valid rule_id, nonexistent rule_id rejection, cascade SET NULL on rule delete), template placeholder validation (valid/invalid/escaped braces), and Pydantic schema validation.
- **`tests/test_notification_crud.py`** / **`tests/test_notification_queue.py`** — Updated 3 existing tests that passed fake `rule_id` values to create a real `Rule` first, now that the FK constraint is enforced.

## How to Verify
1. `git checkout feature/2F-01-rules-model`
2. `pytest -v` — 953 tests pass (33 new)
3. Review generated migration SQL: `POSTGRES_HOST=localhost alembic upgrade 12a1b2c3d4e5:13a1b2c3d4e5 --sql`
4. Confirm downgrade SQL: `POSTGRES_HOST=localhost alembic downgrade 13a1b2c3d4e5:12a1b2c3d4e5 --sql`

## Deviations
- **Model location:** Spec says `app/models/rule.py` but the codebase uses a single `app/models.py` file. Followed the existing pattern.
- **Enum storage strategy:** Model uses `SAEnum(native_enum=False)` which stores enum values as VARCHAR with CHECK constraints in both Postgres and SQLite. The migration separately creates native Postgres ENUM types for production. This keeps tests working with SQLite while production gets native enums.
- **`notification_type` column:** Uses `String` + `CheckConstraint` (matching the existing `notification_queue` pattern) rather than a Postgres ENUM type, since `NotificationType` doesn't exist as a Postgres type in Stream B.

## Test Results
```
$ pytest -v
953 passed in 15.84s
```

```
$ ruff check app/schemas/rule.py app/models.py alembic/versions/013_add_rules_table.py tests/test_rules.py
All checks passed!
```

## Acceptance Checklist
- [x] `rules` table exists with all specified columns
- [x] 4 enums defined as Python string enums and Postgres enums via migration
- [x] `RuleOperator` stores `>=`/`<=`/`==` in DB
- [x] `notification_queue.rule_id` FK constraint with `ON DELETE SET NULL`
- [x] `ix_nq_rule_traceability` index preserved
- [x] Pydantic schemas: `RuleCreate`, `RuleUpdate`, `RuleRead`
- [x] Template placeholder validation rejects unknown placeholders
- [x] Migration is reversible (upgrade + downgrade)
- [x] All model fields have appropriate defaults
- [x] 33 new tests pass, 953 total pass

Closes #140