### PR TITLE
2G-02: Graduation Execution & Habit Status Transition

### DIFF
--- a/app/services/graduation.py
+++ b/app/services/graduation.py
@@ -14,17 +14,18 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-"""Graduation evaluation service — rolling-window analysis for habit scaffolding."""
+"""Graduation evaluation and execution service for habit scaffolding."""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
+from fastapi import HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from app.models import Habit, NotificationQueue
+from app.models import ActivityLog, Habit, NotificationQueue
 from app.services.graduation_defaults import resolve_graduation_params
 
 
@@ -43,6 +44,17 @@ class GraduationResult(BaseModel):
     meets_rate: bool
     meets_threshold: bool
     blocking_reasons: list[str]
+
+
+class GraduationExecutionResult(BaseModel):
+    """Result of executing a habit graduation."""
+
+    success: bool
+    habit_id: UUID
+    previous_scaffolding_status: str
+    previous_notification_frequency: str
+    evaluation: GraduationResult | None
+    message: str
 
 
 def apply_re_scaffold_tightening(
@@ -173,4 +185,98 @@ def evaluate_graduation(
         meets_rate=meets_rate,
         meets_threshold=meets_threshold,
         blocking_reasons=blocking_reasons,
+    )
+
+
+def graduate_habit(
+    db: Session,
+    habit_id: UUID,
+    force: bool = False,
+) -> GraduationExecutionResult:
+    """Execute the graduation state transition for a habit.
+
+    Moves scaffolding_status from 'accountable' to 'graduated' and sets
+    notification_frequency to 'graduated'. Does NOT change habit.status —
+    the habit remains active and continues appearing in routine checklists.
+    """
+    habit = db.query(Habit).filter(Habit.id == habit_id).first()
+    if habit is None:
+        raise HTTPException(status_code=404, detail="Habit not found")
+
+    # Snapshot previous values for audit trail
+    previous_scaffolding = habit.scaffolding_status
+    previous_frequency = habit.notification_frequency
+
+    # Already graduated — idempotency guard
+    if habit.scaffolding_status == "graduated":
+        return GraduationExecutionResult(
+            success=False,
+            habit_id=habit_id,
+            previous_scaffolding_status=previous_scaffolding,
+            previous_notification_frequency=previous_frequency,
+            evaluation=None,
+            message="Habit is already graduated",
+        )
+
+    # Status must be active
+    if habit.status != "active":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot graduate a habit with status '{habit.status}' — must be 'active'",
+        )
+
+    # Scaffolding must be accountable
+    if habit.scaffolding_status != "accountable":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Cannot graduate from scaffolding_status '{habit.scaffolding_status}' "
+                "— must be 'accountable'"
+            ),
+        )
+
+    # Evaluate eligibility
+    evaluation = evaluate_graduation(db, habit_id)
+
+    if not force and not evaluation.eligible:
+        return GraduationExecutionResult(
+            success=False,
+            habit_id=habit_id,
+            previous_scaffolding_status=previous_scaffolding,
+            previous_notification_frequency=previous_frequency,
+            evaluation=evaluation,
+            message=(
+                "Habit does not meet graduation criteria. "
+                + "; ".join(evaluation.blocking_reasons)
+            ),
+        )
+
+    # Execute transition
+    habit.scaffolding_status = "graduated"
+    habit.notification_frequency = "graduated"
+
+    # Log activity entry
+    forced_label = " (forced)" if force else ""
+    activity = ActivityLog(
+        action_type="completed",
+        notes=(
+            f"Habit graduated{forced_label}: {habit.title}. "
+            f"Rate: {evaluation.current_rate:.0%} over {evaluation.window_days} days. "
+            f"Streak preserved at {habit.best_streak}."
+        ),
+        habit_id=habit_id,
+    )
+    db.add(activity)
+
+    # Atomic commit — transition + activity log in one transaction
+    db.commit()
+    db.refresh(habit)
+
+    return GraduationExecutionResult(
+        success=True,
+        habit_id=habit_id,
+        previous_scaffolding_status=previous_scaffolding,
+        previous_notification_frequency=previous_frequency,
+        evaluation=evaluation,
+        message=f"Habit '{habit.title}' graduated successfully{forced_label}",
     )

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -22,10 +22,13 @@ from datetime import UTC, date, datetime, timedelta
 import pytest
 
 from app.models import Habit, NotificationQueue
