### PR TITLE
2G-03: Frequency step-down evaluation and execution

### DIFF
--- a/app/routers/habits.py
+++ b/app/routers/habits.py
@@ -16,7 +16,7 @@
 
 """CRUD endpoints for Habits."""
 
-from datetime import date
+from datetime import UTC, date, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -114,6 +114,14 @@ def update_habit(
         )
         if not routine:
             raise HTTPException(status_code=400, detail="Routine not found")
+
+    # [2G-03] Manual override hook: if notification_frequency is changing,
+    # reset the cooldown timer so step-down evaluation respects the change.
+    if (
+        "notification_frequency" in updates
+        and updates["notification_frequency"] != habit.notification_frequency
+    ):
+        updates["last_frequency_changed_at"] = datetime.now(tz=UTC)
 
     for field, value in updates.items():
         setattr(habit, field, value)

--- a/app/services/graduation.py
+++ b/app/services/graduation.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-"""Graduation evaluation and execution service for habit scaffolding."""
+"""Graduation evaluation, execution, and frequency step-down service for habit scaffolding."""
 
 from __future__ import annotations
 
@@ -279,4 +279,261 @@ def graduate_habit(
         previous_notification_frequency=previous_frequency,
         evaluation=evaluation,
         message=f"Habit '{habit.title}' graduated successfully{forced_label}",
+    )
+
+
+# ===========================================================================
+# [2G-03] Frequency Step-Down
+# ===========================================================================
+
+# Step-down progression — terminal states (graduated, none) are excluded.
+FREQUENCY_ORDER = [
+    "daily",
+    "every_other_day",
+    "twice_week",
+    "weekly",
+]
+
+# Evaluation constants — kept as module-level for easy adjustment.
+STEP_DOWN_NOTIFICATION_LIMIT = 14
+STEP_DOWN_MIN_NOTIFICATIONS = 5
+STEP_DOWN_RATE_THRESHOLD = 0.60
+STEP_DOWN_COOLDOWN_DAYS = 7
+
+
+def next_step_down(current: str) -> str | None:
+    """Return the next lower frequency, or None if already at weekly."""
+    try:
+        idx = FREQUENCY_ORDER.index(current)
+        if idx + 1 < len(FREQUENCY_ORDER):
+            return FREQUENCY_ORDER[idx + 1]
+    except ValueError:
+        pass
+    return None
+
+
+class FrequencyStepResult(BaseModel):
+    """Result of evaluating a habit's frequency step-down eligibility."""
+
+    recommend_step_down: bool
+    habit_id: UUID
+    current_frequency: str
+    recommended_frequency: str | None
+    current_rate: float
+    notifications_evaluated: int
+    cooldown_active: bool
+    cooldown_expires_at: datetime | None
+    blocking_reasons: list[str]
+
+
+class FrequencyChangeResult(BaseModel):
+    """Result of applying a frequency step-down."""
+
+    success: bool
+    habit_id: UUID
+    previous_frequency: str
+    new_frequency: str
+    message: str
+
+
+def evaluate_frequency_step_down(
+    db: Session,
+    habit_id: UUID,
+) -> FrequencyStepResult:
+    """Evaluate whether a habit should step down to a lower notification frequency.
+
+    Uses the N most recent notifications (LIMIT-based, not date-based) and a
+    60% "already done" threshold. Respects a 7-day cooldown after any frequency change.
+    """
+    habit = db.query(Habit).filter(Habit.id == habit_id).first()
+    if habit is None:
+        raise ValueError(f"Habit {habit_id} not found")
+
+    now = datetime.now(tz=UTC)
+
+    # Helper to build a no-recommendation result
+    def _no_recommendation(
+        *,
+        reasons: list[str],
+        rate: float = 0.0,
+        evaluated: int = 0,
+        cooldown: bool = False,
+        cooldown_expires: datetime | None = None,
+    ) -> FrequencyStepResult:
+        return FrequencyStepResult(
+            recommend_step_down=False,
+            habit_id=habit_id,
+            current_frequency=habit.notification_frequency,
+            recommended_frequency=None,
+            current_rate=rate,
+            notifications_evaluated=evaluated,
+            cooldown_active=cooldown,
+            cooldown_expires_at=cooldown_expires,
+            blocking_reasons=reasons,
+        )
+
+    # Gate: must be active + accountable
+    if habit.status != "active" or habit.scaffolding_status != "accountable":
+        return _no_recommendation(
+            reasons=["Habit must be active with scaffolding_status 'accountable'"],
+        )
+
+    # Gate: current frequency must be in the step-down progression
+    if habit.notification_frequency not in FREQUENCY_ORDER:
+        return _no_recommendation(
+            reasons=[
+                f"Frequency '{habit.notification_frequency}' is not in the "
+                "step-down progression"
+            ],
+        )
+
+    # Cooldown check
+    if habit.last_frequency_changed_at is not None:
+        last_changed = habit.last_frequency_changed_at
+        # SQLite returns naive datetimes — normalize to UTC-aware for comparison
+        if last_changed.tzinfo is None:
+            last_changed = last_changed.replace(tzinfo=UTC)
+        cooldown_expires = last_changed + timedelta(
+            days=STEP_DOWN_COOLDOWN_DAYS,
+        )
+        if now < cooldown_expires:
+            return _no_recommendation(
+                cooldown=True,
+                cooldown_expires=cooldown_expires,
+                reasons=[
+                    f"Cooldown active — last frequency change was "
+                    f"{(now - last_changed).days} days ago, "
+                    f"need {STEP_DOWN_COOLDOWN_DAYS}"
+                ],
+            )
+
+    # Query most recent N notifications
+    notifications = (
+        db.query(NotificationQueue)
+        .filter(
+            NotificationQueue.target_entity_type == "habit",
+            NotificationQueue.target_entity_id == habit_id,
+            NotificationQueue.notification_type == "habit_nudge",
+            NotificationQueue.status.in_(["responded", "expired"]),
+        )
+        .order_by(NotificationQueue.scheduled_at.desc())
+        .limit(STEP_DOWN_NOTIFICATION_LIMIT)
+        .all()
+    )
+
+    total = len(notifications)
+
+    # Minimum data check
+    if total < STEP_DOWN_MIN_NOTIFICATIONS:
+        return _no_recommendation(
+            evaluated=total,
+            reasons=[
+                f"Need at least {STEP_DOWN_MIN_NOTIFICATIONS} notifications "
+                f"to evaluate step-down (have {total})"
+            ],
+        )
+
+    # Compute "already done" rate
+    already_done_count = sum(
+        1 for n in notifications if n.response == "Already done"
+    )
+    rate = already_done_count / total
+
+    # Check if already at minimum stepped frequency
+    recommended = next_step_down(habit.notification_frequency)
+    if recommended is None:
+        return _no_recommendation(
+            rate=rate,
+            evaluated=total,
+            reasons=[
+                "Already at minimum stepped frequency (weekly). "
+                "Full graduation evaluated separately."
+            ],
+        )
+
+    # Threshold check
+    if rate < STEP_DOWN_RATE_THRESHOLD:
+        return _no_recommendation(
+            rate=rate,
+            evaluated=total,
+            reasons=[
+                f"Rate {rate:.0%} below step-down threshold "
+                f"{STEP_DOWN_RATE_THRESHOLD:.0%}"
+            ],
+        )
+
+    return FrequencyStepResult(
+        recommend_step_down=True,
+        habit_id=habit_id,
+        current_frequency=habit.notification_frequency,
+        recommended_frequency=recommended,
+        current_rate=rate,
+        notifications_evaluated=total,
+        cooldown_active=False,
+        cooldown_expires_at=None,
+        blocking_reasons=[],
+    )
+
+
+def apply_frequency_step_down(
+    db: Session,
+    habit_id: UUID,
+    new_frequency: str,
+) -> FrequencyChangeResult:
+    """Apply a one-level frequency step-down to a habit.
+
+    Validates that new_frequency is exactly one step below the current frequency.
+    Rejects skipping levels, going backwards, or invalid frequencies.
+    """
+    habit = db.query(Habit).filter(Habit.id == habit_id).first()
+    if habit is None:
+        raise HTTPException(status_code=404, detail="Habit not found")
+
+    previous = habit.notification_frequency
+
+    # Validate: new_frequency must be exactly one step below current
+    expected_next = next_step_down(previous)
+    if expected_next is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Cannot step down from '{previous}' — "
+                "not in the step-down progression or already at minimum"
+            ),
+        )
+    if new_frequency != expected_next:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid step-down: '{previous}' → '{new_frequency}'. "
+                f"Expected exactly one level: '{previous}' → '{expected_next}'"
+            ),
+        )
+
+    # Apply the change
+    habit.notification_frequency = new_frequency
+    habit.last_frequency_changed_at = datetime.now(tz=UTC)
+
+    # Log activity
+    activity = ActivityLog(
+        action_type="completed",
+        notes=(
+            f"Notification frequency stepped down: {habit.title}. "
+            f"{previous} → {new_frequency}."
+        ),
+        habit_id=habit_id,
+    )
+    db.add(activity)
+    db.commit()
+    db.refresh(habit)
+
+    return FrequencyChangeResult(
+        success=True,
+        habit_id=habit_id,
+        previous_frequency=previous,
+        new_frequency=new_frequency,
+        message=(
+            f"Frequency stepped down for '{habit.title}': "
+            f"{previous} → {new_frequency}"
+        ),
     )

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -23,11 +23,17 @@ import pytest
 
 from app.models import ActivityLog, Habit, NotificationQueue
 from app.services.graduation import (
+    FREQUENCY_ORDER,
+    FrequencyChangeResult,
+    FrequencyStepResult,
     GraduationExecutionResult,
     GraduationResult,
+    apply_frequency_step_down,
     apply_re_scaffold_tightening,
+    evaluate_frequency_step_down,
     evaluate_graduation,
     graduate_habit,
+    next_step_down,
 )
 from app.services.graduation_defaults import resolve_graduation_params
 from tests.conftest import make_habit
