### PR TITLE
2F-04: Default Rules — Seed Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Rules table model, migration, enum definitions (RuleEntityType, RuleMetric, RuleOperator, RuleAction), FK on notification_queue.rule_id with SET NULL cascade, Pydantic schemas with template placeholder validation (#140)
 - Rules CRUD endpoints — create, list (composable filters: entity_type, enabled, notification_type, entity_id), get, update, delete (#141)
+- Default rules seed data — 4 rules (consecutive skip alert, non-response alert, stale task nudge, streak break notice) with `is_default` column, unique name constraint, `is_default` list filter, and idempotent seed script support (#143)
 
 ## [v1.2.0] — The Knowledge Layer
 

--- a/alembic/versions/014_add_rules_is_default_and_name_unique.py
+++ b/alembic/versions/014_add_rules_is_default_and_name_unique.py
@@ -1,0 +1,53 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Add is_default column and unique constraint on name to rules table.
+
+Revision ID: 14a1b2c3d4e5
+Revises: 13a1b2c3d4e5
+Create Date: 2026-04-15
+
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "14a1b2c3d4e5"
+down_revision: Union[str, None] = "13a1b2c3d4e5"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    # Add is_default column — False for existing user-created rules
+    op.add_column(
+        "rules",
+        sa.Column(
+            "is_default", sa.Boolean(), nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    # Unique constraint on name — natural key for idempotent seed upsert
+    op.create_unique_constraint("uq_rules_name", "rules", ["name"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_rules_name", "rules", type_="unique")
+    op.drop_column("rules", "is_default")

--- a/app/models.py
+++ b/app/models.py
@@ -1035,6 +1035,9 @@ class Rule(Base):
     cooldown_hours: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("24"),
     )
+    is_default: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false"),
+    )
     last_triggered_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
     )
@@ -1054,6 +1057,7 @@ class Rule(Base):
             ")",
             name="ck_rules_notification_type",
         ),
+        UniqueConstraint("name", name="uq_rules_name"),
         Index("ix_rules_entity_lookup", "entity_type", "enabled"),
         Index("ix_rules_entity_scoped", "entity_type", "entity_id"),
     )

--- a/app/routers/rules.py
+++ b/app/routers/rules.py
@@ -60,6 +60,7 @@ def list_rules(
     enabled: bool | None = Query(None),
     notification_type: NotificationType | None = Query(None),
     entity_id: UUID | None = Query(None),
+    is_default: bool | None = Query(None),
     db: Session = Depends(get_db),
 ) -> list[Rule]:
     """List rules with composable filters (AND logic)."""
@@ -73,6 +74,8 @@ def list_rules(
         query = query.filter(Rule.notification_type == notification_type)
     if entity_id is not None:
         query = query.filter(Rule.entity_id == entity_id)
+    if is_default is not None:
+        query = query.filter(Rule.is_default == is_default)
 
     return query.order_by(Rule.created_at.desc()).all()
 

--- a/app/schemas/rule.py
+++ b/app/schemas/rule.py
@@ -121,6 +121,7 @@ class RuleCreate(BaseModel):
     message_template: str = Field(min_length=1)
     enabled: bool = True
     cooldown_hours: int = 24
+    is_default: bool = False
 
     @field_validator("message_template")
     @classmethod
@@ -168,6 +169,7 @@ class RuleRead(BaseModel):
     message_template: str
     enabled: bool
     cooldown_hours: int
+    is_default: bool
     last_triggered_at: datetime | None = None
     created_at: datetime
     updated_at: datetime

--- a/scripts/seed_data.py
+++ b/scripts/seed_data.py
@@ -39,8 +39,9 @@ import httpx
 DEFAULT_API_URL = "http://localhost:8000"
 SEEDS_DIR = Path(__file__).parent / "seeds"
 
-# Load order matters — skills reference protocols and directives by name
-ENTITY_ORDER = ["protocols", "directives", "skills"]
+# Load order matters — skills reference protocols and directives by name.
+# Rules are independent and loaded last.
+ENTITY_ORDER = ["protocols", "directives", "skills", "rules"]
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -72,7 +73,7 @@ def load_seed_file(entity_type: str) -> dict:
     if not path.exists():
         print(f"  WARNING: Seed file not found: {path}")
         return {"items": []}
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -177,23 +178,41 @@ def load_entity_type(
 
         to_create.append(item)
 
-    # Batch create all new items at once
+    # Create new items — batch endpoint for most types, individual for rules
     if to_create and not dry_run:
-        try:
-            resp = client.post(
-                f"{api_url}/api/{entity_type}/batch",
-                json={"items": to_create},
-            )
-            resp.raise_for_status()
-            result = resp.json()
-            batch_count = result.get("count", len(to_create))
+        if entity_type == "rules":
             for item in to_create:
-                print(f"    CREATED: {item['name']}")
-            created += batch_count
-        except httpx.HTTPStatusError as exc:
-            error_msg = f"    ERROR in batch create: {exc.response.text}"
-            print(error_msg)
-            errors.append(error_msg)
+                try:
+                    resp = client.post(
+                        f"{api_url}/api/{entity_type}",
+                        json=item,
+                    )
+                    resp.raise_for_status()
+                    print(f"    CREATED: {item['name']}")
+                    created += 1
+                except httpx.HTTPStatusError as exc:
+                    error_msg = (
+                        f"    ERROR creating '{item['name']}': "
+                        f"{exc.response.text}"
+                    )
+                    print(error_msg)
+                    errors.append(error_msg)
+        else:
+            try:
+                resp = client.post(
+                    f"{api_url}/api/{entity_type}/batch",
+                    json={"items": to_create},
+                )
+                resp.raise_for_status()
+                result = resp.json()
+                batch_count = result.get("count", len(to_create))
+                for item in to_create:
+                    print(f"    CREATED: {item['name']}")
+                created += batch_count
+            except httpx.HTTPStatusError as exc:
+                error_msg = f"    ERROR in batch create: {exc.response.text}"
+                print(error_msg)
+                errors.append(error_msg)
 
     return created, skipped, errors
 

--- a/scripts/seeds/rules.json
+++ b/scripts/seeds/rules.json
@@ -1,0 +1,60 @@
+{
+  "items": [
+    {
+      "name": "Consecutive skip alert",
+      "entity_type": "habit",
+      "entity_id": null,
+      "metric": "consecutive_skips",
+      "operator": ">=",
+      "threshold": 5,
+      "action": "create_notification",
+      "notification_type": "pattern_observation",
+      "message_template": "You've skipped {entity_name} {metric_value} times in a row. Want to talk about what's getting in the way?",
+      "enabled": true,
+      "cooldown_hours": 72,
+      "is_default": true
+    },
+    {
+      "name": "Non-response alert",
+      "entity_type": "habit",
+      "entity_id": null,
+      "metric": "non_responses",
+      "operator": ">=",
+      "threshold": 3,
+      "action": "create_notification",
+      "notification_type": "pattern_observation",
+      "message_template": "{entity_name} has had {metric_value} notifications with no response. Are the notifications reaching you at the right time?",
+      "enabled": true,
+      "cooldown_hours": 48,
+      "is_default": true
+    },
+    {
+      "name": "Stale task nudge",
+      "entity_type": "task",
+      "entity_id": null,
+      "metric": "days_untouched",
+      "operator": ">=",
+      "threshold": 14,
+      "action": "create_notification",
+      "notification_type": "stale_work_nudge",
+      "message_template": "{entity_name} hasn't been touched in {metric_value} days. Still on your radar?",
+      "enabled": true,
+      "cooldown_hours": 168,
+      "is_default": true
+    },
+    {
+      "name": "Streak break notice",
+      "entity_type": "habit",
+      "entity_id": null,
+      "metric": "streak_length",
+      "operator": ">=",
+      "threshold": 7,
+      "action": "create_notification",
+      "notification_type": "pattern_observation",
+      "message_template": "Your {entity_name} streak of {metric_value} days just ended. That's still real progress — want to restart?",
+      "enabled": true,
+      "cooldown_hours": 168,
+      "is_default": true
+    }
+  ]
+}

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -195,21 +195,21 @@ class TestRuleModel:
     def test_all_entity_types_persist(self, db):
         """Each RuleEntityType value round-trips."""
         for et in RuleEntityType:
-            rule = _make_rule(id=uuid.uuid4(), entity_type=et)
+            rule = _make_rule(id=uuid.uuid4(), name=f"Rule {et.value}", entity_type=et)
             persisted = _persist(db, rule)
             assert persisted.entity_type == et
 
     def test_all_metrics_persist(self, db):
         """Each RuleMetric value round-trips."""
         for m in RuleMetric:
-            rule = _make_rule(id=uuid.uuid4(), metric=m)
+            rule = _make_rule(id=uuid.uuid4(), name=f"Rule {m.value}", metric=m)
             persisted = _persist(db, rule)
             assert persisted.metric == m
 
     def test_all_operators_persist(self, db):
         """Each RuleOperator value round-trips."""
         for op in RuleOperator:
-            rule = _make_rule(id=uuid.uuid4(), operator=op)
+            rule = _make_rule(id=uuid.uuid4(), name=f"Rule {op.value}", operator=op)
             persisted = _persist(db, rule)
             assert persisted.operator == op
 

--- a/tests/test_rules_seed.py
+++ b/tests/test_rules_seed.py
@@ -21,21 +21,17 @@ idempotent seeding, and API filter support.
 """
 
 import json
-import uuid
 from pathlib import Path
 
 import pytest
-from pydantic import ValidationError
 
 from app.models import Rule
 from app.schemas.rule import (
-    ALLOWED_PLACEHOLDERS,
     RuleAction,
     RuleCreate,
     RuleEntityType,
     RuleMetric,
     RuleOperator,
-    RuleRead,
     validate_message_template,
 )
 

--- a/tests/test_rules_seed.py
+++ b/tests/test_rules_seed.py
@@ -1,0 +1,478 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for [2F-04] Default Rules — Seed Data.
+
+Verifies the four default rules, is_default column behavior,
+idempotent seeding, and API filter support.
+"""
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from app.models import Rule
+from app.schemas.rule import (
+    ALLOWED_PLACEHOLDERS,
+    RuleAction,
+    RuleCreate,
+    RuleEntityType,
+    RuleMetric,
+    RuleOperator,
+    RuleRead,
+    validate_message_template,
+)
+
+RULES_URL = "/api/rules"
+SEEDS_DIR = Path(__file__).parent.parent / "scripts" / "seeds"
+
+# ---------------------------------------------------------------------------
+# Seed data fixture — load the JSON once
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def seed_rules() -> list[dict]:
+    """Load the default rules from the seed JSON file."""
+    path = SEEDS_DIR / "rules.json"
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)["items"]
+
+
+@pytest.fixture
+def seeded_rules(client, seed_rules) -> list[dict]:
+    """Create all seed rules via the API and return API responses."""
+    created = []
+    for rule_data in seed_rules:
+        resp = client.post(RULES_URL, json=rule_data)
+        assert resp.status_code == 201, f"Failed to create '{rule_data['name']}': {resp.text}"
+        created.append(resp.json())
+    return created
+
+
+# ---------------------------------------------------------------------------
+# Seed file integrity tests
+# ---------------------------------------------------------------------------
+
+class TestSeedFileIntegrity:
+    """Verify the seed JSON file matches the spec."""
+
+    def test_seed_file_exists(self):
+        assert (SEEDS_DIR / "rules.json").exists()
+
+    def test_seed_file_has_four_rules(self, seed_rules):
+        assert len(seed_rules) == 4
+
+    def test_all_seed_rules_have_is_default_true(self, seed_rules):
+        for rule in seed_rules:
+            assert rule["is_default"] is True, f"'{rule['name']}' missing is_default=True"
+
+    def test_all_seed_rules_have_enabled_true(self, seed_rules):
+        for rule in seed_rules:
+            assert rule["enabled"] is True, f"'{rule['name']}' missing enabled=True"
+
+    def test_all_seed_rules_have_null_entity_id(self, seed_rules):
+        """All default rules are global — no entity scoping."""
+        for rule in seed_rules:
+            assert rule["entity_id"] is None, f"'{rule['name']}' has non-null entity_id"
+
+    def test_seed_rule_names_are_unique(self, seed_rules):
+        names = [r["name"] for r in seed_rules]
+        assert len(names) == len(set(names))
+
+
+class TestConsecutiveSkipAlert:
+    """Verify the Consecutive Skip Alert rule matches spec."""
+
+    @pytest.fixture
+    def rule(self, seed_rules) -> dict:
+        return next(r for r in seed_rules if r["name"] == "Consecutive skip alert")
+
+    def test_entity_type(self, rule):
+        assert rule["entity_type"] == "habit"
+
+    def test_metric(self, rule):
+        assert rule["metric"] == "consecutive_skips"
+
+    def test_operator(self, rule):
+        assert rule["operator"] == ">="
+
+    def test_threshold(self, rule):
+        assert rule["threshold"] == 5
+
+    def test_notification_type(self, rule):
+        assert rule["notification_type"] == "pattern_observation"
+
+    def test_cooldown_hours(self, rule):
+        assert rule["cooldown_hours"] == 72
+
+    def test_message_template(self, rule):
+        assert rule["message_template"] == (
+            "You've skipped {entity_name} {metric_value} times in a row. "
+            "Want to talk about what's getting in the way?"
+        )
+
+
+class TestNonResponseAlert:
+    """Verify the Non-Response Alert rule matches spec."""
+
+    @pytest.fixture
+    def rule(self, seed_rules) -> dict:
+        return next(r for r in seed_rules if r["name"] == "Non-response alert")
+
+    def test_entity_type(self, rule):
+        assert rule["entity_type"] == "habit"
+
+    def test_metric(self, rule):
+        assert rule["metric"] == "non_responses"
+
+    def test_operator(self, rule):
+        assert rule["operator"] == ">="
+
+    def test_threshold(self, rule):
+        assert rule["threshold"] == 3
+
+    def test_notification_type(self, rule):
+        assert rule["notification_type"] == "pattern_observation"
+
+    def test_cooldown_hours(self, rule):
+        assert rule["cooldown_hours"] == 48
+
+    def test_message_template(self, rule):
+        assert rule["message_template"] == (
+            "{entity_name} has had {metric_value} notifications with no response. "
+            "Are the notifications reaching you at the right time?"
+        )
+
+
+class TestStaleTaskNudge:
+    """Verify the Stale Task Nudge rule matches spec."""
+
+    @pytest.fixture
+    def rule(self, seed_rules) -> dict:
+        return next(r for r in seed_rules if r["name"] == "Stale task nudge")
+
+    def test_entity_type(self, rule):
+        assert rule["entity_type"] == "task"
+
+    def test_metric(self, rule):
+        assert rule["metric"] == "days_untouched"
+
+    def test_operator(self, rule):
+        assert rule["operator"] == ">="
+
+    def test_threshold(self, rule):
+        assert rule["threshold"] == 14
+
+    def test_notification_type(self, rule):
+        assert rule["notification_type"] == "stale_work_nudge"
+
+    def test_cooldown_hours(self, rule):
+        assert rule["cooldown_hours"] == 168
+
+    def test_message_template(self, rule):
+        assert rule["message_template"] == (
+            "{entity_name} hasn't been touched in {metric_value} days. "
+            "Still on your radar?"
+        )
+
+
+class TestStreakBreakNotice:
+    """Verify the Streak Break Notice rule matches spec."""
+
+    @pytest.fixture
+    def rule(self, seed_rules) -> dict:
+        return next(r for r in seed_rules if r["name"] == "Streak break notice")
+
+    def test_entity_type(self, rule):
+        assert rule["entity_type"] == "habit"
+
+    def test_metric(self, rule):
+        assert rule["metric"] == "streak_length"
+
+    def test_operator(self, rule):
+        assert rule["operator"] == ">="
+
+    def test_threshold(self, rule):
+        assert rule["threshold"] == 7
+
+    def test_notification_type(self, rule):
+        assert rule["notification_type"] == "pattern_observation"
+
+    def test_cooldown_hours(self, rule):
+        assert rule["cooldown_hours"] == 168
+
+    def test_message_template(self, rule):
+        assert rule["message_template"] == (
+            "Your {entity_name} streak of {metric_value} days just ended. "
+            "That's still real progress \u2014 want to restart?"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Template validation tests — all seed templates pass placeholder validation
+# ---------------------------------------------------------------------------
+
+class TestSeedTemplatesValid:
+    """All seed message templates use only allowed placeholders."""
+
+    def test_all_templates_pass_validation(self, seed_rules):
+        for rule in seed_rules:
+            result = validate_message_template(rule["message_template"])
+            assert result == rule["message_template"], (
+                f"Template validation changed '{rule['name']}' template"
+            )
+
+    def test_all_templates_parse_as_rule_create(self, seed_rules):
+        """Each seed rule produces a valid RuleCreate schema."""
+        for rule_data in seed_rules:
+            schema = RuleCreate(**rule_data)
+            assert schema.name == rule_data["name"]
+
+
+# ---------------------------------------------------------------------------
+# is_default column — model and API tests
+# ---------------------------------------------------------------------------
+
+class TestIsDefaultColumn:
+    """Tests for the is_default boolean column on rules."""
+
+    def test_is_default_false_by_default_via_api(self, client):
+        """Rules created without is_default get False."""
+        payload = {
+            "name": "User rule",
+            "entity_type": "habit",
+            "metric": "consecutive_skips",
+            "operator": ">=",
+            "threshold": 3,
+            "notification_type": "habit_nudge",
+            "message_template": "{entity_name} test",
+        }
+        resp = client.post(RULES_URL, json=payload)
+        assert resp.status_code == 201
+        assert resp.json()["is_default"] is False
+
+    def test_is_default_true_when_set(self, client):
+        """Rules created with is_default=True persist the value."""
+        payload = {
+            "name": "Default rule",
+            "entity_type": "habit",
+            "metric": "consecutive_skips",
+            "operator": ">=",
+            "threshold": 5,
+            "notification_type": "pattern_observation",
+            "message_template": "{entity_name} test",
+            "is_default": True,
+        }
+        resp = client.post(RULES_URL, json=payload)
+        assert resp.status_code == 201
+        assert resp.json()["is_default"] is True
+
+    def test_is_default_in_read_schema(self, client):
+        """RuleRead includes is_default field."""
+        payload = {
+            "name": "Read test",
+            "entity_type": "task",
+            "metric": "days_untouched",
+            "operator": ">=",
+            "threshold": 7,
+            "notification_type": "stale_work_nudge",
+            "message_template": "{entity_name} test",
+            "is_default": True,
+        }
+        created = client.post(RULES_URL, json=payload).json()
+        resp = client.get(f"{RULES_URL}/{created['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["is_default"] is True
+
+    def test_is_default_model_default(self, db):
+        """ORM model defaults is_default to False."""
+        rule = Rule(
+            name="ORM test",
+            entity_type=RuleEntityType.habit,
+            metric=RuleMetric.consecutive_skips,
+            operator=RuleOperator.gte,
+            threshold=3,
+            action=RuleAction.create_notification,
+            notification_type="habit_nudge",
+            message_template="test",
+            enabled=True,
+            cooldown_hours=24,
+        )
+        db.add(rule)
+        db.commit()
+        db.refresh(rule)
+        assert rule.is_default is False
+
+
+# ---------------------------------------------------------------------------
+# is_default list filter
+# ---------------------------------------------------------------------------
+
+class TestIsDefaultFilter:
+    """GET /api/rules?is_default=true|false filters correctly."""
+
+    def test_filter_is_default_true(self, client, seeded_rules):
+        """Filtering by is_default=true returns only defaults."""
+        # Add a user-created rule
+        client.post(RULES_URL, json={
+            "name": "User custom",
+            "entity_type": "habit",
+            "metric": "consecutive_skips",
+            "operator": ">=",
+            "threshold": 10,
+            "notification_type": "habit_nudge",
+            "message_template": "{entity_name} custom",
+        })
+
+        resp = client.get(RULES_URL, params={"is_default": "true"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 4
+        assert all(r["is_default"] is True for r in data)
+
+    def test_filter_is_default_false(self, client, seeded_rules):
+        """Filtering by is_default=false returns only user-created rules."""
+        client.post(RULES_URL, json={
+            "name": "User custom",
+            "entity_type": "habit",
+            "metric": "consecutive_skips",
+            "operator": ">=",
+            "threshold": 10,
+            "notification_type": "habit_nudge",
+            "message_template": "{entity_name} custom",
+        })
+
+        resp = client.get(RULES_URL, params={"is_default": "false"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "User custom"
+        assert data[0]["is_default"] is False
+
+
+# ---------------------------------------------------------------------------
+# Seed creation via API — verifies rules round-trip correctly
+# ---------------------------------------------------------------------------
+
+class TestSeedCreationViaAPI:
+    """Seed rules created via POST /api/rules match spec values."""
+
+    def test_creates_four_rules(self, seeded_rules):
+        assert len(seeded_rules) == 4
+
+    def test_all_have_is_default_true(self, seeded_rules):
+        for rule in seeded_rules:
+            assert rule["is_default"] is True
+
+    def test_all_have_enabled_true(self, seeded_rules):
+        for rule in seeded_rules:
+            assert rule["enabled"] is True
+
+    def test_all_fetchable_by_id(self, client, seeded_rules):
+        """Each seeded rule can be fetched via GET /api/rules/{id}."""
+        for rule in seeded_rules:
+            resp = client.get(f"{RULES_URL}/{rule['id']}")
+            assert resp.status_code == 200
+            assert resp.json()["name"] == rule["name"]
+
+    def test_list_with_enabled_true_returns_all_defaults(self, client, seeded_rules):
+        """GET /api/rules?enabled=true returns all 4 default rules."""
+        resp = client.get(RULES_URL, params={"enabled": "true"})
+        assert resp.status_code == 200
+        assert len(resp.json()) == 4
+
+
+# ---------------------------------------------------------------------------
+# Idempotency tests
+# ---------------------------------------------------------------------------
+
+class TestSeedIdempotency:
+    """Running the seed twice produces exactly 4 rules — no duplicates."""
+
+    def test_duplicate_name_rejected_at_db_level(self, db):
+        """Inserting a rule with a duplicate name raises IntegrityError."""
+        from sqlalchemy.exc import IntegrityError as SAIntegrityError
+
+        base = dict(
+            entity_type=RuleEntityType.habit,
+            metric=RuleMetric.consecutive_skips,
+            operator=RuleOperator.gte,
+            threshold=5,
+            action=RuleAction.create_notification,
+            notification_type="pattern_observation",
+            message_template="test",
+            enabled=True,
+            cooldown_hours=24,
+        )
+        db.add(Rule(name="Duplicate test", **base))
+        db.commit()
+
+        db.add(Rule(name="Duplicate test", **base))
+        with pytest.raises(SAIntegrityError):
+            db.commit()
+        db.rollback()
+
+    def test_seed_twice_still_four_rules(self, client, seed_rules):
+        """Seeding, then seeding again (skipping existing), yields exactly 4."""
+        # First pass — create all
+        for rule_data in seed_rules:
+            resp = client.post(RULES_URL, json=rule_data)
+            assert resp.status_code == 201
+
+        # Verify 4 rules
+        resp = client.get(RULES_URL)
+        assert len(resp.json()) == 4
+
+        # Second pass — skip existing (simulates seed script behavior)
+        existing = {r["name"] for r in client.get(RULES_URL).json()}
+        created_count = 0
+        for rule_data in seed_rules:
+            if rule_data["name"] not in existing:
+                resp = client.post(RULES_URL, json=rule_data)
+                assert resp.status_code == 201
+                created_count += 1
+
+        assert created_count == 0
+
+        # Still exactly 4 rules
+        resp = client.get(RULES_URL)
+        assert len(resp.json()) == 4
+
+
+# ---------------------------------------------------------------------------
+# Unique name constraint tests
+# ---------------------------------------------------------------------------
+
+class TestUniqueNameConstraint:
+    """The unique constraint on rules.name prevents duplicates at the DB level."""
+
+    def test_unique_names_allowed(self, client):
+        """Two rules with different names succeed."""
+        base = {
+            "entity_type": "habit",
+            "metric": "consecutive_skips",
+            "operator": ">=",
+            "threshold": 3,
+            "notification_type": "habit_nudge",
+            "message_template": "{entity_name} test",
+        }
+        resp1 = client.post(RULES_URL, json={**base, "name": "Rule A"})
+        resp2 = client.post(RULES_URL, json={**base, "name": "Rule B"})
+        assert resp1.status_code == 201
+        assert resp2.status_code == 201


### PR DESCRIPTION
## Summary
Ship BRAIN with four default rules as seed data, using confirmed thresholds from Escalation #7. Adds `is_default` boolean column, unique name constraint, and idempotent seed mechanism.

- **Consecutive skip alert** — 5+ skips on any habit, 72h cooldown, pattern_observation
- **Non-response alert** — 3+ non-responses on any habit, 48h cooldown, pattern_observation
- **Stale task nudge** — 14+ days untouched on any task, 168h cooldown, stale_work_nudge
- **Streak break notice** — 7+ day streak broken on any habit, 168h cooldown, pattern_observation

## Changes
- `alembic/versions/014_add_rules_is_default_and_name_unique.py` — Migration adds `is_default` boolean column (default false) and unique constraint on `name`
- `app/models.py` — `is_default` column and `UniqueConstraint` on Rule model
- `app/schemas/rule.py` — `is_default` field added to RuleCreate (default false) and RuleRead
- `app/routers/rules.py` — `is_default` filter added to list endpoint
- `scripts/seeds/rules.json` — Four default rules with all spec values
- `scripts/seed_data.py` — Rules added to entity load order; individual creation (no batch endpoint) with UTF-8 encoding fix
- `tests/test_rules.py` — Existing loop tests updated for unique name constraint
- `tests/test_rules_seed.py` — 50 new tests covering spec compliance, idempotency, filtering
- `CHANGELOG.md` — Updated

## How to Verify
1. `python -m pytest tests/test_rules_seed.py tests/test_rules.py -v` — 116 tests pass
2. `python -m pytest` — Full suite, 1036 tests pass
3. Start API, run `python scripts/seed_data.py --api-url http://localhost:8000` — creates 4 rules
4. Run seed script again — skips all 4 (idempotent)
5. `GET /api/rules?is_default=true` — returns exactly 4 defaults
6. `GET /api/rules?is_default=false` — returns only user-created rules

## Deviations
- Added `is_default` filter to list endpoint — not in spec but logically necessary for the `is_default` column to be useful via API. Minimal addition (2 lines in router).
- Seed script creates rules individually via POST (not batch) since no batch endpoint exists for rules. This matches the spec's "follow existing brain3 seed patterns" intent while working within the current API surface.
- Added UTF-8 encoding to `load_seed_file()` to fix Windows cp1252 default encoding issue with em dash characters in templates.

## Test Results
```
$ python -m pytest tests/test_rules_seed.py tests/test_rules.py -v
116 passed in 1.84s

$ python -m pytest
1036 passed in 21.29s
```

## Acceptance Checklist
- [x] Four default rules seeded with correct field values per spec
- [x] Seed is idempotent — running twice produces exactly 4 rules
- [x] All four rules have `enabled = True`
- [x] Message templates use valid placeholders from [2F-01] allowed set
- [x] Each rule's metric, operator, threshold, notification type, and cooldown match spec
- [x] `is_default = True` on all seed data, `False` on user-created rules
- [x] Unique constraint on `name` prevents duplicates at DB level

Closes #143