+from app.models import ActivityLog
 from app.services.graduation import (
+    GraduationExecutionResult,
     GraduationResult,
     apply_re_scaffold_tightening,
     evaluate_graduation,
+    graduate_habit,
 )
 from app.services.graduation_defaults import resolve_graduation_params
 from tests.conftest import make_habit
@@ -430,3 +433,242 @@ class TestFrictionScoreValidation:
         habit = make_habit(client)
         assert habit["re_scaffold_count"] == 0
         assert habit["last_frequency_changed_at"] is None
+
+
+# ===========================================================================
+# graduate_habit — execution & state transition
+# ===========================================================================
+
+
+class TestGraduateHabit:
+    """Tests for the graduate_habit() service function ([2G-02])."""
+
+    def _eligible_habit(self, db, **overrides) -> Habit:
+        """Create a habit that meets graduation criteria."""
+        defaults = {
+            "introduced_at": date.today() - timedelta(days=60),
+            "scaffolding_status": "accountable",
+            "notification_frequency": "daily",
+            "status": "active",
+        }
+        defaults.update(overrides)
+        habit = _create_habit(db, **defaults)
+        # 10 notifications, 9 "Already done" = 90% rate
+        for i in range(9):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+        _create_notification(db, habit.id, "Skip today", "responded", days_ago=10)
+        return habit
+
+    def _ineligible_habit(self, db, **overrides) -> Habit:
+        """Create a habit that does NOT meet graduation criteria (low rate)."""
+        defaults = {
+            "introduced_at": date.today() - timedelta(days=60),
+            "scaffolding_status": "accountable",
+            "notification_frequency": "daily",
+            "status": "active",
+        }
+        defaults.update(overrides)
+        habit = _create_habit(db, **defaults)
+        # 10 notifications, 3 "Already done" = 30% rate
+        for i in range(3):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+        for i in range(7):
+            _create_notification(db, habit.id, "Skip today", "responded", days_ago=i + 4)
+        return habit
+
+    # --- Successful graduation ---
+
+    def test_successful_graduation(self, db):
+        """Eligible habit transitions scaffolding_status and notification_frequency."""
+        habit = self._eligible_habit(db)
+        original_best_streak = habit.best_streak
+        original_last_completed = habit.last_completed
+
+        result = graduate_habit(db, habit.id)
+
+        assert isinstance(result, GraduationExecutionResult)
+        assert result.success is True
+        assert result.previous_scaffolding_status == "accountable"
+        assert result.previous_notification_frequency == "daily"
+        assert result.evaluation is not None
+        assert result.evaluation.eligible is True
+        assert "graduated successfully" in result.message
+
+        db.refresh(habit)
+        assert habit.scaffolding_status == "graduated"
+        assert habit.notification_frequency == "graduated"
+        assert habit.status == "active"
+        assert habit.best_streak == original_best_streak
+        assert habit.last_completed == original_last_completed
+
+    def test_graduation_preserves_active_status(self, db):
+        """habit.status remains 'active' after graduation."""
+        habit = self._eligible_habit(db)
+        graduate_habit(db, habit.id)
+        db.refresh(habit)
+        assert habit.status == "active"
+
+    def test_graduation_preserves_streak_history(self, db):
+        """best_streak and last_completed are unchanged after graduation."""
+        habit = self._eligible_habit(
+            db, best_streak=15, last_completed=date.today() - timedelta(days=1),
+        )
+        # Force the values in since _create_habit defaults may not set them
+        habit.best_streak = 15
+        habit.last_completed = date.today() - timedelta(days=1)
+        db.commit()
+        db.refresh(habit)
+
+        graduate_habit(db, habit.id)
+        db.refresh(habit)
+
+        assert habit.best_streak == 15
+        assert habit.last_completed == date.today() - timedelta(days=1)
+
+    # --- Forced graduation ---
+
+    def test_forced_graduation_bypasses_eligibility(self, db):
+        """force=True graduates even when evaluation says ineligible."""
+        habit = self._ineligible_habit(db)
+
+        result = graduate_habit(db, habit.id, force=True)
+
+        assert result.success is True
+        assert result.evaluation is not None
+        assert result.evaluation.eligible is False
+        assert "(forced)" in result.message
+
+        db.refresh(habit)
+        assert habit.scaffolding_status == "graduated"
+        assert habit.notification_frequency == "graduated"
+
+    def test_forced_graduation_activity_log_label(self, db):
+        """Forced graduation activity log entry includes '(forced)' marker."""
+        habit = self._ineligible_habit(db)
+        graduate_habit(db, habit.id, force=True)
+
+        log = (
+            db.query(ActivityLog)
+            .filter(ActivityLog.habit_id == habit.id)
+            .first()
+        )
+        assert log is not None
+        assert "(forced)" in log.notes
+
+    # --- Ineligible habit (force=False) ---
+
+    def test_ineligible_returns_failure(self, db):
+        """Ineligible habit with force=False returns success=False."""
+        habit = self._ineligible_habit(db)
+
+        result = graduate_habit(db, habit.id, force=False)
+
+        assert result.success is False
+        assert result.evaluation is not None
+        assert result.evaluation.eligible is False
+        assert len(result.evaluation.blocking_reasons) > 0
+
+        db.refresh(habit)
+        assert habit.scaffolding_status == "accountable"
+        assert habit.notification_frequency == "daily"
+
+    # --- Wrong status ---
+
+    def test_paused_habit_rejected(self, db):
+        """Cannot graduate a paused habit."""
+        habit = _create_habit(
+            db, status="paused", scaffolding_status="accountable",
+            notification_frequency="daily",
+        )
+        with pytest.raises(Exception) as exc_info:
+            graduate_habit(db, habit.id)
+        assert exc_info.value.status_code == 400
+        assert "paused" in exc_info.value.detail
+
+    def test_abandoned_habit_rejected(self, db):
+        """Cannot graduate an abandoned habit."""
+        habit = _create_habit(
+            db, status="abandoned", scaffolding_status="accountable",
+            notification_frequency="daily",
+        )
+        with pytest.raises(Exception) as exc_info:
+            graduate_habit(db, habit.id)
+        assert exc_info.value.status_code == 400
+        assert "abandoned" in exc_info.value.detail
+
+    # --- Wrong scaffolding_status ---
+
+    def test_tracking_scaffolding_rejected(self, db):
+        """Cannot graduate from 'tracking' scaffolding_status."""
+        habit = _create_habit(
+            db, scaffolding_status="tracking", notification_frequency="daily",
+        )
+        with pytest.raises(Exception) as exc_info:
+            graduate_habit(db, habit.id)
+        assert exc_info.value.status_code == 400
+        assert "tracking" in exc_info.value.detail
+
+    # --- Already graduated ---
+
+    def test_already_graduated_returns_failure(self, db):
+        """Already graduated habit returns success=False (not an exception)."""
+        habit = _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+        )
+
+        result = graduate_habit(db, habit.id)
+
+        assert result.success is False
+        assert result.message == "Habit is already graduated"
+        assert result.evaluation is None
+
+    # --- Nonexistent habit ---
+
+    def test_nonexistent_habit_404(self, db):
+        """Nonexistent habit_id raises 404."""
+        with pytest.raises(Exception) as exc_info:
+            graduate_habit(db, uuid.uuid4())
+        assert exc_info.value.status_code == 404
+
+    # --- Activity log ---
+
+    def test_activity_log_created_on_success(self, db):
+        """Successful graduation creates an activity log entry."""
+        habit = self._eligible_habit(db)
+        graduate_habit(db, habit.id)
+
+        log = (
+            db.query(ActivityLog)
+            .filter(ActivityLog.habit_id == habit.id)
+            .first()
+        )
+        assert log is not None
+        assert log.action_type == "completed"
+        assert habit.title in log.notes
+        assert "graduated" in log.notes.lower()
+        assert "Rate:" in log.notes
+        assert "Streak preserved" in log.notes
+
+    def test_no_activity_log_on_failure(self, db):
+        """Failed graduation does NOT create an activity log entry."""
+        habit = self._ineligible_habit(db)
+        graduate_habit(db, habit.id, force=False)
+
+        log_count = (
+            db.query(ActivityLog)
+            .filter(ActivityLog.habit_id == habit.id)
+            .count()
+        )
+        assert log_count == 0
+
+    def test_evaluated_graduation_no_forced_label(self, db):
+        """Normal (non-forced) graduation does NOT include '(forced)' in activity log."""
+        habit = self._eligible_habit(db)
+        graduate_habit(db, habit.id)
+
+        log = (
+            db.query(ActivityLog)
+            .filter(ActivityLog.habit_id == habit.id)
+            .first()
+        )
+        assert "(forced)" not in log.notes

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -21,8 +21,7 @@ from datetime import UTC, date, datetime, timedelta
 
 import pytest
 