@@ -671,3 +677,462 @@ class TestGraduateHabit:
             .first()
         )
         assert "(forced)" not in log.notes
+
+
+# ===========================================================================
+# [2G-03] next_step_down
+# ===========================================================================
+
+
+class TestNextStepDown:
+
+    def test_daily_to_every_other_day(self):
+        assert next_step_down("daily") == "every_other_day"
+
+    def test_every_other_day_to_twice_week(self):
+        assert next_step_down("every_other_day") == "twice_week"
+
+    def test_twice_week_to_weekly(self):
+        assert next_step_down("twice_week") == "weekly"
+
+    def test_weekly_returns_none(self):
+        assert next_step_down("weekly") is None
+
+    def test_graduated_returns_none(self):
+        assert next_step_down("graduated") is None
+
+    def test_none_returns_none(self):
+        assert next_step_down("none") is None
+
+    def test_unknown_returns_none(self):
+        assert next_step_down("bogus") is None
+
+
+# ===========================================================================
+# [2G-03] evaluate_frequency_step_down
+# ===========================================================================
+
+
+class TestEvaluateFrequencyStepDown:
+
+    def _habit_with_notifications(
+        self, db, *, notification_frequency="daily", already_done=10,
+        other_response=4, status="active", scaffolding_status="accountable",
+        last_frequency_changed_at=None, **habit_overrides,
+    ) -> Habit:
+        """Create a habit with a mix of notification responses."""
+        habit = _create_habit(
+            db,
+            notification_frequency=notification_frequency,
+            status=status,
+            scaffolding_status=scaffolding_status,
+            last_frequency_changed_at=last_frequency_changed_at,
+            **habit_overrides,
+        )
+        for i in range(already_done):
+            _create_notification(
+                db, habit.id, "Already done", "responded", days_ago=i + 1,
+            )
+        for i in range(other_response):
+            _create_notification(
+                db, habit.id, "Skip today", "responded",
+                days_ago=already_done + i + 1,
+            )
+        return habit
+
+    # --- Recommends step-down ---
+
+    def test_daily_step_down_recommended(self, db):
+        """Daily habit with >= 60% already-done rate recommends every_other_day."""
+        habit = self._habit_with_notifications(
+            db, notification_frequency="daily", already_done=9, other_response=5,
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert isinstance(result, FrequencyStepResult)
+        assert result.recommend_step_down is True
+        assert result.current_frequency == "daily"
+        assert result.recommended_frequency == "every_other_day"
+        assert result.current_rate == pytest.approx(9 / 14)
+        assert result.notifications_evaluated == 14
+        assert result.cooldown_active is False
+        assert result.blocking_reasons == []
+
+    def test_every_other_day_step_down(self, db):
+        """every_other_day → twice_week when rate meets threshold."""
+        habit = self._habit_with_notifications(
+            db, notification_frequency="every_other_day",
+            already_done=10, other_response=4,
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is True
+        assert result.recommended_frequency == "twice_week"
+
+    def test_twice_week_step_down(self, db):
+        """twice_week → weekly when rate meets threshold."""
+        habit = self._habit_with_notifications(
+            db, notification_frequency="twice_week",
+            already_done=10, other_response=4,
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is True
+        assert result.recommended_frequency == "weekly"
+
+    def test_exact_threshold_recommends(self, db):
+        """Exactly 60% rate still recommends step-down."""
+        # 6 out of 10 = 60%
+        habit = self._habit_with_notifications(
+            db, notification_frequency="daily",
+            already_done=6, other_response=4,
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is True
+        assert result.current_rate == pytest.approx(0.6)
+
+    # --- No recommendation ---
+
+    def test_weekly_no_step_down(self, db):
+        """Weekly habit cannot step down further — graduation is separate."""
+        habit = self._habit_with_notifications(
+            db, notification_frequency="weekly",
+            already_done=14, other_response=0,
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is False
+        assert result.recommended_frequency is None
+        assert any("minimum stepped frequency" in r for r in result.blocking_reasons)
+
+    def test_graduated_no_step_down(self, db):
+        """Graduated frequency is not in the progression."""
+        habit = self._habit_with_notifications(
+            db, notification_frequency="graduated",
+            already_done=10, other_response=4,
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is False
+        assert any("not in the step-down progression" in r for r in result.blocking_reasons)
+
+    def test_none_frequency_no_step_down(self, db):
+        """'none' frequency is not in the progression."""
+        habit = self._habit_with_notifications(
+            db, notification_frequency="none",
+            already_done=10, other_response=4,
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is False
+
+    def test_rate_below_threshold(self, db):
+        """Rate below 60% does not recommend step-down."""
+        # 5 out of 14 = ~36%
+        habit = self._habit_with_notifications(
+            db, notification_frequency="daily",
+            already_done=5, other_response=9,
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is False
+        assert result.current_rate == pytest.approx(5 / 14)
+        assert any("below step-down threshold" in r for r in result.blocking_reasons)
+
+    def test_insufficient_notifications(self, db):
+        """Fewer than 5 notifications returns no recommendation."""
+        habit = self._habit_with_notifications(
+            db, notification_frequency="daily",
+            already_done=3, other_response=1,
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is False
+        assert result.notifications_evaluated == 4
+        assert any("Need at least 5" in r for r in result.blocking_reasons)
+
+    def test_zero_notifications(self, db):
+        """No notifications at all returns no recommendation."""
+        habit = self._habit_with_notifications(
+            db, notification_frequency="daily",
+            already_done=0, other_response=0,
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is False
+        assert result.notifications_evaluated == 0
+
+    # --- Cooldown ---
+
+    def test_cooldown_active(self, db):
+        """Habit with recent frequency change is in cooldown."""
+        recent = datetime.now(tz=UTC) - timedelta(days=3)
+        habit = self._habit_with_notifications(
+            db, notification_frequency="daily",
+            already_done=14, other_response=0,
+            last_frequency_changed_at=recent,
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is False
+        assert result.cooldown_active is True
+        assert result.cooldown_expires_at is not None
+        assert any("Cooldown active" in r for r in result.blocking_reasons)
+
+    def test_cooldown_expired(self, db):
+        """Habit with frequency change > 7 days ago is past cooldown."""
+        old = datetime.now(tz=UTC) - timedelta(days=10)
+        habit = self._habit_with_notifications(
+            db, notification_frequency="daily",
+            already_done=14, other_response=0,
+            last_frequency_changed_at=old,
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is True
+        assert result.cooldown_active is False
+
+    def test_cooldown_exactly_7_days(self, db):
+        """Frequency change exactly 7 days ago — cooldown has expired."""
+        boundary = datetime.now(tz=UTC) - timedelta(days=7)
+        habit = self._habit_with_notifications(
+            db, notification_frequency="daily",
+            already_done=14, other_response=0,
+            last_frequency_changed_at=boundary,
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is True
+        assert result.cooldown_active is False
+
+    # --- Status gates ---
+
+    def test_paused_habit_rejected(self, db):
+        """Paused habits are not evaluated for step-down."""
+        habit = self._habit_with_notifications(
+            db, notification_frequency="daily",
+            already_done=14, other_response=0,
+            status="paused",
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is False
+        assert any("active" in r for r in result.blocking_reasons)
+
+    def test_tracking_scaffolding_rejected(self, db):
+        """Tracking habits are not evaluated for step-down."""
+        habit = self._habit_with_notifications(
+            db, notification_frequency="daily",
+            already_done=14, other_response=0,
+            scaffolding_status="tracking",
+        )
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.recommend_step_down is False
+
+    def test_nonexistent_habit_raises(self, db):
+        """Evaluating a nonexistent habit raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            evaluate_frequency_step_down(db, uuid.uuid4())
+
+    # --- LIMIT-based query ---
+
+    def test_only_most_recent_14_considered(self, db):
+        """Only the 14 most recent notifications are evaluated."""
+        habit = _create_habit(db, notification_frequency="daily")
+        # 14 recent "Already done"
+        for i in range(14):
+            _create_notification(
+                db, habit.id, "Already done", "responded", days_ago=i + 1,
+            )
+        # 10 older "Skip today" — should be excluded by LIMIT
+        for i in range(10):
+            _create_notification(
+                db, habit.id, "Skip today", "responded", days_ago=20 + i,
+            )
+
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.notifications_evaluated == 14
+        assert result.current_rate == 1.0
+        assert result.recommend_step_down is True
+
+    def test_pending_excluded(self, db):
+        """Pending notifications are not counted."""
+        habit = _create_habit(db, notification_frequency="daily")
+        for i in range(10):
+            _create_notification(
+                db, habit.id, "Already done", "responded", days_ago=i + 1,
+            )
+        _create_notification(db, habit.id, None, "pending", days_ago=1)
+        _create_notification(db, habit.id, None, "delivered", days_ago=1)
+
+        result = evaluate_frequency_step_down(db, habit.id)
+
+        assert result.notifications_evaluated == 10
+
+
+# ===========================================================================
+# [2G-03] apply_frequency_step_down
+# ===========================================================================
+
+
+class TestApplyFrequencyStepDown:
+
+    def _accountable_habit(self, db, notification_frequency="daily") -> Habit:
+        return _create_habit(
+            db,
+            notification_frequency=notification_frequency,
+            scaffolding_status="accountable",
+        )
+
+    # --- Successful transitions ---
+
+    def test_daily_to_every_other_day(self, db):
+        habit = self._accountable_habit(db, "daily")
+        result = apply_frequency_step_down(db, habit.id, "every_other_day")
+
+        assert isinstance(result, FrequencyChangeResult)
+        assert result.success is True
+        assert result.previous_frequency == "daily"
+        assert result.new_frequency == "every_other_day"
+
+        db.refresh(habit)
+        assert habit.notification_frequency == "every_other_day"
+        assert habit.last_frequency_changed_at is not None
+
+    def test_every_other_day_to_twice_week(self, db):
+        habit = self._accountable_habit(db, "every_other_day")
+        result = apply_frequency_step_down(db, habit.id, "twice_week")
+
+        assert result.success is True
+        db.refresh(habit)
+        assert habit.notification_frequency == "twice_week"
+
+    def test_twice_week_to_weekly(self, db):
+        habit = self._accountable_habit(db, "twice_week")
+        result = apply_frequency_step_down(db, habit.id, "weekly")
+
+        assert result.success is True
+        db.refresh(habit)
+        assert habit.notification_frequency == "weekly"
+
+    def test_activity_log_created(self, db):
+        """Successful step-down creates an activity log entry."""
+        habit = self._accountable_habit(db)
+        apply_frequency_step_down(db, habit.id, "every_other_day")
+
+        log = (
+            db.query(ActivityLog)
+            .filter(ActivityLog.habit_id == habit.id)
+            .first()
+        )
+        assert log is not None
+        assert log.action_type == "completed"
+        assert "stepped down" in log.notes
+        assert "daily" in log.notes
+        assert "every_other_day" in log.notes
+
+    def test_last_frequency_changed_at_set(self, db):
+        """Step-down sets last_frequency_changed_at for cooldown tracking."""
+        habit = self._accountable_habit(db)
+        before = datetime.now(tz=UTC)
+
+        apply_frequency_step_down(db, habit.id, "every_other_day")
+
+        db.refresh(habit)
+        assert habit.last_frequency_changed_at is not None
+        # SQLite may strip tzinfo — normalize for comparison
+        changed_at = habit.last_frequency_changed_at
+        if changed_at.tzinfo is None:
+            changed_at = changed_at.replace(tzinfo=UTC)
+        assert changed_at >= before
+
+    # --- Rejected transitions ---
+
+    def test_skip_level_rejected(self, db):
+        """Cannot skip from daily to twice_week."""
+        habit = self._accountable_habit(db, "daily")
+        with pytest.raises(Exception) as exc_info:
+            apply_frequency_step_down(db, habit.id, "twice_week")
+        assert exc_info.value.status_code == 400
+        assert "Expected exactly one level" in exc_info.value.detail
+
+    def test_backward_rejected(self, db):
+        """Cannot go from every_other_day back to daily."""
+        habit = self._accountable_habit(db, "every_other_day")
+        with pytest.raises(Exception) as exc_info:
+            apply_frequency_step_down(db, habit.id, "daily")
+        assert exc_info.value.status_code == 400
+
+    def test_weekly_cannot_step_down(self, db):
+        """Cannot step down from weekly — that's graduation territory."""
+        habit = self._accountable_habit(db, "weekly")
+        with pytest.raises(Exception) as exc_info:
+            apply_frequency_step_down(db, habit.id, "graduated")
+        assert exc_info.value.status_code == 400
+        assert "not in the step-down progression" in exc_info.value.detail
+
+    def test_nonexistent_habit_404(self, db):
+        """Nonexistent habit_id raises 404."""
+        with pytest.raises(Exception) as exc_info:
+            apply_frequency_step_down(db, uuid.uuid4(), "every_other_day")
+        assert exc_info.value.status_code == 404
+
+
+# ===========================================================================
+# [2G-03] Manual override — cooldown reset via PATCH
+# ===========================================================================
+
+
+class TestManualFrequencyOverrideCooldown:
+
+    def test_manual_change_sets_last_frequency_changed_at(self, client):
+        """Changing notification_frequency via PATCH sets last_frequency_changed_at."""
+        habit = make_habit(client, notification_frequency="daily",
+                          scaffolding_status="accountable")
+
+        resp = client.patch(
+            f"/api/habits/{habit['id']}",
+            json={"notification_frequency": "weekly"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["notification_frequency"] == "weekly"
+        assert data["last_frequency_changed_at"] is not None
+
+    def test_same_frequency_does_not_reset_cooldown(self, client):
+        """Setting notification_frequency to the same value does NOT reset cooldown."""
+        habit = make_habit(client, notification_frequency="daily",
+                          scaffolding_status="accountable")
+
+        resp = client.patch(
+            f"/api/habits/{habit['id']}",
+            json={"notification_frequency": "daily"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["last_frequency_changed_at"] is None
+
+    def test_manual_override_then_cooldown_respected(self, client, db):
+        """After manual override, step-down evaluation sees cooldown."""
+        habit_data = make_habit(client, notification_frequency="daily",
+                                scaffolding_status="accountable")
+
+        # Manual override to weekly
+        client.patch(
+            f"/api/habits/{habit_data['id']}",
+            json={"notification_frequency": "every_other_day"},
+        )
+
+        # Create enough notifications for evaluation
+        habit_id = uuid.UUID(habit_data["id"])
+        for i in range(14):
+            _create_notification(
+                db, habit_id, "Already done", "responded", days_ago=i + 1,
+            )
+
+        result = evaluate_frequency_step_down(db, habit_id)
+
+        assert result.cooldown_active is True
+        assert result.recommend_step_down is False

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -23,7 +23,6 @@ import pytest
 
 from app.models import ActivityLog, Habit, NotificationQueue
 from app.services.graduation import (
-    FREQUENCY_ORDER,
     FrequencyChangeResult,
     FrequencyStepResult,
     GraduationExecutionResult,


### PR DESCRIPTION
## Summary
Implements the intermediate frequency step-down logic for habit scaffolding. Between initial accountability (daily notifications) and full graduation (notifications off), habits can now step through decreasing notification frequencies (daily → every_other_day → twice_week → weekly) as the "already done" rate rises past 60%.

## Changes
- **app/services/graduation.py** — Added `FREQUENCY_ORDER` progression map, `next_step_down()` helper, `evaluate_frequency_step_down()` with LIMIT-based notification query (most recent 14) and 7-day cooldown from `last_frequency_changed_at`, `apply_frequency_step_down()` with strict one-level-only validation. Added `FrequencyStepResult` and `FrequencyChangeResult` Pydantic schemas. Module-level constants for all thresholds (14 notifications, 5 minimum, 60% rate, 7-day cooldown).
- **app/routers/habits.py** — Added manual override hook in `update_habit`: when `notification_frequency` changes via PATCH, `last_frequency_changed_at` is set to `utcnow()` to reset the cooldown timer. Same-value updates are ignored.
- **tests/test_graduation.py** — 37 new tests across 4 test classes: `TestNextStepDown` (7 tests), `TestEvaluateFrequencyStepDown` (17 tests), `TestApplyFrequencyStepDown` (9 tests), `TestManualFrequencyOverrideCooldown` (3 tests + 1 integration test).

## How to Verify
1. `python -m pytest tests/test_graduation.py -v` — all 81 tests pass
2. `python -m pytest` — full suite (1154 tests) passes with no regressions
3. Verify step-down evaluation returns correct recommendations for each frequency level
4. Verify cooldown blocks re-evaluation within 7 days of last change
5. Verify manual PATCH to notification_frequency resets cooldown timer

## Deviations
- Added SQLite timezone-awareness normalization in `evaluate_frequency_step_down()` — SQLite strips tzinfo from datetime columns, requiring a `replace(tzinfo=UTC)` guard before comparing `last_frequency_changed_at` against the UTC-aware `now`. This is test-infrastructure only; Postgres (production) preserves timezone info natively.

## Test Results
```
81 passed in 0.88s (test_graduation.py)
1154 passed in 15.54s (full suite)
```

## Acceptance Checklist
- [x] `evaluate_frequency_step_down()` returns correct recommendation for each frequency level
- [x] Returns no recommendation when frequency is already `weekly`, `graduated`, or `none`
- [x] Respects 7-day cooldown after last frequency change
- [x] Requires minimum 5 notifications to evaluate (returns blocking reason if fewer)
- [x] 60% "already done" rate threshold is correctly applied
- [x] `apply_frequency_step_down()` updates notification_frequency and last_frequency_changed_at
- [x] Rejects attempts to skip frequency levels or go backwards
- [x] Activity log entry created on successful step-down
- [x] Manual frequency changes via habit update also set last_frequency_changed_at
- [x] Tests cover: each frequency transition, cooldown active, insufficient data, threshold not met, threshold met, already at weekly, manual override cooldown reset