### PR TITLE
2F-02: Rules CRUD API Endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to BRAIN 3.0 will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [v1.3.0] — Rules Engine (Phase 2 Stream F)
+
+### Added
+- Rules table model, migration, enum definitions (RuleEntityType, RuleMetric, RuleOperator, RuleAction), FK on notification_queue.rule_id with SET NULL cascade, Pydantic schemas with template placeholder validation (#140)
+- Rules CRUD endpoints — create, list (composable filters: entity_type, enabled, notification_type, entity_id), get, update, delete (#141)
+
 ## [v1.2.0] — The Knowledge Layer
 
 ### Added

--- a/app/main.py
+++ b/app/main.py
@@ -36,6 +36,7 @@ from app.routers import (
     protocols,
     reports,
     routines,
+    rules,
     skills,
     tags,
     tasks,
@@ -103,6 +104,7 @@ app.include_router(skills.router, prefix="/api/skills", tags=["Skills"])
 app.include_router(
     notification.router, prefix="/api/notifications", tags=["Notifications"],
 )
+app.include_router(rules.router, prefix="/api/rules", tags=["Rules"])
 app.include_router(
     skills.skill_domains_router, prefix="/api/skills", tags=["Skill Domains"],
 )

--- a/app/routers/rules.py
+++ b/app/routers/rules.py
@@ -1,0 +1,127 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""CRUD endpoints for Rules."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import Rule
+from app.schemas.rule import (
+    NotificationType,
+    RuleCreate,
+    RuleEntityType,
+    RuleRead,
+    RuleUpdate,
+)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# POST — create rule
+# ---------------------------------------------------------------------------
+
+@router.post("/", response_model=RuleRead, status_code=status.HTTP_201_CREATED)
+def create_rule(
+    payload: RuleCreate, db: Session = Depends(get_db),
+) -> Rule:
+    """Create a rule. Template placeholders are validated by the schema."""
+    rule = Rule(**payload.model_dump())
+    db.add(rule)
+    db.commit()
+    db.refresh(rule)
+    return rule
+
+
+# ---------------------------------------------------------------------------
+# GET list — with composable filters
+# ---------------------------------------------------------------------------
+
+@router.get("/", response_model=list[RuleRead])
+def list_rules(
+    entity_type: RuleEntityType | None = Query(None),
+    enabled: bool | None = Query(None),
+    notification_type: NotificationType | None = Query(None),
+    entity_id: UUID | None = Query(None),
+    db: Session = Depends(get_db),
+) -> list[Rule]:
+    """List rules with composable filters (AND logic)."""
+    query = db.query(Rule)
+
+    if entity_type is not None:
+        query = query.filter(Rule.entity_type == entity_type)
+    if enabled is not None:
+        query = query.filter(Rule.enabled == enabled)
+    if notification_type is not None:
+        query = query.filter(Rule.notification_type == notification_type)
+    if entity_id is not None:
+        query = query.filter(Rule.entity_id == entity_id)
+
+    return query.order_by(Rule.created_at.desc()).all()
+
+
+# ---------------------------------------------------------------------------
+# GET detail
+# ---------------------------------------------------------------------------
+
+@router.get("/{rule_id}", response_model=RuleRead)
+def get_rule(rule_id: UUID, db: Session = Depends(get_db)) -> Rule:
+    """Get a single rule by ID."""
+    rule = db.query(Rule).filter(Rule.id == rule_id).first()
+    if not rule:
+        raise HTTPException(status_code=404, detail="Rule not found")
+    return rule
+
+
+# ---------------------------------------------------------------------------
+# PATCH — partial update
+# ---------------------------------------------------------------------------
+
+@router.patch("/{rule_id}", response_model=RuleRead)
+def update_rule(
+    rule_id: UUID, payload: RuleUpdate, db: Session = Depends(get_db),
+) -> Rule:
+    """Partial update of a rule. Re-validates template if changed."""
+    rule = db.query(Rule).filter(Rule.id == rule_id).first()
+    if not rule:
+        raise HTTPException(status_code=404, detail="Rule not found")
+
+    updates = payload.model_dump(exclude_unset=True)
+    for field, value in updates.items():
+        setattr(rule, field, value)
+
+    db.commit()
+    db.refresh(rule)
+    return rule
+
+
+# ---------------------------------------------------------------------------
+# DELETE
+# ---------------------------------------------------------------------------
+
+@router.delete("/{rule_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_rule(rule_id: UUID, db: Session = Depends(get_db)) -> None:
+    """Delete a rule. FK cascade sets notification_queue.rule_id to NULL."""
+    rule = db.query(Rule).filter(Rule.id == rule_id).first()
+    if not rule:
+        raise HTTPException(status_code=404, detail="Rule not found")
+
+    db.delete(rule)
+    db.commit()

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -450,3 +450,401 @@ class TestRuleReadSchema:
         assert read.threshold == 3
         assert read.enabled is True
         assert read.last_triggered_at is None
+
+
+# ===========================================================================
+# API endpoint tests — [2F-02]
+# ===========================================================================
+
+RULES_URL = "/api/rules"
+
+
+def _rule_payload(**overrides) -> dict:
+    """Build a valid rule creation payload."""
+    defaults = {
+        "name": "Skip alert",
+        "entity_type": "habit",
+        "metric": "consecutive_skips",
+        "operator": ">=",
+        "threshold": 3,
+        "notification_type": "habit_nudge",
+        "message_template": "{entity_name} has been skipped {metric_value} times",
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+# ---------------------------------------------------------------------------
+# POST /api/rules — create
+# ---------------------------------------------------------------------------
+
+class TestCreateRuleEndpoint:
+    """POST /api/rules"""
+
+    def test_create_rule_happy_path(self, client):
+        payload = _rule_payload()
+        resp = client.post(RULES_URL, json=payload)
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "Skip alert"
+        assert data["entity_type"] == "habit"
+        assert data["metric"] == "consecutive_skips"
+        assert data["operator"] == ">="
+        assert data["threshold"] == 3
+        assert data["notification_type"] == "habit_nudge"
+        assert data["enabled"] is True
+        assert data["cooldown_hours"] == 24
+        assert data["action"] == "create_notification"
+        assert data["last_triggered_at"] is None
+        assert data["id"] is not None
+        assert data["created_at"] is not None
+
+    def test_create_rule_with_entity_id(self, client):
+        eid = str(uuid.uuid4())
+        resp = client.post(RULES_URL, json=_rule_payload(entity_id=eid))
+        assert resp.status_code == 201
+        assert resp.json()["entity_id"] == eid
+
+    def test_create_rule_with_all_optional_overrides(self, client):
+        resp = client.post(RULES_URL, json=_rule_payload(
+            enabled=False,
+            cooldown_hours=48,
+        ))
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["cooldown_hours"] == 48
+
+    def test_create_rule_invalid_template_returns_422(self, client):
+        resp = client.post(RULES_URL, json=_rule_payload(
+            message_template="{bad_placeholder} is invalid",
+        ))
+        assert resp.status_code == 422
+
+    def test_create_rule_invalid_entity_type_returns_422(self, client):
+        resp = client.post(RULES_URL, json=_rule_payload(entity_type="invalid"))
+        assert resp.status_code == 422
+
+    def test_create_rule_invalid_metric_returns_422(self, client):
+        resp = client.post(RULES_URL, json=_rule_payload(metric="invalid"))
+        assert resp.status_code == 422
+
+    def test_create_rule_invalid_operator_returns_422(self, client):
+        resp = client.post(RULES_URL, json=_rule_payload(operator="!="))
+        assert resp.status_code == 422
+
+    def test_create_rule_invalid_notification_type_returns_422(self, client):
+        resp = client.post(RULES_URL, json=_rule_payload(
+            notification_type="invalid_type",
+        ))
+        assert resp.status_code == 422
+
+    def test_create_rule_missing_required_field_returns_422(self, client):
+        payload = _rule_payload()
+        del payload["name"]
+        resp = client.post(RULES_URL, json=payload)
+        assert resp.status_code == 422
+
+    def test_create_rule_empty_name_returns_422(self, client):
+        resp = client.post(RULES_URL, json=_rule_payload(name=""))
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/rules — list with filters
+# ---------------------------------------------------------------------------
+
+class TestListRulesEndpoint:
+    """GET /api/rules"""
+
+    def test_list_empty(self, client):
+        resp = client.get(RULES_URL)
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_returns_created_rules(self, client):
+        client.post(RULES_URL, json=_rule_payload(name="Rule A"))
+        client.post(RULES_URL, json=_rule_payload(name="Rule B"))
+        resp = client.get(RULES_URL)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+
+    def test_list_ordered_by_created_at_desc(self, client, db):
+        """Newest rule appears first in the list."""
+        from datetime import datetime, timezone
+
+        from app.models import Rule as RuleModel
+        from app.schemas.rule import (
+            RuleAction as RA,
+        )
+        from app.schemas.rule import (
+            RuleEntityType as RET,
+        )
+        from app.schemas.rule import (
+            RuleMetric as RM,
+        )
+        from app.schemas.rule import (
+            RuleOperator as RO,
+        )
+
+        earlier = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        later = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        r1 = RuleModel(
+            name="First", entity_type=RET.habit, metric=RM.consecutive_skips,
+            operator=RO.gte, threshold=3, action=RA.create_notification,
+            notification_type="habit_nudge", message_template="hi",
+            enabled=True, cooldown_hours=24, created_at=earlier, updated_at=earlier,
+        )
+        r2 = RuleModel(
+            name="Second", entity_type=RET.habit, metric=RM.consecutive_skips,
+            operator=RO.gte, threshold=3, action=RA.create_notification,
+            notification_type="habit_nudge", message_template="hi",
+            enabled=True, cooldown_hours=24, created_at=later, updated_at=later,
+        )
+        db.add_all([r1, r2])
+        db.commit()
+
+        resp = client.get(RULES_URL)
+        names = [r["name"] for r in resp.json()]
+        assert names == ["Second", "First"]
+
+    def test_filter_by_entity_type(self, client):
+        client.post(RULES_URL, json=_rule_payload(
+            name="Habit rule", entity_type="habit",
+        ))
+        client.post(RULES_URL, json=_rule_payload(
+            name="Task rule", entity_type="task",
+            metric="days_untouched",
+            notification_type="stale_work_nudge",
+        ))
+        resp = client.get(RULES_URL, params={"entity_type": "task"})
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Task rule"
+
+    def test_filter_by_enabled(self, client):
+        client.post(RULES_URL, json=_rule_payload(name="Active", enabled=True))
+        client.post(RULES_URL, json=_rule_payload(name="Disabled", enabled=False))
+        resp = client.get(RULES_URL, params={"enabled": "false"})
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Disabled"
+
+    def test_filter_by_notification_type(self, client):
+        client.post(RULES_URL, json=_rule_payload(
+            name="Nudge", notification_type="habit_nudge",
+        ))
+        client.post(RULES_URL, json=_rule_payload(
+            name="Stale", entity_type="task", metric="days_untouched",
+            notification_type="stale_work_nudge",
+        ))
+        resp = client.get(RULES_URL, params={
+            "notification_type": "stale_work_nudge",
+        })
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Stale"
+
+    def test_filter_by_entity_id(self, client):
+        eid = str(uuid.uuid4())
+        client.post(RULES_URL, json=_rule_payload(name="Scoped", entity_id=eid))
+        client.post(RULES_URL, json=_rule_payload(name="Global"))
+        resp = client.get(RULES_URL, params={"entity_id": eid})
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Scoped"
+
+    def test_filter_combined(self, client):
+        """Multiple filters compose with AND logic."""
+        client.post(RULES_URL, json=_rule_payload(
+            name="Match", entity_type="habit", enabled=True,
+        ))
+        client.post(RULES_URL, json=_rule_payload(
+            name="Wrong type", entity_type="task", enabled=True,
+            metric="days_untouched", notification_type="stale_work_nudge",
+        ))
+        client.post(RULES_URL, json=_rule_payload(
+            name="Disabled", entity_type="habit", enabled=False,
+        ))
+        resp = client.get(RULES_URL, params={
+            "entity_type": "habit", "enabled": "true",
+        })
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Match"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/rules/{rule_id} — detail
+# ---------------------------------------------------------------------------
+
+class TestGetRuleEndpoint:
+    """GET /api/rules/{rule_id}"""
+
+    def test_get_rule_happy_path(self, client):
+        created = client.post(RULES_URL, json=_rule_payload()).json()
+        resp = client.get(f"{RULES_URL}/{created['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == created["id"]
+        assert resp.json()["name"] == "Skip alert"
+
+    def test_get_rule_not_found(self, client):
+        fake = str(uuid.uuid4())
+        resp = client.get(f"{RULES_URL}/{fake}")
+        assert resp.status_code == 404
+
+    def test_get_rule_invalid_uuid(self, client):
+        resp = client.get(f"{RULES_URL}/not-a-uuid")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/rules/{rule_id} — update
+# ---------------------------------------------------------------------------
+
+class TestUpdateRuleEndpoint:
+    """PATCH /api/rules/{rule_id}"""
+
+    def test_update_name(self, client):
+        created = client.post(RULES_URL, json=_rule_payload()).json()
+        resp = client.patch(f"{RULES_URL}/{created['id']}", json={"name": "New name"})
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "New name"
+
+    def test_update_threshold(self, client):
+        created = client.post(RULES_URL, json=_rule_payload()).json()
+        resp = client.patch(
+            f"{RULES_URL}/{created['id']}", json={"threshold": 10},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["threshold"] == 10
+
+    def test_update_enabled(self, client):
+        created = client.post(RULES_URL, json=_rule_payload()).json()
+        resp = client.patch(
+            f"{RULES_URL}/{created['id']}", json={"enabled": False},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["enabled"] is False
+
+    def test_update_template_validated(self, client):
+        created = client.post(RULES_URL, json=_rule_payload()).json()
+        resp = client.patch(
+            f"{RULES_URL}/{created['id']}",
+            json={"message_template": "{bad_placeholder}"},
+        )
+        assert resp.status_code == 422
+
+    def test_update_valid_template(self, client):
+        created = client.post(RULES_URL, json=_rule_payload()).json()
+        resp = client.patch(
+            f"{RULES_URL}/{created['id']}",
+            json={"message_template": "{entity_name} updated"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["message_template"] == "{entity_name} updated"
+
+    def test_update_not_found(self, client):
+        fake = str(uuid.uuid4())
+        resp = client.patch(f"{RULES_URL}/{fake}", json={"name": "Nope"})
+        assert resp.status_code == 404
+
+    def test_update_multiple_fields(self, client):
+        created = client.post(RULES_URL, json=_rule_payload()).json()
+        resp = client.patch(
+            f"{RULES_URL}/{created['id']}",
+            json={"name": "Updated", "threshold": 5, "cooldown_hours": 48},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "Updated"
+        assert data["threshold"] == 5
+        assert data["cooldown_hours"] == 48
+
+    def test_update_empty_body_is_noop(self, client):
+        created = client.post(RULES_URL, json=_rule_payload()).json()
+        resp = client.patch(f"{RULES_URL}/{created['id']}", json={})
+        assert resp.status_code == 200
+        assert resp.json()["name"] == created["name"]
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/rules/{rule_id}
+# ---------------------------------------------------------------------------
+
+class TestDeleteRuleEndpoint:
+    """DELETE /api/rules/{rule_id}"""
+
+    def test_delete_rule_happy_path(self, client):
+        created = client.post(RULES_URL, json=_rule_payload()).json()
+        resp = client.delete(f"{RULES_URL}/{created['id']}")
+        assert resp.status_code == 204
+        # Confirm it's gone
+        resp = client.get(f"{RULES_URL}/{created['id']}")
+        assert resp.status_code == 404
+
+    def test_delete_rule_not_found(self, client):
+        fake = str(uuid.uuid4())
+        resp = client.delete(f"{RULES_URL}/{fake}")
+        assert resp.status_code == 404
+
+    def test_delete_rule_sets_notification_rule_id_null(self, client, db):
+        """FK cascade: deleting a rule NULLs notification_queue.rule_id."""
+        # Create rule via API
+        created = client.post(RULES_URL, json=_rule_payload()).json()
+        rule_id = created["id"]
+
+        # Create notification linked to the rule (convert str to UUID)
+        nq = _make_notification(db, rule_id=uuid.UUID(rule_id))
+        assert str(nq.rule_id) == rule_id
+
+        # Delete the rule
+        resp = client.delete(f"{RULES_URL}/{rule_id}")
+        assert resp.status_code == 204
+
+        # Verify notification's rule_id is now NULL
+        db.refresh(nq)
+        assert nq.rule_id is None
+
+
+# ---------------------------------------------------------------------------
+# Full lifecycle test
+# ---------------------------------------------------------------------------
+
+class TestRuleLifecycle:
+    """End-to-end CRUD lifecycle through the API."""
+
+    def test_create_read_update_delete(self, client):
+        # Create
+        resp = client.post(RULES_URL, json=_rule_payload())
+        assert resp.status_code == 201
+        rule_id = resp.json()["id"]
+
+        # Read
+        resp = client.get(f"{RULES_URL}/{rule_id}")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Skip alert"
+
+        # List
+        resp = client.get(RULES_URL)
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+        # Update
+        resp = client.patch(
+            f"{RULES_URL}/{rule_id}",
+            json={"name": "Updated alert", "threshold": 5},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Updated alert"
+        assert resp.json()["threshold"] == 5
+
+        # Delete
+        resp = client.delete(f"{RULES_URL}/{rule_id}")
+        assert resp.status_code == 204
+
+        # Confirm gone
+        resp = client.get(RULES_URL)
+        assert resp.json() == []


### PR DESCRIPTION
## Summary
Implements the 5 CRUD endpoints for the `rules` table, completing the API layer for brain3's rules engine. This follows established patterns (notification, habits routers) and gives MCP tools, the future Companion App, and manual testing a complete interface for managing rules.

## Changes
- **`app/routers/rules.py`** (new) — FastAPI router with 5 endpoints: `POST /api/rules` (create with template validation), `GET /api/rules` (list with composable AND-logic filters on `entity_type`, `enabled`, `notification_type`, `entity_id`), `GET /api/rules/{rule_id}`, `PATCH /api/rules/{rule_id}` (partial update with re-validation), `DELETE /api/rules/{rule_id}` (FK cascade sets `notification_queue.rule_id` to NULL).
- **`app/main.py`** — Registered the rules router at `/api/rules` with tag `Rules`.
- **`tests/test_rules.py`** — Added 33 API-level tests (66 total in file, 986 suite-wide). Covers happy path, validation errors (422), not-found (404), each filter in isolation and combined, FK cascade on delete, and full CRUD lifecycle.
- **`CHANGELOG.md`** — Added v1.3.0 section for Stream F rules engine work.

## How to Verify
1. `git checkout feature/2F-02-rules-crud`
2. `docker compose -f docker-compose.dev.yml up -d`
3. `uvicorn app.main:app --reload`
4. Hit endpoints at `/docs` — create a rule, list with filters, get/update/delete.
5. `pytest -v tests/test_rules.py` — 66 tests pass.
6. `pytest -v` — 986 tests pass, no regressions.
7. `ruff check` — clean.

## Deviations
None. Fully aligned with spec artifact `3ec37028-3265-4d4c-85bb-7da5a09c4df0` and GitHub issue #141.

## Test Results
```
tests/test_rules.py: 66 passed in 1.05s
Full suite: 986 passed in 19.21s
Ruff: All checks passed
```

## Acceptance Checklist
- [x] POST /api/rules — create with template placeholder validation
- [x] GET /api/rules — list with composable filters (entity_type, enabled, notification_type, entity_id)
- [x] GET /api/rules/{rule_id} — get single rule, 404 if not found
- [x] PATCH /api/rules/{rule_id} — partial update, re-validates template
- [x] DELETE /api/rules/{rule_id} — 204, FK cascade NULLs notification_queue.rule_id
- [x] Appropriate HTTP status codes (201/200/204/404/422)
- [x] Unknown template placeholders return 422
- [x] All tests pass, ruff clean

Closes #141