### PR TITLE
2G-01: Graduation evaluation service — core rolling-window logic & schema additions

### DIFF
--- a/alembic/versions/015_add_graduation_columns_to_habits.py
+++ b/alembic/versions/015_add_graduation_columns_to_habits.py
@@ -1,0 +1,68 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Add friction_score, re_scaffold_count, last_frequency_changed_at to habits.
+
+Revision ID: 15a1b2c3d4e5
+Revises: 14a1b2c3d4e5
+Create Date: 2026-04-15
+
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "15a1b2c3d4e5"
+down_revision: Union[str, None] = "14a1b2c3d4e5"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "habits",
+        sa.Column("friction_score", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "habits",
+        sa.Column(
+            "re_scaffold_count", sa.Integer(), nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+    op.add_column(
+        "habits",
+        sa.Column(
+            "last_frequency_changed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.create_check_constraint(
+        "ck_habits_friction_score",
+        "habits",
+        "friction_score IS NULL OR (friction_score >= 1 AND friction_score <= 5)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_habits_friction_score", "habits", type_="check")
+    op.drop_column("habits", "last_frequency_changed_at")
+    op.drop_column("habits", "re_scaffold_count")
+    op.drop_column("habits", "friction_score")

--- a/app/models.py
+++ b/app/models.py
@@ -486,6 +486,13 @@ class Habit(Base):
         Numeric(precision=3, scale=2), default=0.85,
     )
     graduation_threshold: Mapped[int | None] = mapped_column(Integer, default=30)
+    friction_score: Mapped[int | None] = mapped_column(Integer)
+    re_scaffold_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0"),
+    )
+    last_frequency_changed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+    )
     current_streak: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("0"),
     )
@@ -518,6 +525,10 @@ class Habit(Base):
         CheckConstraint(
             "scaffolding_status IN ('tracking', 'accountable', 'graduated')",
             name="ck_habits_scaffolding_status",
+        ),
+        CheckConstraint(
+            "friction_score IS NULL OR (friction_score >= 1 AND friction_score <= 5)",
+            name="ck_habits_friction_score",
         ),
         Index("ix_habits_status", "status"),
         Index("ix_habits_routine_id", "routine_id"),

--- a/app/schemas/habits.py
+++ b/app/schemas/habits.py
@@ -46,12 +46,21 @@ class HabitCreate(BaseModel):
     graduation_window: int | None = None
     graduation_target: float | None = None
     graduation_threshold: int | None = None
+    friction_score: int | None = None
 
     @field_validator("graduation_target")
     @classmethod
     def validate_graduation_target(cls, v: float | None) -> float | None:
         if v is not None and (v < 0.0 or v > 1.0):
             msg = "graduation_target must be between 0.0 and 1.0"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("friction_score")
+    @classmethod
+    def validate_friction_score(cls, v: int | None) -> int | None:
+        if v is not None and (v < 1 or v > 5):
+            msg = "friction_score must be between 1 and 5"
             raise ValueError(msg)
         return v
 
@@ -79,12 +88,21 @@ class HabitUpdate(BaseModel):
     graduation_window: int | None = None
     graduation_target: float | None = None
     graduation_threshold: int | None = None
+    friction_score: int | None = None
 
     @field_validator("graduation_target")
     @classmethod
     def validate_graduation_target(cls, v: float | None) -> float | None:
         if v is not None and (v < 0.0 or v > 1.0):
             msg = "graduation_target must be between 0.0 and 1.0"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("friction_score")
+    @classmethod
+    def validate_friction_score(cls, v: int | None) -> int | None:
+        if v is not None and (v < 1 or v > 5):
+            msg = "friction_score must be between 1 and 5"
             raise ValueError(msg)
         return v
 
@@ -106,6 +124,9 @@ class HabitResponse(BaseModel):
     graduation_window: int | None = None
     graduation_target: float | None = None
     graduation_threshold: int | None = None