-from app.models import Habit, NotificationQueue
-from app.models import ActivityLog
+from app.models import ActivityLog, Habit, NotificationQueue
 from app.services.graduation import (
     GraduationExecutionResult,
     GraduationResult,


### PR DESCRIPTION
## Summary
Implements `graduate_habit()` — the write side of graduation that transitions a habit's `scaffolding_status` from `accountable` to `graduated` and sets `notification_frequency` to `graduated`. Includes a `force` flag for qualitative overrides (Claude-recommended graduations that don't meet the math), activity log integration to record graduation events, and the `GraduationExecutionResult` schema for structured return values.

## Changes
- **app/services/graduation.py** — Added `GraduationExecutionResult` schema and `graduate_habit()` service function. The function validates pre-conditions (404 for missing habit, 400 for wrong status/scaffolding_status, success=False for already graduated), runs `evaluate_graduation()` for eligibility check, executes the atomic state transition, and logs an activity entry distinguishing forced vs evaluated graduations.
- **tests/test_graduation.py** — Added `TestGraduateHabit` class with 14 tests covering: successful graduation, status/streak preservation, forced graduation bypassing eligibility, forced activity log labeling, ineligible habit failure, paused/abandoned habit rejection, wrong scaffolding_status rejection, already-graduated idempotency, nonexistent habit 404, activity log creation on success, no activity log on failure, and non-forced log label verification.

