### PR TITLE
2F-03: Rule evaluation engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Rules table model, migration, enum definitions (RuleEntityType, RuleMetric, RuleOperator, RuleAction), FK on notification_queue.rule_id with SET NULL cascade, Pydantic schemas with template placeholder validation (#140)
 - Rules CRUD endpoints — create, list (composable filters: entity_type, enabled, notification_type, entity_id), get, update, delete (#141)
 - Default rules seed data — 4 rules (consecutive skip alert, non-response alert, stale task nudge, streak break notice) with `is_default` column, unique name constraint, `is_default` list filter, and idempotent seed script support (#143)
+- Rule evaluation engine — service-layer `evaluate_rules()` function with metric computation (consecutive_skips, non_responses, days_untouched, streak_length), cooldown enforcement, template rendering, friction-matching for stale task nudge, notification creation via Stream B queue. Two API endpoints: `POST /api/rules/evaluate` (all rules) and `POST /api/rules/{rule_id}/evaluate` (single rule with optional cooldown bypass) (#142)
 
 ## [v1.2.0] — The Knowledge Layer
 

--- a/app/routers/rules.py
+++ b/app/routers/rules.py
@@ -14,8 +14,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-"""CRUD endpoints for Rules."""
+"""CRUD and evaluation endpoints for Rules."""
 
+from dataclasses import asdict
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -27,9 +28,11 @@ from app.schemas.rule import (
     NotificationType,
     RuleCreate,
     RuleEntityType,
+    RuleEvaluationResultResponse,
     RuleRead,
     RuleUpdate,
 )
+from app.services.rule_evaluation import evaluate_rules
 
 router = APIRouter()
 
@@ -78,6 +81,37 @@ def list_rules(
         query = query.filter(Rule.is_default == is_default)
 
     return query.order_by(Rule.created_at.desc()).all()
+
+
+# ---------------------------------------------------------------------------
+# POST — evaluate all rules
+# ---------------------------------------------------------------------------
+
+@router.post("/evaluate", response_model=list[RuleEvaluationResultResponse])
+def evaluate_all_rules(
+    db: Session = Depends(get_db),
+) -> list[dict]:
+    """Evaluate all enabled rules and create notifications for matches."""
+    results = evaluate_rules(db)
+    return [asdict(r) for r in results]
+
+
+# ---------------------------------------------------------------------------
+# POST — evaluate single rule
+# ---------------------------------------------------------------------------
+
+@router.post("/{rule_id}/evaluate", response_model=RuleEvaluationResultResponse)
+def evaluate_single_rule(
+    rule_id: UUID,
+    respect_cooldown: bool = Query(True),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Evaluate a single rule, optionally ignoring cooldown for testing."""
+    rule = db.query(Rule).filter(Rule.id == rule_id).first()
+    if not rule:
+        raise HTTPException(status_code=404, detail="Rule not found")
+    results = evaluate_rules(db, rule_id=rule_id, respect_cooldown=respect_cooldown)
+    return asdict(results[0])
 
 
 # ---------------------------------------------------------------------------

--- a/app/schemas/rule.py
+++ b/app/schemas/rule.py
@@ -173,3 +173,14 @@ class RuleRead(BaseModel):
     last_triggered_at: datetime | None = None
     created_at: datetime
     updated_at: datetime
+
+
+class RuleEvaluationResultResponse(BaseModel):
+    """API response model for a rule evaluation result."""
+
+    rule_id: UUID
+    rule_name: str
+    fired: bool
+    reason: str
+    notifications_created: int
+    entities_evaluated: int

--- a/app/services/rule_evaluation.py
+++ b/app/services/rule_evaluation.py
@@ -1,0 +1,378 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Rule evaluation engine — checks rules against BRAIN data and creates notifications."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.models import Habit, NotificationQueue, Rule, StateCheckin, Task
+from app.schemas.rule import RuleEntityType, RuleMetric, RuleOperator
+from app.services.notification_defaults import get_default_responses
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RuleEvaluationResult:
+    """Summary of a single rule's evaluation."""
+
+    rule_id: UUID
+    rule_name: str
+    fired: bool
+    reason: str  # "fired", "cooldown", "condition_not_met", "no_matching_entities", "error"
+    notifications_created: int = 0
+    entities_evaluated: int = 0
+
+
+def evaluate_rules(
+    db: Session,
+    rule_id: UUID | None = None,
+    respect_cooldown: bool = True,
+) -> list[RuleEvaluationResult]:
+    """Evaluate all enabled rules (or a single rule if rule_id is provided).
+
+    Creates notifications for rules whose conditions are met and cooldown has elapsed.
+    Returns a summary of evaluation results.
+    """
+    if rule_id is not None:
+        rules = db.query(Rule).filter(Rule.id == rule_id).all()
+    else:
+        rules = db.query(Rule).filter(Rule.enabled.is_(True)).all()
+
+    now = datetime.now(tz=UTC)
+    results = []
+
+    for rule in rules:
+        result = _evaluate_single_rule(db, rule, now, respect_cooldown)
+        results.append(result)
+
+    return results
+
+
+def _evaluate_single_rule(
+    db: Session,
+    rule: Rule,
+    now: datetime,
+    respect_cooldown: bool,
+) -> RuleEvaluationResult:
+    """Evaluate a single rule against current data."""
+    # Check cooldown
+    if respect_cooldown and rule.last_triggered_at is not None:
+        triggered = rule.last_triggered_at
+        if triggered.tzinfo is None:
+            triggered = triggered.replace(tzinfo=UTC)
+        cooldown_expiry = triggered + timedelta(hours=rule.cooldown_hours)
+        if now < cooldown_expiry:
+            return RuleEvaluationResult(
+                rule_id=rule.id,
+                rule_name=rule.name,
+                fired=False,
+                reason="cooldown",
+            )
+
+    try:
+        entities = _get_entities(db, rule)
+    except Exception as exc:
+        logger.warning("Error fetching entities for rule %s: %s", rule.name, exc)
+        return RuleEvaluationResult(
+            rule_id=rule.id,
+            rule_name=rule.name,
+            fired=False,
+            reason="error",
+        )
+
+    if not entities:
+        return RuleEvaluationResult(
+            rule_id=rule.id,
+            rule_name=rule.name,
+            fired=False,
+            reason="no_matching_entities",
+        )
+
+    notifications_created = 0
+    entities_evaluated = len(entities)
+
+    # For friction matching on stale tasks, get recent energy
+    recent_energy = None
+    if rule.metric == RuleMetric.days_untouched:
+        recent_energy = _get_recent_energy(db, now)
+
+    for entity in entities:
+        try:
+            metric_value = _compute_metric(db, rule, entity, now)
+        except Exception as exc:
+            logger.warning(
+                "Error computing metric for rule '%s', entity %s: %s",
+                rule.name, entity.id, exc,
+            )
+            continue
+
+        # Friction matching for stale task nudge: skip if task friction > current energy
+        if rule.metric == RuleMetric.days_untouched and recent_energy is not None:
+            friction = getattr(entity, "activation_friction", None)
+            if friction is not None and friction > recent_energy:
+                continue
+
+        if _compare(metric_value, rule.operator, rule.threshold):
+            try:
+                _create_notification(db, rule, entity, metric_value, now)
+                notifications_created += 1
+            except Exception as exc:
+                logger.warning(
+                    "Error creating notification for rule '%s', entity %s: %s",
+                    rule.name, entity.id, exc,
+                )
+                continue
+
+    if notifications_created > 0:
+        rule.last_triggered_at = now
+        db.commit()
+        return RuleEvaluationResult(
+            rule_id=rule.id,
+            rule_name=rule.name,
+            fired=True,
+            reason="fired",
+            notifications_created=notifications_created,
+            entities_evaluated=entities_evaluated,
+        )
+
+    return RuleEvaluationResult(
+        rule_id=rule.id,
+        rule_name=rule.name,
+        fired=False,
+        reason="condition_not_met",
+        entities_evaluated=entities_evaluated,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entity fetching
+# ---------------------------------------------------------------------------
+
+
+def _get_entities(db: Session, rule: Rule) -> list:
+    """Fetch the entities a rule should evaluate."""
+    entity_type = rule.entity_type
+
+    if entity_type == RuleEntityType.habit:
+        query = db.query(Habit).filter(Habit.status == "active")
+        if rule.entity_id is not None:
+            query = query.filter(Habit.id == rule.entity_id)
+        return query.all()
+
+    if entity_type == RuleEntityType.task:
+        query = db.query(Task).filter(Task.status.in_(["pending", "active"]))
+        if rule.entity_id is not None:
+            query = query.filter(Task.id == rule.entity_id)
+        return query.all()
+
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Metric computation
+# ---------------------------------------------------------------------------
+
+
+def _compute_metric(
+    db: Session, rule: Rule, entity: Habit | Task, now: datetime,
+) -> int:
+    """Compute the metric value for a rule against a specific entity."""
+    metric = rule.metric
+
+    if metric == RuleMetric.consecutive_skips:
+        return _compute_consecutive_skips(db, entity)
+
+    if metric == RuleMetric.non_responses:
+        return _compute_non_responses(db, entity)
+
+    if metric == RuleMetric.days_untouched:
+        return _compute_days_untouched(entity, now)
+
+    if metric == RuleMetric.streak_length:
+        return _compute_streak_length(entity)
+
+    return 0
+
+
+def _compute_consecutive_skips(db: Session, habit: Habit) -> int:
+    """Count consecutive 'Skip today' responses on habit nudge notifications.
+
+    Reads backward from the most recent responded notification. Stops at the
+    first non-skip response.
+    """
+    notifications = (
+        db.query(NotificationQueue)
+        .filter(
+            NotificationQueue.target_entity_type == "habit",
+            NotificationQueue.target_entity_id == habit.id,
+            NotificationQueue.notification_type == "habit_nudge",
+            NotificationQueue.status == "responded",
+        )
+        .order_by(NotificationQueue.responded_at.desc())
+        .all()
+    )
+
+    count = 0
+    for nq in notifications:
+        if nq.response == "Skip today":
+            count += 1
+        else:
+            break
+    return count
+
+
+def _compute_non_responses(db: Session, habit: Habit) -> int:
+    """Count consecutive expired notifications with no response.
+
+    Reads backward from the most recent notification. Stops at the first
+    notification that has a response (any status).
+    """
+    notifications = (
+        db.query(NotificationQueue)
+        .filter(
+            NotificationQueue.target_entity_type == "habit",
+            NotificationQueue.target_entity_id == habit.id,
+        )
+        .order_by(NotificationQueue.created_at.desc())
+        .all()
+    )
+
+    count = 0
+    for nq in notifications:
+        if nq.status == "expired" and nq.response is None:
+            count += 1
+        else:
+            break
+    return count
+
+
+def _compute_days_untouched(task: Task, now: datetime) -> int:
+    """Compute days since a task was last updated."""
+    if task.updated_at is None:
+        return 0
+    updated = task.updated_at
+    if updated.tzinfo is None:
+        delta = now.replace(tzinfo=None) - updated
+    else:
+        delta = now - updated
+    return delta.days
+
+
+def _compute_streak_length(habit: Habit) -> int:
+    """Compute the broken streak length for a habit.
+
+    Returns best_streak when current_streak is 0, indicating a recently broken
+    streak. Returns 0 when the streak is ongoing (no break to report).
+    """
+    if habit.current_streak == 0 and habit.best_streak > 0:
+        return habit.best_streak
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Comparison and helpers
+# ---------------------------------------------------------------------------
+
+
+def _compare(value: int, operator: RuleOperator, threshold: int) -> bool:
+    """Apply a comparison operator."""
+    if operator == RuleOperator.gte:
+        return value >= threshold
+    if operator == RuleOperator.lte:
+        return value <= threshold
+    if operator == RuleOperator.eq:
+        return value == threshold
+    return False
+
+
+def _get_recent_energy(db: Session, now: datetime) -> int | None:
+    """Get the most recent check-in energy level within the last 24 hours."""
+    cutoff = now - timedelta(hours=24)
+    checkin = (
+        db.query(StateCheckin)
+        .filter(
+            StateCheckin.logged_at >= cutoff,
+            StateCheckin.energy_level.isnot(None),
+        )
+        .order_by(StateCheckin.logged_at.desc())
+        .first()
+    )
+    if checkin is not None:
+        return checkin.energy_level
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Notification creation
+# ---------------------------------------------------------------------------
+
+
+def _create_notification(
+    db: Session,
+    rule: Rule,
+    entity: Habit | Task,
+    metric_value: int,
+    now: datetime,
+) -> NotificationQueue:
+    """Create a notification in the queue for a fired rule."""
+    entity_name = (
+        getattr(entity, "title", None)
+        or getattr(entity, "name", None)
+        or "Unknown"
+    )
+    entity_type_str = rule.entity_type.value
+
+    template_vars = {
+        "entity_name": entity_name,
+        "entity_type": entity_type_str,
+        "metric_value": metric_value,
+        "threshold": rule.threshold,
+        "rule_name": rule.name,
+    }
+
+    try:
+        message = rule.message_template.format_map(template_vars)
+    except (KeyError, ValueError) as exc:
+        logger.warning(
+            "Template rendering failed for rule '%s': %s", rule.name, exc,
+        )
+        raise
+
+    canned_responses = get_default_responses(rule.notification_type)
+
+    notification = NotificationQueue(
+        notification_type=rule.notification_type,
+        delivery_type="notification",
+        status="pending",
+        scheduled_at=now,
+        target_entity_type=entity_type_str,
+        target_entity_id=entity.id,
+        message=message,
+        canned_responses=canned_responses,
+        scheduled_by="rule",
+        rule_id=rule.id,
+    )
+    db.add(notification)
+    db.flush()
+    return notification

--- a/tests/test_rule_evaluation.py
+++ b/tests/test_rule_evaluation.py
@@ -1,0 +1,930 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for the rule evaluation engine — [2F-03]."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from app.models import Habit, NotificationQueue, Rule, StateCheckin, Task
+from app.schemas.rule import (
+    RuleAction,
+    RuleEntityType,
+    RuleMetric,
+    RuleOperator,
+)
+from app.services.rule_evaluation import (
+    evaluate_rules,
+)
+
+RULES_URL = "/api/rules"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_rule(db, **overrides) -> Rule:
+    """Create and persist a rule with sensible defaults."""
+    defaults = {
+        "name": f"Test rule {uuid.uuid4().hex[:6]}",
+        "entity_type": RuleEntityType.habit,
+        "metric": RuleMetric.consecutive_skips,
+        "operator": RuleOperator.gte,
+        "threshold": 3,
+        "action": RuleAction.create_notification,
+        "notification_type": "habit_nudge",
+        "message_template": "{entity_name} hit {metric_value} (threshold {threshold})",
+        "enabled": True,
+        "cooldown_hours": 24,
+    }
+    defaults.update(overrides)
+    rule = Rule(**defaults)
+    db.add(rule)
+    db.commit()
+    db.refresh(rule)
+    return rule
+
+
+def _make_habit_orm(db, **overrides) -> Habit:
+    """Create and persist a habit directly via ORM."""
+    defaults = {
+        "title": "Test Habit",
+        "status": "active",
+        "current_streak": 0,
+        "best_streak": 0,
+    }
+    defaults.update(overrides)
+    habit = Habit(**defaults)
+    db.add(habit)
+    db.commit()
+    db.refresh(habit)
+    return habit
+
+
+def _make_task_orm(db, **overrides) -> Task:
+    """Create and persist a task directly via ORM."""
+    defaults = {
+        "title": "Test Task",
+        "status": "pending",
+    }
+    defaults.update(overrides)
+    task = Task(**defaults)
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+def _make_notification_orm(db, **overrides) -> NotificationQueue:
+    """Create and persist a notification directly via ORM."""
+    defaults = {
+        "notification_type": "habit_nudge",
+        "delivery_type": "notification",
+        "status": "pending",
+        "scheduled_at": datetime.now(tz=UTC),
+        "target_entity_type": "habit",
+        "target_entity_id": uuid.uuid4(),
+        "message": "Test notification",
+        "scheduled_by": "system",
+    }
+    defaults.update(overrides)
+    nq = NotificationQueue(**defaults)
+    db.add(nq)
+    db.commit()
+    db.refresh(nq)
+    return nq
+
+
+def _make_checkin_orm(db, **overrides) -> StateCheckin:
+    """Create and persist a state check-in directly via ORM."""
+    defaults = {
+        "checkin_type": "morning",
+        "logged_at": datetime.now(tz=UTC),
+    }
+    defaults.update(overrides)
+    checkin = StateCheckin(**defaults)
+    db.add(checkin)
+    db.commit()
+    db.refresh(checkin)
+    return checkin
+
+
+# ===========================================================================
+# Happy path: consecutive_skips metric
+# ===========================================================================
+
+
+class TestConsecutiveSkipsMetric:
+    """evaluate_rules fires for habits with consecutive skip responses."""
+
+    def test_fires_when_skip_threshold_met(self, db):
+        habit = _make_habit_orm(db, title="Meditation")
+        rule = _make_rule(
+            db,
+            entity_type=RuleEntityType.habit,
+            metric=RuleMetric.consecutive_skips,
+            operator=RuleOperator.gte,
+            threshold=3,
+            notification_type="pattern_observation",
+            message_template="You've skipped {entity_name} {metric_value} times",
+        )
+
+        # Create 3 consecutive skip responses
+        base_time = datetime.now(tz=UTC) - timedelta(hours=10)
+        for i in range(3):
+            _make_notification_orm(
+                db,
+                target_entity_type="habit",
+                target_entity_id=habit.id,
+                notification_type="habit_nudge",
+                status="responded",
+                response="Skip today",
+                responded_at=base_time + timedelta(hours=i),
+                scheduled_by="system",
+            )
+
+        results = evaluate_rules(db)
+        assert len(results) == 1
+        assert results[0].fired is True
+        assert results[0].reason == "fired"
+        assert results[0].notifications_created == 1
+
+        # Verify notification in queue
+        notifs = db.query(NotificationQueue).filter(
+            NotificationQueue.scheduled_by == "rule",
+        ).all()
+        assert len(notifs) == 1
+        assert notifs[0].rule_id == rule.id
+        assert "Meditation" in notifs[0].message
+        assert "3" in notifs[0].message
+
+    def test_does_not_fire_below_threshold(self, db):
+        habit = _make_habit_orm(db, title="Meditation")
+        _make_rule(
+            db,
+            metric=RuleMetric.consecutive_skips,
+            threshold=3,
+        )
+
+        # Only 2 skips — below threshold
+        base_time = datetime.now(tz=UTC) - timedelta(hours=5)
+        for i in range(2):
+            _make_notification_orm(
+                db,
+                target_entity_type="habit",
+                target_entity_id=habit.id,
+                notification_type="habit_nudge",
+                status="responded",
+                response="Skip today",
+                responded_at=base_time + timedelta(hours=i),
+                scheduled_by="system",
+            )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is False
+        assert results[0].reason == "condition_not_met"
+
+    def test_non_skip_response_breaks_chain(self, db):
+        habit = _make_habit_orm(db, title="Meditation")
+        _make_rule(
+            db,
+            metric=RuleMetric.consecutive_skips,
+            threshold=3,
+        )
+
+        base_time = datetime.now(tz=UTC) - timedelta(hours=10)
+        # Skip, then "Doing it now", then 2 more skips
+        responses = ["Skip today", "Skip today", "Doing it now", "Skip today"]
+        for i, resp in enumerate(responses):
+            _make_notification_orm(
+                db,
+                target_entity_type="habit",
+                target_entity_id=habit.id,
+                notification_type="habit_nudge",
+                status="responded",
+                response=resp,
+                responded_at=base_time + timedelta(hours=i),
+                scheduled_by="system",
+            )
+
+        # Most recent 2 are skips, then "Doing it now" breaks chain → count = 2
+        results = evaluate_rules(db)
+        assert results[0].fired is False
+        assert results[0].reason == "condition_not_met"
+
+
+# ===========================================================================
+# Happy path: non_responses metric
+# ===========================================================================
+
+
+class TestNonResponsesMetric:
+    """evaluate_rules fires for habits with consecutive expired notifications."""
+
+    def test_fires_when_non_response_threshold_met(self, db):
+        habit = _make_habit_orm(db, title="Exercise")
+        _make_rule(
+            db,
+            metric=RuleMetric.non_responses,
+            operator=RuleOperator.gte,
+            threshold=3,
+            notification_type="pattern_observation",
+            message_template="{entity_name} has {metric_value} non-responses",
+        )
+
+        base_time = datetime.now(tz=UTC) - timedelta(hours=10)
+        for i in range(3):
+            _make_notification_orm(
+                db,
+                target_entity_type="habit",
+                target_entity_id=habit.id,
+                status="expired",
+                response=None,
+                created_at=base_time + timedelta(hours=i),
+                scheduled_by="system",
+            )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is True
+        assert results[0].notifications_created == 1
+
+    def test_responded_notification_breaks_chain(self, db):
+        habit = _make_habit_orm(db, title="Exercise")
+        _make_rule(
+            db,
+            metric=RuleMetric.non_responses,
+            threshold=3,
+        )
+
+        base_time = datetime.now(tz=UTC) - timedelta(hours=10)
+        # Responded, then 2 expired — only 2 consecutive non-responses
+        _make_notification_orm(
+            db,
+            target_entity_type="habit",
+            target_entity_id=habit.id,
+            status="responded",
+            response="Already done",
+            responded_at=base_time,
+            created_at=base_time,
+            scheduled_by="system",
+        )
+        for i in range(1, 3):
+            _make_notification_orm(
+                db,
+                target_entity_type="habit",
+                target_entity_id=habit.id,
+                status="expired",
+                response=None,
+                created_at=base_time + timedelta(hours=i),
+                scheduled_by="system",
+            )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is False
+        assert results[0].reason == "condition_not_met"
+
+
+# ===========================================================================
+# Happy path: days_untouched metric
+# ===========================================================================
+
+
+class TestDaysUntouchedMetric:
+    """evaluate_rules fires for stale tasks."""
+
+    def test_fires_for_stale_task(self, db):
+        task = _make_task_orm(
+            db,
+            title="Clean garage",
+            updated_at=datetime.now(tz=UTC) - timedelta(days=15),
+        )
+        _make_rule(
+            db,
+            entity_type=RuleEntityType.task,
+            metric=RuleMetric.days_untouched,
+            operator=RuleOperator.gte,
+            threshold=14,
+            notification_type="stale_work_nudge",
+            message_template="{entity_name} hasn't been touched in {metric_value} days",
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is True
+        assert results[0].notifications_created == 1
+
+        notifs = db.query(NotificationQueue).filter(
+            NotificationQueue.scheduled_by == "rule",
+        ).all()
+        assert len(notifs) == 1
+        assert "Clean garage" in notifs[0].message
+        assert notifs[0].target_entity_type == "task"
+        assert notifs[0].target_entity_id == task.id
+
+    def test_does_not_fire_for_recent_task(self, db):
+        _make_task_orm(
+            db,
+            title="Fresh task",
+            updated_at=datetime.now(tz=UTC) - timedelta(days=5),
+        )
+        _make_rule(
+            db,
+            entity_type=RuleEntityType.task,
+            metric=RuleMetric.days_untouched,
+            threshold=14,
+            notification_type="stale_work_nudge",
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is False
+
+
+# ===========================================================================
+# Happy path: streak_length metric
+# ===========================================================================
+
+
+class TestStreakLengthMetric:
+    """evaluate_rules fires when a habit streak is broken."""
+
+    def test_fires_when_streak_broken(self, db):
+        _make_habit_orm(
+            db,
+            title="Journaling",
+            current_streak=0,
+            best_streak=10,
+        )
+        _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            operator=RuleOperator.gte,
+            threshold=7,
+            notification_type="pattern_observation",
+            message_template="Your {entity_name} streak of {metric_value} days ended",
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is True
+        assert results[0].notifications_created == 1
+
+        notifs = db.query(NotificationQueue).filter(
+            NotificationQueue.scheduled_by == "rule",
+        ).all()
+        assert "Journaling" in notifs[0].message
+        assert "10" in notifs[0].message
+
+    def test_does_not_fire_when_streak_ongoing(self, db):
+        _make_habit_orm(
+            db,
+            title="Journaling",
+            current_streak=5,
+            best_streak=10,
+        )
+        _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is False
+
+    def test_does_not_fire_when_streak_below_threshold(self, db):
+        _make_habit_orm(
+            db,
+            title="Journaling",
+            current_streak=0,
+            best_streak=3,
+        )
+        _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is False
+
+
+# ===========================================================================
+# Cooldown enforcement
+# ===========================================================================
+
+
+class TestCooldown:
+    """Cooldown prevents re-firing within the cooldown window."""
+
+    def test_rule_in_cooldown_is_skipped(self, db):
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            cooldown_hours=24,
+            last_triggered_at=datetime.now(tz=UTC) - timedelta(hours=2),
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is False
+        assert results[0].reason == "cooldown"
+
+    def test_rule_after_cooldown_fires(self, db):
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            cooldown_hours=24,
+            last_triggered_at=datetime.now(tz=UTC) - timedelta(hours=25),
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is True
+
+    def test_fire_then_cooldown_then_fire(self, db):
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            cooldown_hours=24,
+        )
+
+        # First evaluation — fires
+        results1 = evaluate_rules(db)
+        assert results1[0].fired is True
+
+        # Second evaluation — cooldown blocks
+        results2 = evaluate_rules(db)
+        assert results2[0].fired is False
+        assert results2[0].reason == "cooldown"
+
+    def test_respect_cooldown_false_bypasses_cooldown(self, db):
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        rule = _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            cooldown_hours=24,
+            last_triggered_at=datetime.now(tz=UTC) - timedelta(hours=2),
+        )
+
+        results = evaluate_rules(db, rule_id=rule.id, respect_cooldown=False)
+        assert results[0].fired is True
+
+
+# ===========================================================================
+# Entity-scoped vs global rules
+# ===========================================================================
+
+
+class TestEntityScoping:
+    """Entity-scoped rules evaluate only the target entity; global rules evaluate all."""
+
+    def test_scoped_rule_evaluates_only_target(self, db):
+        habit_x = _make_habit_orm(db, title="Habit X", current_streak=0, best_streak=10)
+        _make_habit_orm(db, title="Habit Y", current_streak=0, best_streak=10)
+        _make_habit_orm(db, title="Habit Z", current_streak=0, best_streak=10)
+
+        _make_rule(
+            db,
+            entity_id=habit_x.id,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            notification_type="pattern_observation",
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is True
+        assert results[0].notifications_created == 1
+
+        notifs = db.query(NotificationQueue).filter(
+            NotificationQueue.scheduled_by == "rule",
+        ).all()
+        assert len(notifs) == 1
+        assert notifs[0].target_entity_id == habit_x.id
+
+    def test_global_rule_evaluates_all_matching(self, db):
+        _make_habit_orm(db, title="Habit X", current_streak=0, best_streak=10)
+        _make_habit_orm(db, title="Habit Y", current_streak=0, best_streak=10)
+        _make_habit_orm(db, title="Habit Z", current_streak=0, best_streak=10)
+
+        _make_rule(
+            db,
+            entity_id=None,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            notification_type="pattern_observation",
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is True
+        assert results[0].notifications_created == 3
+        assert results[0].entities_evaluated == 3
+
+
+# ===========================================================================
+# Template rendering
+# ===========================================================================
+
+
+class TestTemplateRendering:
+    """Message templates resolve all 5 placeholders correctly."""
+
+    def test_all_placeholders_resolve(self, db):
+        _make_habit_orm(db, title="Meditation", current_streak=0, best_streak=10)
+        _make_rule(
+            db,
+            name="Streak break notice",
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            notification_type="pattern_observation",
+            message_template=(
+                "{rule_name}: {entity_type} '{entity_name}' hit "
+                "{metric_value} (threshold {threshold})"
+            ),
+        )
+
+        evaluate_rules(db)
+
+        notifs = db.query(NotificationQueue).filter(
+            NotificationQueue.scheduled_by == "rule",
+        ).all()
+        assert len(notifs) == 1
+        msg = notifs[0].message
+        assert "Streak break notice" in msg
+        assert "habit" in msg
+        assert "Meditation" in msg
+        assert "10" in msg
+        assert "7" in msg
+
+
+# ===========================================================================
+# Error resilience
+# ===========================================================================
+
+
+class TestErrorResilience:
+    """Evaluation completes gracefully when entities are missing or broken."""
+
+    def test_deleted_entity_skipped_gracefully(self, db):
+        habit = _make_habit_orm(db, title="Ghost Habit", current_streak=0, best_streak=10)
+        _make_rule(
+            db,
+            entity_id=habit.id,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+        )
+
+        # Delete the habit before evaluation
+        db.delete(habit)
+        db.commit()
+
+        results = evaluate_rules(db)
+        assert results[0].fired is False
+        assert results[0].reason == "no_matching_entities"
+
+    def test_disabled_rule_not_evaluated(self, db):
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            enabled=False,
+        )
+
+        results = evaluate_rules(db)
+        assert len(results) == 0
+
+
+# ===========================================================================
+# Friction matching (stale task nudge)
+# ===========================================================================
+
+
+class TestFrictionMatching:
+    """Stale task nudge respects friction vs. current energy."""
+
+    def test_fires_when_friction_within_energy(self, db):
+        _make_task_orm(
+            db,
+            title="Easy task",
+            activation_friction=2,
+            updated_at=datetime.now(tz=UTC) - timedelta(days=15),
+        )
+        _make_checkin_orm(db, energy_level=3, logged_at=datetime.now(tz=UTC))
+        _make_rule(
+            db,
+            entity_type=RuleEntityType.task,
+            metric=RuleMetric.days_untouched,
+            threshold=14,
+            notification_type="stale_work_nudge",
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is True
+
+    def test_skips_when_friction_exceeds_energy(self, db):
+        _make_task_orm(
+            db,
+            title="Hard task",
+            activation_friction=4,
+            updated_at=datetime.now(tz=UTC) - timedelta(days=15),
+        )
+        _make_checkin_orm(db, energy_level=1, logged_at=datetime.now(tz=UTC))
+        _make_rule(
+            db,
+            entity_type=RuleEntityType.task,
+            metric=RuleMetric.days_untouched,
+            threshold=14,
+            notification_type="stale_work_nudge",
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is False
+        assert results[0].reason == "condition_not_met"
+
+    def test_fires_without_checkin_data(self, db):
+        """No recent check-in → friction filter skipped, evaluates on days_untouched alone."""
+        _make_task_orm(
+            db,
+            title="Hard task",
+            activation_friction=5,
+            updated_at=datetime.now(tz=UTC) - timedelta(days=15),
+        )
+        # No check-in created — friction filter should be skipped
+        _make_rule(
+            db,
+            entity_type=RuleEntityType.task,
+            metric=RuleMetric.days_untouched,
+            threshold=14,
+            notification_type="stale_work_nudge",
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is True
+
+    def test_old_checkin_ignored(self, db):
+        """Check-in older than 24h is treated as no check-in (friction filter skipped)."""
+        _make_task_orm(
+            db,
+            title="Hard task",
+            activation_friction=5,
+            updated_at=datetime.now(tz=UTC) - timedelta(days=15),
+        )
+        _make_checkin_orm(
+            db,
+            energy_level=1,
+            logged_at=datetime.now(tz=UTC) - timedelta(hours=25),
+        )
+        _make_rule(
+            db,
+            entity_type=RuleEntityType.task,
+            metric=RuleMetric.days_untouched,
+            threshold=14,
+            notification_type="stale_work_nudge",
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is True
+
+
+# ===========================================================================
+# Notification properties
+# ===========================================================================
+
+
+class TestNotificationProperties:
+    """Notifications created by evaluation have correct scheduled_by and rule_id."""
+
+    def test_notification_has_rule_metadata(self, db):
+        habit = _make_habit_orm(db, title="Test", current_streak=0, best_streak=10)
+        rule = _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            notification_type="pattern_observation",
+        )
+
+        evaluate_rules(db)
+
+        notifs = db.query(NotificationQueue).filter(
+            NotificationQueue.scheduled_by == "rule",
+        ).all()
+        assert len(notifs) == 1
+        assert notifs[0].scheduled_by == "rule"
+        assert notifs[0].rule_id == rule.id
+        assert notifs[0].status == "pending"
+        assert notifs[0].delivery_type == "notification"
+        assert notifs[0].target_entity_type == "habit"
+        assert notifs[0].target_entity_id == habit.id
+
+    def test_notification_gets_default_canned_responses(self, db):
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            notification_type="pattern_observation",
+        )
+
+        evaluate_rules(db)
+
+        notifs = db.query(NotificationQueue).filter(
+            NotificationQueue.scheduled_by == "rule",
+        ).all()
+        assert notifs[0].canned_responses is not None
+        assert "Noted" in notifs[0].canned_responses
+
+    def test_last_triggered_at_updated_on_fire(self, db):
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        rule = _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+        )
+        assert rule.last_triggered_at is None
+
+        evaluate_rules(db)
+
+        db.refresh(rule)
+        assert rule.last_triggered_at is not None
+
+    def test_idempotent_within_cooldown(self, db):
+        """Running evaluation twice within cooldown produces no duplicates."""
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            cooldown_hours=24,
+        )
+
+        evaluate_rules(db)
+        evaluate_rules(db)
+
+        notifs = db.query(NotificationQueue).filter(
+            NotificationQueue.scheduled_by == "rule",
+        ).all()
+        assert len(notifs) == 1
+
+
+# ===========================================================================
+# API endpoint tests
+# ===========================================================================
+
+
+class TestEvaluateAllEndpoint:
+    """POST /api/rules/evaluate"""
+
+    def test_evaluate_all_returns_results(self, client, db):
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            notification_type="pattern_observation",
+        )
+
+        resp = client.post(f"{RULES_URL}/evaluate")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["fired"] is True
+        assert data[0]["reason"] == "fired"
+        assert data[0]["notifications_created"] == 1
+
+    def test_evaluate_all_empty_when_no_rules(self, client):
+        resp = client.post(f"{RULES_URL}/evaluate")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_evaluate_all_skips_disabled_rules(self, client, db):
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        _make_rule(db, metric=RuleMetric.streak_length, threshold=7, enabled=False)
+
+        resp = client.post(f"{RULES_URL}/evaluate")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestEvaluateSingleEndpoint:
+    """POST /api/rules/{rule_id}/evaluate"""
+
+    def test_evaluate_single_rule(self, client, db):
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        rule = _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            notification_type="pattern_observation",
+        )
+
+        resp = client.post(f"{RULES_URL}/{rule.id}/evaluate")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["fired"] is True
+        assert data["rule_id"] == str(rule.id)
+
+    def test_evaluate_single_not_found(self, client):
+        fake_id = str(uuid.uuid4())
+        resp = client.post(f"{RULES_URL}/{fake_id}/evaluate")
+        assert resp.status_code == 404
+
+    def test_evaluate_single_bypass_cooldown(self, client, db):
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        rule = _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            cooldown_hours=24,
+            last_triggered_at=datetime.now(tz=UTC) - timedelta(hours=2),
+        )
+
+        # With cooldown respected (default) — should be skipped
+        resp = client.post(f"{RULES_URL}/{rule.id}/evaluate")
+        assert resp.json()["fired"] is False
+        assert resp.json()["reason"] == "cooldown"
+
+        # With cooldown bypassed
+        resp = client.post(
+            f"{RULES_URL}/{rule.id}/evaluate",
+            params={"respect_cooldown": False},
+        )
+        assert resp.json()["fired"] is True
+
+    def test_evaluate_single_evaluates_disabled_rule(self, client, db):
+        """Single-rule evaluate works even if the rule is disabled."""
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        rule = _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            enabled=False,
+        )
+
+        resp = client.post(f"{RULES_URL}/{rule.id}/evaluate")
+        assert resp.status_code == 200
+        assert resp.json()["fired"] is True
+
+
+# ===========================================================================
+# No matching entities
+# ===========================================================================
+
+
+class TestNoMatchingEntities:
+    """Rules report no_matching_entities when no relevant entities exist."""
+
+    def test_habit_rule_with_no_habits(self, db):
+        _make_rule(db, metric=RuleMetric.consecutive_skips, threshold=3)
+
+        results = evaluate_rules(db)
+        assert results[0].fired is False
+        assert results[0].reason == "no_matching_entities"
+
+    def test_task_rule_with_no_tasks(self, db):
+        _make_rule(
+            db,
+            entity_type=RuleEntityType.task,
+            metric=RuleMetric.days_untouched,
+            threshold=14,
+            notification_type="stale_work_nudge",
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is False
+        assert results[0].reason == "no_matching_entities"
+
+    def test_task_rule_ignores_completed_tasks(self, db):
+        _make_task_orm(
+            db,
+            title="Done task",
+            status="completed",
+            updated_at=datetime.now(tz=UTC) - timedelta(days=30),
+        )
+        _make_rule(
+            db,
+            entity_type=RuleEntityType.task,
+            metric=RuleMetric.days_untouched,
+            threshold=14,
+            notification_type="stale_work_nudge",
+        )
+
+        results = evaluate_rules(db)
+        assert results[0].fired is False
+        assert results[0].reason == "no_matching_entities"


### PR DESCRIPTION
## Summary
- Implements the rule evaluation engine — the core intelligence of Stream F that makes rules actually do something
- Service-layer `evaluate_rules()` function with 4 metric computations, cooldown enforcement, template rendering, and notification creation via Stream B queue
- Two API endpoints: `POST /api/rules/evaluate` (all enabled rules) and `POST /api/rules/{rule_id}/evaluate` (single rule with optional cooldown bypass)

## Changes
- **`app/services/rule_evaluation.py`** (new) — Core evaluation engine: `evaluate_rules()` function, `RuleEvaluationResult` dataclass, metric computation for all 4 metrics (`consecutive_skips`, `non_responses`, `days_untouched`, `streak_length`), cooldown checking, entity-scoped vs global evaluation, friction-matching for stale task nudge (respects recent check-in energy), notification creation via existing Stream B defaults
- **`app/routers/rules.py`** — Added `POST /evaluate` and `POST /{rule_id}/evaluate` endpoints wrapping the service function
- **`app/schemas/rule.py`** — Added `RuleEvaluationResultResponse` Pydantic model for API serialization
- **`tests/test_rule_evaluation.py`** (new) — 37 tests covering all acceptance criteria
- **`CHANGELOG.md`** — Added 2F-03 entry

## How to Verify
1. Start dev environment: `docker compose -f docker-compose.dev.yml up -d && uvicorn app.main:app --reload`
2. Seed default rules: `python scripts/seed_data.py --only rules`
3. Create test entities (habits, tasks) via the API
4. `POST /api/rules/evaluate` — should return evaluation results for all enabled rules
5. `POST /api/rules/{rule_id}/evaluate?respect_cooldown=false` — single rule evaluation
6. Verify notifications appear in `GET /api/notifications?scheduled_by=rule`
7. Run full test suite: `pytest -v` (1073 tests pass)

## Deviations
- **`streak_length` metric implementation:** Spec notes that computing the "recently broken streak" from completion history would be ideal. Implemented using `best_streak` when `current_streak == 0` as the pragmatic approach — the cooldown mechanism prevents repeated firing for the same streak break. Per-entity streak history computation deferred to Phase 3 per spec guidance.
- **Entity types:** Only `habit` and `task` entity types are actively evaluated. `routine` and `checkin` entity types return empty entity lists (no metrics defined for them in the current spec). This is by design — those types exist in the enum for future extensibility.

## Test Results
```
pytest -v tests/test_rule_evaluation.py
37 passed in 0.47s

pytest -v (full suite)
1073 passed in 18.14s
```

## Acceptance Checklist
- [x] Service-layer function `evaluate_rules(db, rule_id, respect_cooldown)` exists
- [x] Queries all enabled rules (or single rule by ID)
- [x] Computes current metric value per entity per rule
- [x] Applies operator + threshold comparison
- [x] Skips rules within cooldown window
- [x] Fires: renders template, creates notification, updates `last_triggered_at`
- [x] Returns `RuleEvaluationResult` list with fired/skipped/reason detail
- [x] `POST /api/rules/evaluate` endpoint exists and returns results
- [x] `POST /api/rules/{rule_id}/evaluate` with `respect_cooldown` query param
- [x] Cooldown enforced: 2h-old trigger with 24h cooldown → skipped
- [x] Entity-scoped rules evaluate only that entity
- [x] Global rules evaluate all entities of the type
- [x] Notifications have `scheduled_by = "rule"` and `rule_id` set
- [x] Template rendering uses `str.format_map()` with all 5 placeholders
- [x] Missing entity data skips gracefully with logged warning
- [x] Friction matching: stale task nudge respects current energy, falls back without check-in
- [x] All tests pass, ruff clean

Closes #142