+    friction_score: int | None = None
+    re_scaffold_count: int
+    last_frequency_changed_at: datetime | None = None
     current_streak: int
     best_streak: int
     last_completed: date | None = None

--- a/app/services/graduation.py
+++ b/app/services/graduation.py
@@ -1,0 +1,176 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Graduation evaluation service — rolling-window analysis for habit scaffolding."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.models import Habit, NotificationQueue
+from app.services.graduation_defaults import resolve_graduation_params
+
+
+class GraduationResult(BaseModel):
+    """Result of evaluating a habit's graduation eligibility."""
+
+    eligible: bool
+    habit_id: UUID
+    current_rate: float
+    total_notifications: int
+    already_done_count: int
+    window_days: int
+    target_rate: float
+    days_since_introduction: int
+    threshold_days: int
+    meets_rate: bool
+    meets_threshold: bool
+    blocking_reasons: list[str]
+
+
+def apply_re_scaffold_tightening(
+    window: int, target: float, threshold: int, re_scaffold_count: int,
+) -> tuple[int, float, int]:
+    """Tighten graduation criteria based on re-scaffold history."""
+    for _ in range(re_scaffold_count):
+        window = int(window * 1.25)
+        target = min(target + 0.05, 0.95)
+        threshold = int(threshold * 1.25)
+    return (window, target, threshold)
+
+
+def evaluate_graduation(
+    db: Session,
+    habit_id: UUID,
+) -> GraduationResult:
+    """Evaluate whether a habit is eligible for graduation.
+
+    This function does NOT change state — it returns a result.
+    State transitions happen in [2G-02].
+    """
+    habit = db.query(Habit).filter(Habit.id == habit_id).first()
+    if habit is None:
+        raise ValueError(f"Habit {habit_id} not found")
+
+    # Gate: only accountable habits can be evaluated
+    if habit.scaffolding_status != "accountable":
+        return GraduationResult(
+            eligible=False,
+            habit_id=habit_id,
+            current_rate=0.0,
+            total_notifications=0,
+            already_done_count=0,
+            window_days=0,
+            target_rate=0.0,
+            days_since_introduction=0,
+            threshold_days=0,
+            meets_rate=False,
+            meets_threshold=False,
+            blocking_reasons=[
+                "Habit scaffolding_status must be 'accountable' to evaluate graduation"
+            ],
+        )
+
+    # Resolve parameters with friction-aware defaults
+    window, target, threshold = resolve_graduation_params(habit)
+
+    # Apply re-scaffold tightening if applicable
+    if habit.re_scaffold_count > 0:
+        window, target, threshold = apply_re_scaffold_tightening(
+            window, target, threshold, habit.re_scaffold_count,
+        )
+
+    now = datetime.now(tz=UTC)
+
+    # Compute days since introduction
+    if habit.introduced_at is not None:
+        days_since_introduction = (now.date() - habit.introduced_at).days
+    else:
+        days_since_introduction = 0
+
+    meets_threshold = days_since_introduction >= threshold
+
+    # Query notification responses in the rolling window
+    window_start = now - timedelta(days=window)
+    notifications = (
+        db.query(NotificationQueue)
+        .filter(
+            NotificationQueue.target_entity_type == "habit",
+            NotificationQueue.target_entity_id == habit_id,
+            NotificationQueue.notification_type == "habit_nudge",
+            NotificationQueue.scheduled_at >= window_start,
+            NotificationQueue.status.in_(["responded", "expired"]),
+        )
+        .all()
+    )
+
+    total_notifications = len(notifications)
+
+    # Handle zero-notification edge case
+    if total_notifications == 0:
+        return GraduationResult(
+            eligible=False,
+            habit_id=habit_id,
+            current_rate=0.0,
+            total_notifications=0,
+            already_done_count=0,
+            window_days=window,
+            target_rate=target,
+            days_since_introduction=days_since_introduction,
+            threshold_days=threshold,
+            meets_rate=False,
+            meets_threshold=meets_threshold,
+            blocking_reasons=["No notification data in evaluation window"],
+        )
+
+    already_done_count = sum(
+        1 for n in notifications if n.response == "Already done"
+    )
+    current_rate = already_done_count / total_notifications
+
+    meets_rate = current_rate >= target
+
+    # Build blocking reasons
+    blocking_reasons: list[str] = []
+    if not meets_rate:
+        blocking_reasons.append(
+            f"Rate {current_rate:.0%} below target {target:.0%}"
+        )
+    if not meets_threshold:
+        blocking_reasons.append(
+            f"{days_since_introduction} days since introduction, need {threshold}"
+        )
+
+    eligible = meets_rate and meets_threshold
+
+    return GraduationResult(
+        eligible=eligible,
+        habit_id=habit_id,
+        current_rate=current_rate,
+        total_notifications=total_notifications,
+        already_done_count=already_done_count,
+        window_days=window,
+        target_rate=target,
+        days_since_introduction=days_since_introduction,
+        threshold_days=threshold,
+        meets_rate=meets_rate,
+        meets_threshold=meets_threshold,
+        blocking_reasons=blocking_reasons,
+    )