## How to Verify
1. `git checkout feature/2G-02-graduation-execution`
2. `pytest tests/test_graduation.py -v` — all 44 tests pass (30 from 2G-01 + 14 new)
3. Full suite: `pytest -v` — 1117 passed, 0 failures

## Deviations
- **Sync Session instead of AsyncSession:** Spec says `AsyncSession` but the entire codebase uses synchronous SQLAlchemy (`Session`, `db.query()`). Matched existing patterns.
- **No standalone `log_activity()` helper:** Spec references `log_activity()` from Stream A [A-8], but no such function exists — activity logging is done via the API router. Created `ActivityLog` ORM instance directly in the service function instead, which is consistent with how the service layer operates (direct ORM, not going through HTTP).
- **`habit.title` vs `habit.name`:** Spec uses `habit.name` in the activity log template but the model field is `habit.title`. Used `habit.title`.

## Test Results
```
44 passed in 0.54s (graduation tests)
1117 passed in 15.43s (full suite)
```

## Acceptance Checklist
- [x] `graduate_habit()` transitions `scaffolding_status` from `accountable` to `graduated`
- [x] `graduate_habit()` transitions `notification_frequency` to `graduated`
- [x] `habit.status` remains `active` after graduation
- [x] `habit.best_streak` and `habit.last_completed` are preserved unchanged
- [x] Returns success=False with evaluation details when habit doesn't meet criteria and force=False
- [x] Returns success=True with forced graduation when force=True, even if evaluation fails
- [x] Rejects graduation for habits with status != active (paused, abandoned)
- [x] Rejects graduation for habits with scaffolding_status != accountable
- [x] Returns appropriate error for already-graduated habits
- [x] Activity log entry created on successful graduation
- [x] Activity log entry distinguishes forced vs evaluated graduation
- [x] 404 for non-existent habit_id
- [x] All state transitions are atomic (single DB commit)
- [x] Tests cover: successful graduation, forced graduation, ineligible habit, wrong status, wrong scaffolding_status, already graduated, nonexistent habit