--- a/app/services/graduation_defaults.py
+++ b/app/services/graduation_defaults.py
@@ -1,0 +1,49 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Friction-aware graduation defaults and parameter resolution."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.models import Habit
+
+# friction_score: (window_days, target_rate, threshold_days)
+GRADUATION_DEFAULTS: dict[int | None, tuple[int, float, int]] = {
+    1: (30, 0.85, 30),
+    2: (30, 0.85, 30),
+    3: (45, 0.85, 45),
+    4: (60, 0.80, 60),
+    5: (60, 0.80, 60),
+    None: (45, 0.85, 45),  # unknown friction falls to middle tier
+}
+
+
+def resolve_graduation_params(habit: Habit) -> tuple[int, float, int]:
+    """Return (window, target, threshold) using per-habit overrides or friction defaults.
+
+    Each of the three knobs resolves independently — a habit can override
+    graduation_window but inherit graduation_target from its friction tier.
+    """
+    defaults = GRADUATION_DEFAULTS[habit.friction_score]
+    window = habit.graduation_window if habit.graduation_window is not None else defaults[0]
+    target = float(habit.graduation_target) if habit.graduation_target is not None else defaults[1]
+    threshold = (
+        habit.graduation_threshold if habit.graduation_threshold is not None else defaults[2]
+    )
+    return (window, target, threshold)

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -1,0 +1,432 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for graduation evaluation service, defaults resolution, and schema additions."""
+
+import uuid
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+from app.models import Habit, NotificationQueue
+from app.services.graduation import (
+    GraduationResult,
+    apply_re_scaffold_tightening,
+    evaluate_graduation,
+)
+from app.services.graduation_defaults import resolve_graduation_params
+from tests.conftest import make_habit
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_habit(db, **overrides) -> Habit:
+    """Insert a Habit directly via ORM.
+
+    Fields with model-level defaults (graduation_window, graduation_target,
+    graduation_threshold) need a two-phase approach when the caller wants
+    them NULL — SQLAlchemy 2.0's column defaults override None at init time.
+    """
+    # Fields that have model-level Python defaults and need explicit nulling
+    nullable_grad_fields = ("graduation_window", "graduation_target", "graduation_threshold")
+    force_null = {k for k in nullable_grad_fields if k in overrides and overrides[k] is None}
+
+    constructor_overrides = {
+        k: v for k, v in overrides.items() if k not in force_null
+    }
+
+    defaults = {
+        "id": uuid.uuid4(),
+        "title": "Test Habit",
+        "status": "active",
+        "frequency": "daily",
+        "notification_frequency": "daily",
+        "scaffolding_status": "accountable",
+        "introduced_at": date.today() - timedelta(days=60),
+    }
+    defaults.update(constructor_overrides)
+    habit = Habit(**defaults)
+    db.add(habit)
+    db.commit()
+
+    # Phase 2: force-null graduation fields via UPDATE
+    if force_null:
+        for field in force_null:
+            setattr(habit, field, None)
+        db.commit()
+
+    db.refresh(habit)
+    return habit
+
+
+def _create_notification(db, habit_id: uuid.UUID, response: str | None,
+                         status: str, days_ago: int = 5) -> NotificationQueue:
+    """Insert a notification_queue entry for a habit."""
+    n = NotificationQueue(
+        id=uuid.uuid4(),
+        notification_type="habit_nudge",
+        delivery_type="notification",
+        status=status,
+        scheduled_at=datetime.now(tz=UTC) - timedelta(days=days_ago),
+        target_entity_type="habit",
+        target_entity_id=habit_id,
+        message="Time for your habit!",
+        response=response,
+        scheduled_by="system",
+    )
+    db.add(n)
+    db.commit()
+    return n
+
+
+# ===========================================================================
+# resolve_graduation_params
+# ===========================================================================
+
+
+class TestResolveGraduationParams:
+
+    def test_all_defaults_friction_none(self, db):
+        """Habit with no overrides and no friction_score gets middle-tier defaults."""
+        habit = _create_habit(db, graduation_window=None, graduation_target=None,
+                              graduation_threshold=None, friction_score=None)
+        window, target, threshold = resolve_graduation_params(habit)
+        assert (window, target, threshold) == (45, 0.85, 45)
+
+    def test_friction_1_defaults(self, db):
+        habit = _create_habit(db, friction_score=1, graduation_window=None,
+                              graduation_target=None, graduation_threshold=None)
+        window, target, threshold = resolve_graduation_params(habit)
+        assert (window, target, threshold) == (30, 0.85, 30)
+
+    def test_friction_5_defaults(self, db):
+        habit = _create_habit(db, friction_score=5, graduation_window=None,
+                              graduation_target=None, graduation_threshold=None)
+        window, target, threshold = resolve_graduation_params(habit)
+        assert (window, target, threshold) == (60, 0.80, 60)
+
+    def test_per_habit_overrides(self, db):
+        """Per-habit values take precedence over friction defaults."""
+        habit = _create_habit(db, friction_score=1, graduation_window=90,
+                              graduation_target=0.70, graduation_threshold=90)
+        window, target, threshold = resolve_graduation_params(habit)
+        assert window == 90
+        assert target == 0.70
+        assert threshold == 90
+
+    def test_partial_override(self, db):
+        """One override, rest from friction tier."""
+        habit = _create_habit(db, friction_score=4, graduation_window=100,
+                              graduation_target=None, graduation_threshold=None)
+        window, target, threshold = resolve_graduation_params(habit)
+        assert window == 100
+        assert target == 0.80  # friction-4 default
+        assert threshold == 60  # friction-4 default
+
+
+# ===========================================================================
+# apply_re_scaffold_tightening
+# ===========================================================================
+
+
+class TestReScaffoldTightening:
+
+    def test_no_tightening(self):
+        w, t, th = apply_re_scaffold_tightening(30, 0.85, 30, 0)
+        assert (w, t, th) == (30, 0.85, 30)
+
+    def test_single_re_scaffold(self):
+        w, t, th = apply_re_scaffold_tightening(30, 0.85, 30, 1)
+        assert w == 37   # int(30 * 1.25)
+        assert t == 0.90  # 0.85 + 0.05
+        assert th == 37  # int(30 * 1.25)
+
+    def test_double_re_scaffold(self):
+        w, t, th = apply_re_scaffold_tightening(30, 0.85, 30, 2)
+        # First pass: 37, 0.90, 37
+        # Second pass: int(37 * 1.25) = 46, min(0.95, 0.95) = 0.95, 46
+        assert w == 46
+        assert t == 0.95
+        assert th == 46
+
+    def test_target_caps_at_95(self):
+        """Target never exceeds 0.95 even with many re-scaffolds."""
+        w, t, th = apply_re_scaffold_tightening(30, 0.85, 30, 10)
+        assert t == 0.95
+
+    def test_friction_5_double_rescaffold(self):
+        """Higher friction habits tighten more in absolute terms."""
+        w, t, th = apply_re_scaffold_tightening(60, 0.80, 60, 2)
+        # First: 75, 0.85, 75
+        # Second: int(75 * 1.25) = 93, 0.90, 93
+        assert w == 93
+        assert t == pytest.approx(0.90)
+        assert th == 93
+
+
+# ===========================================================================
+# evaluate_graduation
+# ===========================================================================
+
+
+class TestEvaluateGraduation:
+
+    def test_eligible_habit(self, db):
+        """Habit that meets both rate and threshold is eligible."""
+        habit = _create_habit(db, introduced_at=date.today() - timedelta(days=60))
+        # 10 notifications, 9 "Already done" = 90% rate
+        for i in range(9):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+        _create_notification(db, habit.id, "Skip today", "responded", days_ago=10)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert isinstance(result, GraduationResult)
+        assert result.eligible is True
+        assert result.meets_rate is True
+        assert result.meets_threshold is True
+        assert result.total_notifications == 10
+        assert result.already_done_count == 9
+        assert result.current_rate == 0.9
+        assert result.blocking_reasons == []
+
+    def test_ineligible_rate_too_low(self, db):
+        """Habit with rate below target is not eligible."""
+        habit = _create_habit(db, introduced_at=date.today() - timedelta(days=60))
+        # 10 notifications, 5 "Already done" = 50%
+        for i in range(5):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+        for i in range(5):
+            _create_notification(db, habit.id, "Skip today", "responded", days_ago=i + 6)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.eligible is False
+        assert result.meets_rate is False
+        assert result.meets_threshold is True
+        assert any("below target" in r for r in result.blocking_reasons)
+
+    def test_ineligible_not_enough_time(self, db):
+        """Habit introduced recently (below threshold) is not eligible."""
+        habit = _create_habit(db, introduced_at=date.today() - timedelta(days=10))
+        for i in range(10):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.eligible is False
+        assert result.meets_rate is True
+        assert result.meets_threshold is False
+        assert any("days since introduction" in r for r in result.blocking_reasons)
+
+    def test_ineligible_no_notification_data(self, db):
+        """Habit with no notifications in window is not eligible."""
+        habit = _create_habit(db, introduced_at=date.today() - timedelta(days=60))
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.eligible is False
+        assert result.total_notifications == 0
+        assert any("No notification data" in r for r in result.blocking_reasons)
+
+    def test_wrong_scaffolding_status_tracking(self, db):
+        """Habit in 'tracking' status cannot be evaluated."""
+        habit = _create_habit(db, scaffolding_status="tracking")
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.eligible is False
+        assert any("accountable" in r for r in result.blocking_reasons)
+
+    def test_wrong_scaffolding_status_graduated(self, db):
+        """Already graduated habits cannot be re-evaluated."""
+        habit = _create_habit(db, scaffolding_status="graduated")
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.eligible is False
+        assert any("accountable" in r for r in result.blocking_reasons)
+
+    def test_re_scaffold_tightens_criteria(self, db):
+        """Habit with re_scaffold_count > 0 has tightened criteria."""
+        habit = _create_habit(
+            db,
+            introduced_at=date.today() - timedelta(days=60),
+            re_scaffold_count=1,
+            friction_score=1,
+            graduation_window=None,
+            graduation_target=None,
+            graduation_threshold=None,
+        )
+        # Friction-1 defaults: (30, 0.85, 30) → tightened: (37, 0.90, 37)
+        # 10 notifications, 9 "Already done" = 90% — exactly meets tightened target
+        for i in range(9):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+        _create_notification(db, habit.id, "Doing it now", "responded", days_ago=10)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.target_rate == 0.90
+        assert result.window_days == 37
+        assert result.threshold_days == 37
+        assert result.eligible is True
+
+    def test_re_scaffold_makes_previously_eligible_ineligible(self, db):
+        """Same data that passes without re-scaffold fails with re_scaffold_count=1."""
+        habit = _create_habit(
+            db,
+            introduced_at=date.today() - timedelta(days=60),
+            re_scaffold_count=1,
+            friction_score=1,
+            graduation_window=None,
+            graduation_target=None,
+            graduation_threshold=None,
+        )
+        # 10 notifications, 8 "Already done" = 80% — would pass 0.85 normally...
+        # but tightened target is 0.90
+        for i in range(8):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+        for i in range(2):
+            _create_notification(db, habit.id, "Skip today", "responded", days_ago=i + 9)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.target_rate == 0.90
+        assert result.eligible is False
+        assert result.meets_rate is False
+
+    def test_expired_notifications_counted(self, db):
+        """Expired (unanswered) notifications are included in total count."""
+        habit = _create_habit(db, introduced_at=date.today() - timedelta(days=60))
+        for i in range(8):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+        # 2 expired notifications (no response)
+        for i in range(2):
+            _create_notification(db, habit.id, None, "expired", days_ago=i + 9)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.total_notifications == 10
+        assert result.already_done_count == 8
+        assert result.current_rate == 0.8
+
+    def test_pending_notifications_excluded(self, db):
+        """Pending/delivered notifications are NOT included in evaluation."""
+        habit = _create_habit(db, introduced_at=date.today() - timedelta(days=60))
+        for i in range(10):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+        # These should be excluded
+        _create_notification(db, habit.id, None, "pending", days_ago=1)
+        _create_notification(db, habit.id, None, "delivered", days_ago=1)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.total_notifications == 10  # only responded/expired
+
+    def test_notifications_outside_window_excluded(self, db):
+        """Notifications older than the window are not counted."""
+        habit = _create_habit(
+            db,
+            introduced_at=date.today() - timedelta(days=120),
+            friction_score=1,  # 30-day window
+            graduation_window=None,
+            graduation_target=None,
+            graduation_threshold=None,
+        )
+        # 5 recent "Already done" (within 30-day window)
+        for i in range(5):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+        # 5 old ones (outside window)
+        for i in range(5):
+            _create_notification(db, habit.id, "Skip today", "responded", days_ago=35 + i)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.total_notifications == 5
+        assert result.already_done_count == 5
+        assert result.current_rate == 1.0
+
+    def test_nonexistent_habit_raises(self, db):
+        """Evaluating a nonexistent habit raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            evaluate_graduation(db, uuid.uuid4())
+
+    def test_habit_with_no_introduced_at(self, db):
+        """Habit with no introduced_at gets 0 days_since_introduction."""
+        habit = _create_habit(db, introduced_at=None)
+        for i in range(10):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.days_since_introduction == 0
+        assert result.meets_threshold is False
+
+
+# ===========================================================================
+# Schema validation — friction_score on create/update
+# ===========================================================================
+
+
+class TestFrictionScoreValidation:
+
+    def test_create_with_valid_friction_score(self, client):
+        resp = client.post("/api/habits", json={
+            "title": "Test", "frequency": "daily", "friction_score": 3,
+        })
+        assert resp.status_code == 201
+        assert resp.json()["friction_score"] == 3
+
+    def test_create_with_null_friction_score(self, client):
+        resp = client.post("/api/habits", json={
+            "title": "Test", "frequency": "daily",
+        })
+        assert resp.status_code == 201
+        assert resp.json()["friction_score"] is None
+
+    def test_create_friction_score_too_low(self, client):
+        resp = client.post("/api/habits", json={
+            "title": "Test", "frequency": "daily", "friction_score": 0,
+        })
+        assert resp.status_code == 422
+
+    def test_create_friction_score_too_high(self, client):
+        resp = client.post("/api/habits", json={
+            "title": "Test", "frequency": "daily", "friction_score": 6,
+        })
+        assert resp.status_code == 422
+
+    def test_update_friction_score(self, client):
+        habit = make_habit(client)
+        resp = client.patch(
+            f"/api/habits/{habit['id']}", json={"friction_score": 5},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["friction_score"] == 5
+
+    def test_update_friction_score_invalid(self, client):
+        habit = make_habit(client)
+        resp = client.patch(
+            f"/api/habits/{habit['id']}", json={"friction_score": 10},
+        )
+        assert resp.status_code == 422
+
+    def test_response_includes_new_fields(self, client):
+        """HabitResponse includes re_scaffold_count and last_frequency_changed_at."""
+        habit = make_habit(client)
+        assert habit["re_scaffold_count"] == 0
+        assert habit["last_frequency_changed_at"] is None


### PR DESCRIPTION
## Summary
- Adds the foundation for Stream G graduated scaffolding: core graduation evaluation function, friction-aware defaults, schema additions, and re-scaffold tightening logic
- Three new columns on `habits` table (`friction_score`, `re_scaffold_count`, `last_frequency_changed_at`) via reversible Alembic migration
- Pure evaluation function — returns `GraduationResult` without side effects, enabling dry-run evaluation in downstream tickets

## Changes
- **`alembic/versions/015_add_graduation_columns_to_habits.py`** — Migration adding three columns with check constraint on friction_score (1–5)
- **`app/models.py`** — Habit model updated with friction_score, re_scaffold_count, last_frequency_changed_at columns and check constraint
- **`app/schemas/habits.py`** — friction_score added to HabitCreate/HabitUpdate with 1–5 validation; all three fields added to HabitResponse
- **`app/services/graduation_defaults.py`** — GRADUATION_DEFAULTS lookup table and resolve_graduation_params() with two-layer resolution (per-habit overrides → friction tier defaults)
- **`app/services/graduation.py`** — evaluate_graduation() with rolling-window notification query, apply_re_scaffold_tightening(), and GraduationResult Pydantic schema
- **`tests/test_graduation.py`** — 30 tests covering defaults resolution, re-scaffold tightening, all evaluation paths (eligible, rate too low, not enough time, no data, wrong status, re-scaffold), schema validation, and edge cases

## How to Verify
1. `pip install -r requirements.txt`
2. `alembic upgrade head` (migration 015 applies cleanly)
3. `alembic downgrade -1` / `alembic upgrade head` (reversible)
4. `pytest tests/test_graduation.py -v` — 30 tests pass
5. `pytest tests/ -v` — full suite (1103 tests) passes
6. `POST /api/habits` with `friction_score: 3` → accepted; `friction_score: 0` or `6` → 422
7. `GET /api/habits/{id}` → response includes `re_scaffold_count: 0` and `last_frequency_changed_at: null`

## Deviations
- Spec uses `AsyncSession` — codebase uses synchronous `Session`. Matched existing pattern.
- Spec shows `resolve_graduation_params` using `habit.graduation_window or defaults[0]` — this treats 0 as falsy. Used explicit `is not None` check instead for correctness.

## Test Results
```
tests/test_graduation.py: 30 passed in 0.35s
Full suite: 1103 passed in 16.03s
Ruff: All checks passed
```

## Acceptance Checklist
- [x] Alembic migration adds friction_score, re_scaffold_count, last_frequency_changed_at to habits table
- [x] Migration is reversible (downgrade removes columns)
- [x] friction_score validates 1–5 on create/update, rejects out-of-range values
- [x] resolve_graduation_params() returns per-habit overrides when set, friction defaults when null
- [x] evaluate_graduation() returns correct GraduationResult for all specified scenarios
- [x] Rolling window query correctly filters by notification_type, target_entity, date range, and terminal status
- [x] "Already done" rate calculation handles zero-notification edge case
- [x] All functions have unit tests with fixture-based notification response data
- [x] Existing habit CRUD tests still pass (new columns are optional/defaulted)

Closes #145