### PR TITLE
2G-04: Re-Scaffolding Detection & Execution

### DIFF
--- a/app/services/graduation.py
+++ b/app/services/graduation.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-"""Graduation evaluation, execution, and frequency step-down service for habit scaffolding."""
+"""Graduation evaluation, execution, frequency step-down, and re-scaffolding service."""
 
 from __future__ import annotations
 
@@ -23,9 +23,10 @@ from uuid import UUID
 
 from fastapi import HTTPException
 from pydantic import BaseModel
+from sqlalchemy import func as sa_func
 from sqlalchemy.orm import Session
 
-from app.models import ActivityLog, Habit, NotificationQueue
+from app.models import ActivityLog, Habit, HabitCompletion, NotificationQueue
 from app.services.graduation_defaults import resolve_graduation_params
 
 
@@ -535,5 +536,316 @@ def apply_frequency_step_down(
         message=(
             f"Frequency stepped down for '{habit.title}': "
             f"{previous} → {new_frequency}"
+        ),
+    )
+
+
+# ===========================================================================
+# [2G-04] Slip Detection & Re-Scaffolding
+# ===========================================================================
+
+# Detection window and thresholds
+SLIP_DETECTION_WINDOW_DAYS = 14
+CHECKLIST_WARNING_THRESHOLD = 3
+CHECKLIST_CRITICAL_THRESHOLD = 5
+COMPLETION_WARNING_DAYS = 7  # 0 completions in this many days → warning
+COMPLETION_CRITICAL_DAYS = 14  # 0 completions in this many days → critical
+
+
+class SlipSignal(BaseModel):
+    """A single signal indicating potential habit regression."""
+
+    signal_type: str  # "missed_in_checklist" | "no_completion_recorded"
+    detail: str
+    severity: str  # "warning" | "critical"
+
+
+class SlipDetectionResult(BaseModel):
+    """Result of evaluating a graduated habit for slip signals."""
+
+    slip_detected: bool
+    habit_id: UUID
+    habit_name: str
+    slip_signals: list[SlipSignal]
+    recommendation: str  # "re_scaffold" | "monitor" | "no_action"
+    days_since_graduation: int
+    message: str
+
+
+class ReScaffoldResult(BaseModel):
+    """Result of executing a habit re-scaffolding."""
+
+    success: bool
+    habit_id: UUID
+    previous_scaffolding_status: str
+    previous_notification_frequency: str
+    new_notification_frequency: str
+    re_scaffold_count: int
+    tightened_params: dict
+    message: str
+
+
+def evaluate_graduated_habit_slip(
+    db: Session,
+    habit_id: UUID,
+) -> SlipDetectionResult:
+    """Evaluate whether a graduated habit is showing signs of regression.
+
+    Read-only — returns recommendations but does not trigger re-scaffolding.
+    The caller decides what to do with the result.
+    """
+    habit = db.query(Habit).filter(Habit.id == habit_id).first()
+    if habit is None:
+        raise ValueError(f"Habit {habit_id} not found")
+
+    # Gate: only graduated habits are evaluated for slip
+    if habit.scaffolding_status != "graduated":
+        return SlipDetectionResult(
+            slip_detected=False,
+            habit_id=habit_id,
+            habit_name=habit.title,
+            slip_signals=[],
+            recommendation="no_action",
+            days_since_graduation=0,
+            message="Habit is not graduated — slip detection does not apply",
+        )
+
+    now = datetime.now(tz=UTC)
+    window_start = now - timedelta(days=SLIP_DETECTION_WINDOW_DAYS)
+
+    # Compute days since graduation (approximate — use updated_at as proxy
+    # since we don't have a dedicated graduated_at column)
+    days_since_graduation = 0
+    if habit.updated_at is not None:
+        updated = habit.updated_at
+        if updated.tzinfo is None:
+            updated = updated.replace(tzinfo=UTC)
+        days_since_graduation = (now - updated).days
+
+    signals: list[SlipSignal] = []
+
+    # Signal 1: Missed in routine checklists (only for habits with a routine)
+    if habit.routine_id is not None:
+        checklist_notifications = (
+            db.query(NotificationQueue)
+            .filter(
+                NotificationQueue.target_entity_type == "routine",
+                NotificationQueue.target_entity_id == habit.routine_id,
+                NotificationQueue.notification_type == "routine_checklist",
+                NotificationQueue.scheduled_at >= window_start,
+                NotificationQueue.status.in_(["responded", "expired"]),
+            )
+            .all()
+        )
+
+        miss_count = sum(
+            1 for n in checklist_notifications
+            if n.response == "Partial" or n.status == "expired"
+        )
+
+        if miss_count >= CHECKLIST_CRITICAL_THRESHOLD:
+            signals.append(SlipSignal(
+                signal_type="missed_in_checklist",
+                detail=(
+                    f"{miss_count} partial/expired routine checklists in "
+                    f"the last {SLIP_DETECTION_WINDOW_DAYS} days"
+                ),
+                severity="critical",
+            ))
+        elif miss_count >= CHECKLIST_WARNING_THRESHOLD:
+            signals.append(SlipSignal(
+                signal_type="missed_in_checklist",
+                detail=(
+                    f"{miss_count} partial/expired routine checklists in "
+                    f"the last {SLIP_DETECTION_WINDOW_DAYS} days"
+                ),
+                severity="warning",
+            ))
+
+    # Signal 2: No completion recorded
+    window_7 = now - timedelta(days=COMPLETION_WARNING_DAYS)
+
+    completions_14d = (
+        db.query(sa_func.count(HabitCompletion.id))
+        .filter(
+            HabitCompletion.habit_id == habit_id,
+            HabitCompletion.completed_at >= window_start.date(),
+        )
+        .scalar()
+    )
+
+    if completions_14d == 0:
+        # Zero completions in full 14-day window → critical
+        signals.append(SlipSignal(
+            signal_type="no_completion_recorded",
+            detail=(
+                f"No completions recorded in the last "
+                f"{SLIP_DETECTION_WINDOW_DAYS} days"
+            ),
+            severity="critical",
+        ))
+    else:
+        completions_7d = (
+            db.query(sa_func.count(HabitCompletion.id))
+            .filter(
+                HabitCompletion.habit_id == habit_id,
+                HabitCompletion.completed_at >= window_7.date(),
+            )
+            .scalar()
+        )
+
+        if completions_7d == 0:
+            # Zero completions in last 7 days but some in 14-day window → warning
+            signals.append(SlipSignal(
+                signal_type="no_completion_recorded",
+                detail=(
+                    f"No completions in the last {COMPLETION_WARNING_DAYS} days "
+                    f"(last completion was more than a week ago)"
+                ),
+                severity="warning",
+            ))
+
+    # Determine recommendation
+    has_critical = any(s.severity == "critical" for s in signals)
+    has_warning = any(s.severity == "warning" for s in signals)
+
+    if has_critical:
+        recommendation = "re_scaffold"
+    elif has_warning:
+        recommendation = "monitor"
+    else:
+        recommendation = "no_action"
+
+    # Build human-readable message
+    if recommendation == "re_scaffold":
+        message = (
+            f"Habit '{habit.title}' is showing critical signs of regression. "
+            f"Re-scaffolding recommended."
+        )
+    elif recommendation == "monitor":
+        message = (
+            f"Habit '{habit.title}' has early warning signs of slipping. "
+            f"Monitor during next session."
+        )
+    else:
+        message = f"Habit '{habit.title}' is holding steady after graduation."
+
+    return SlipDetectionResult(
+        slip_detected=len(signals) > 0,
+        habit_id=habit_id,
+        habit_name=habit.title,
+        slip_signals=signals,
+        recommendation=recommendation,
+        days_since_graduation=days_since_graduation,
+        message=message,
+    )
+
+
+def evaluate_all_graduated_habits(
+    db: Session,
+) -> list[SlipDetectionResult]:
+    """Evaluate all active graduated habits for slip signals.
+
+    Returns only habits that need attention (recommendation != 'no_action').
+    This is the function the scheduler calls periodically.
+    """
+    habits = (
+        db.query(Habit)
+        .filter(
+            Habit.scaffolding_status == "graduated",
+            Habit.status == "active",
+        )
+        .all()
+    )
+
+    results = []
+    for habit in habits:
+        result = evaluate_graduated_habit_slip(db, habit.id)
+        if result.recommendation != "no_action":
+            results.append(result)
+    return results
+
+
+def re_scaffold_habit(
+    db: Session,
+    habit_id: UUID,
+) -> ReScaffoldResult:
+    """Execute re-scaffolding: reverse graduation and return to daily notifications.
+
+    Increments re_scaffold_count so future graduation criteria are tightened.
+    Does NOT reset streaks — historical achievement is preserved.
+    """
+    habit = db.query(Habit).filter(Habit.id == habit_id).first()
+    if habit is None:
+        raise HTTPException(status_code=404, detail="Habit not found")
+
+    if habit.status != "active":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot re-scaffold a habit with status '{habit.status}' — must be 'active'",
+        )
+
+    if habit.scaffolding_status != "graduated":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Cannot re-scaffold from scaffolding_status '{habit.scaffolding_status}' "
+                "— must be 'graduated'"
+            ),
+        )
+
+    # Snapshot previous values
+    previous_scaffolding = habit.scaffolding_status
+    previous_frequency = habit.notification_frequency
+
+    # Reverse graduation
+    habit.scaffolding_status = "accountable"
+    habit.notification_frequency = "daily"
+
+    # Increment re-scaffold count
+    habit.re_scaffold_count += 1
+
+    # Reset cooldown timer
+    habit.last_frequency_changed_at = datetime.now(tz=UTC)
+
+    # Compute tightened criteria for informational purposes
+    window, target, threshold = resolve_graduation_params(habit)
+    window, target, threshold = apply_re_scaffold_tightening(
+        window, target, threshold, habit.re_scaffold_count,
+    )
+    tightened_params = {
+        "window_days": window,
+        "target_rate": target,
+        "threshold_days": threshold,
+    }
+
+    # Log activity entry
+    activity = ActivityLog(
+        action_type="reflected",
+        notes=(
+            f"Habit re-scaffolded: {habit.title} "
+            f"(re-scaffold #{habit.re_scaffold_count}). "
+            f"Returning to daily notifications. "
+            f"Next graduation requires: {window}d window, "
+            f"{target:.0%} rate, {threshold}d minimum."
+        ),
+        habit_id=habit_id,
+    )
+    db.add(activity)
+    db.commit()
+    db.refresh(habit)
+
+    return ReScaffoldResult(
+        success=True,
+        habit_id=habit_id,
+        previous_scaffolding_status=previous_scaffolding,
+        previous_notification_frequency=previous_frequency,
+        new_notification_frequency="daily",
+        re_scaffold_count=habit.re_scaffold_count,
+        tightened_params=tightened_params,
+        message=(
+            f"Habit '{habit.title}' re-scaffolded "
+            f"(#{habit.re_scaffold_count}). "
+            f"Returning to daily notifications."
         ),
     )

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -21,18 +21,30 @@ from datetime import UTC, date, datetime, timedelta
 
 import pytest
 
-from app.models import ActivityLog, Habit, NotificationQueue
+from app.models import (
+    ActivityLog,
+    Domain,
+    Habit,
+    HabitCompletion,
+    NotificationQueue,
+    Routine,
+)
 from app.services.graduation import (
     FrequencyChangeResult,
     FrequencyStepResult,
     GraduationExecutionResult,
     GraduationResult,
+    ReScaffoldResult,
+    SlipDetectionResult,
     apply_frequency_step_down,
     apply_re_scaffold_tightening,
+    evaluate_all_graduated_habits,
     evaluate_frequency_step_down,
+    evaluate_graduated_habit_slip,
     evaluate_graduation,
     graduate_habit,
     next_step_down,
+    re_scaffold_habit,
 )
 from app.services.graduation_defaults import resolve_graduation_params
 from tests.conftest import make_habit
@@ -78,6 +90,55 @@ def _create_habit(db, **overrides) -> Habit:
 
     db.refresh(habit)
     return habit
+
+
+def _create_routine(db) -> Routine:
+    """Insert a Domain + Routine and return the Routine."""
+    domain = Domain(id=uuid.uuid4(), name="Test Domain")
+    db.add(domain)
+    db.commit()
+    routine = Routine(
+        id=uuid.uuid4(),
+        domain_id=domain.id,
+        title="Test Routine",
+        frequency="daily",
+    )
+    db.add(routine)
+    db.commit()
+    return routine
+
+
+def _create_completion(db, habit_id: uuid.UUID, days_ago: int = 0) -> HabitCompletion:
+    """Insert a habit completion record."""
+    c = HabitCompletion(
+        id=uuid.uuid4(),
+        habit_id=habit_id,
+        completed_at=date.today() - timedelta(days=days_ago),
+        source="individual",
+    )
+    db.add(c)
+    db.commit()
+    return c
+
+
+def _create_routine_checklist(db, routine_id: uuid.UUID, response: str | None,
+                              status: str, days_ago: int = 5) -> NotificationQueue:
+    """Insert a routine_checklist notification for a routine."""
+    n = NotificationQueue(
+        id=uuid.uuid4(),
+        notification_type="routine_checklist",
+        delivery_type="notification",
+        status=status,
+        scheduled_at=datetime.now(tz=UTC) - timedelta(days=days_ago),
+        target_entity_type="routine",
+        target_entity_id=routine_id,
+        message="Routine checklist time!",
+        response=response,
+        scheduled_by="system",
+    )
+    db.add(n)
+    db.commit()
+    return n
 
 
 def _create_notification(db, habit_id: uuid.UUID, response: str | None,
@@ -1135,3 +1196,529 @@ class TestManualFrequencyOverrideCooldown:
 
         assert result.cooldown_active is True
         assert result.recommend_step_down is False
+
+
+# ===========================================================================
+# [2G-04] evaluate_graduated_habit_slip
+# ===========================================================================
+
+
+class TestEvaluateGraduatedHabitSlip:
+    """Tests for slip detection on graduated habits."""
+
+    def _graduated_habit(self, db, *, routine_id=None, **overrides) -> Habit:
+        """Create a graduated habit."""
+        defaults = {
+            "scaffolding_status": "graduated",
+            "notification_frequency": "graduated",
+            "status": "active",
+            "introduced_at": date.today() - timedelta(days=90),
+            "routine_id": routine_id,
+        }
+        defaults.update(overrides)
+        return _create_habit(db, **defaults)
+
+    # --- No slip ---
+
+    def test_no_slip_with_recent_completions(self, db):
+        """Graduated habit with recent completions shows no slip."""
+        habit = self._graduated_habit(db)
+        # Completions in the last 7 days
+        for i in range(5):
+            _create_completion(db, habit.id, days_ago=i + 1)
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        assert isinstance(result, SlipDetectionResult)
+        assert result.slip_detected is False
+        assert result.recommendation == "no_action"
+        assert result.slip_signals == []
+        assert "holding steady" in result.message
+
+    def test_no_action_for_non_graduated_habit(self, db):
+        """Accountable habit returns no_action — slip detection only applies to graduated."""
+        habit = _create_habit(db, scaffolding_status="accountable")
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        assert result.slip_detected is False
+        assert result.recommendation == "no_action"
+        assert "not graduated" in result.message
+
+    def test_nonexistent_habit_raises(self, db):
+        """Evaluating a nonexistent habit raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            evaluate_graduated_habit_slip(db, uuid.uuid4())
+
+    # --- Signal 2: No completion recorded (standalone habit) ---
+
+    def test_warning_no_completions_7_days(self, db):
+        """0 completions in last 7 days but some in 14-day window → warning."""
+        habit = self._graduated_habit(db)
+        # Completion 10 days ago (within 14-day window, outside 7-day window)
+        _create_completion(db, habit.id, days_ago=10)
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        assert result.slip_detected is True
+        assert result.recommendation == "monitor"
+        assert len(result.slip_signals) == 1
+        signal = result.slip_signals[0]
+        assert signal.signal_type == "no_completion_recorded"
+        assert signal.severity == "warning"
+
+    def test_critical_no_completions_14_days(self, db):
+        """0 completions in 14 days → critical."""
+        habit = self._graduated_habit(db)
+        # No completions at all
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        assert result.slip_detected is True
+        assert result.recommendation == "re_scaffold"
+        assert len(result.slip_signals) == 1
+        signal = result.slip_signals[0]
+        assert signal.signal_type == "no_completion_recorded"
+        assert signal.severity == "critical"
+        assert "Re-scaffolding recommended" in result.message
+
+    def test_no_warning_with_recent_completions_within_7_days(self, db):
+        """Completions within 7 days → no completion signal."""
+        habit = self._graduated_habit(db)
+        _create_completion(db, habit.id, days_ago=3)
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        assert result.slip_detected is False
+        assert result.recommendation == "no_action"
+
+    # --- Signal 1: Missed in routine checklists ---
+
+    def test_standalone_habit_only_signal_2(self, db):
+        """Standalone habits (no routine) only evaluate Signal 2."""
+        habit = self._graduated_habit(db, routine_id=None)
+        _create_completion(db, habit.id, days_ago=2)
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        assert result.slip_detected is False
+        # No checklist signals even if we somehow had checklist notifications
+        assert all(
+            s.signal_type != "missed_in_checklist" for s in result.slip_signals
+        )
+
+    def test_checklist_warning_3_misses(self, db):
+        """3 partial/expired routine checklists in 14 days → warning signal."""
+        routine = _create_routine(db)
+        habit = self._graduated_habit(db, routine_id=routine.id)
+        # Recent completions to avoid Signal 2
+        for i in range(3):
+            _create_completion(db, habit.id, days_ago=i + 1)
+        # 3 partial checklist responses
+        for i in range(3):
+            _create_routine_checklist(
+                db, routine.id, "Partial", "responded", days_ago=i + 1,
+            )
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        assert result.slip_detected is True
+        assert result.recommendation == "monitor"
+        checklist_signals = [
+            s for s in result.slip_signals if s.signal_type == "missed_in_checklist"
+        ]
+        assert len(checklist_signals) == 1
+        assert checklist_signals[0].severity == "warning"
+
+    def test_checklist_critical_5_misses(self, db):
+        """5+ partial/expired routine checklists in 14 days → critical signal."""
+        routine = _create_routine(db)
+        habit = self._graduated_habit(db, routine_id=routine.id)
+        # Recent completions to avoid Signal 2
+        for i in range(5):
+            _create_completion(db, habit.id, days_ago=i + 1)
+        # 5 partial/expired checklist responses
+        for i in range(3):
+            _create_routine_checklist(
+                db, routine.id, "Partial", "responded", days_ago=i + 1,
+            )
+        for i in range(2):
+            _create_routine_checklist(
+                db, routine.id, None, "expired", days_ago=i + 4,
+            )
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        assert result.slip_detected is True
+        checklist_signals = [
+            s for s in result.slip_signals if s.signal_type == "missed_in_checklist"
+        ]
+        assert len(checklist_signals) == 1
+        assert checklist_signals[0].severity == "critical"
+        assert result.recommendation == "re_scaffold"
+
+    def test_checklist_2_misses_no_signal(self, db):
+        """Only 2 misses — below threshold, no signal."""
+        routine = _create_routine(db)
+        habit = self._graduated_habit(db, routine_id=routine.id)
+        for i in range(3):
+            _create_completion(db, habit.id, days_ago=i + 1)
+        for i in range(2):
+            _create_routine_checklist(
+                db, routine.id, "Partial", "responded", days_ago=i + 1,
+            )
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        checklist_signals = [
+            s for s in result.slip_signals if s.signal_type == "missed_in_checklist"
+        ]
+        assert len(checklist_signals) == 0
+
+    def test_expired_checklists_count_as_misses(self, db):
+        """Expired (unanswered) routine checklists count toward miss threshold."""
+        routine = _create_routine(db)
+        habit = self._graduated_habit(db, routine_id=routine.id)
+        for i in range(3):
+            _create_completion(db, habit.id, days_ago=i + 1)
+        # 3 expired checklists
+        for i in range(3):
+            _create_routine_checklist(
+                db, routine.id, None, "expired", days_ago=i + 1,
+            )
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        checklist_signals = [
+            s for s in result.slip_signals if s.signal_type == "missed_in_checklist"
+        ]
+        assert len(checklist_signals) == 1
+        assert checklist_signals[0].severity == "warning"
+
+    # --- Combined signals ---
+
+    def test_critical_from_both_signals(self, db):
+        """Both critical signals present → re_scaffold recommendation."""
+        routine = _create_routine(db)
+        habit = self._graduated_habit(db, routine_id=routine.id)
+        # No completions (Signal 2 critical)
+        # 5 partial checklists (Signal 1 critical)
+        for i in range(5):
+            _create_routine_checklist(
+                db, routine.id, "Partial", "responded", days_ago=i + 1,
+            )
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        assert result.slip_detected is True
+        assert result.recommendation == "re_scaffold"
+        assert len(result.slip_signals) == 2
+
+    def test_monitor_with_only_warnings(self, db):
+        """Warning-only signals → monitor recommendation."""
+        routine = _create_routine(db)
+        habit = self._graduated_habit(db, routine_id=routine.id)
+        # Completion 10 days ago (Signal 2 warning)
+        _create_completion(db, habit.id, days_ago=10)
+        # 3 partial checklists (Signal 1 warning)
+        for i in range(3):
+            _create_routine_checklist(
+                db, routine.id, "Partial", "responded", days_ago=i + 1,
+            )
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        assert result.slip_detected is True
+        assert result.recommendation == "monitor"
+        assert len(result.slip_signals) == 2
+
+    def test_critical_overrides_warning(self, db):
+        """If any signal is critical, recommendation is re_scaffold even if others are warning."""
+        routine = _create_routine(db)
+        habit = self._graduated_habit(db, routine_id=routine.id)
+        # No completions → critical (Signal 2)
+        # 3 partial checklists → warning only (Signal 1)
+        for i in range(3):
+            _create_routine_checklist(
+                db, routine.id, "Partial", "responded", days_ago=i + 1,
+            )
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        assert result.recommendation == "re_scaffold"
+        severities = {s.severity for s in result.slip_signals}
+        assert "critical" in severities
+        assert "warning" in severities
+
+    def test_completed_checklists_not_counted(self, db):
+        """Checklists with response='Complete' or status='responded' (not Partial) don't count."""
+        routine = _create_routine(db)
+        habit = self._graduated_habit(db, routine_id=routine.id)
+        for i in range(3):
+            _create_completion(db, habit.id, days_ago=i + 1)
+        # 5 complete checklists — should NOT trigger
+        for i in range(5):
+            _create_routine_checklist(
+                db, routine.id, "Complete", "responded", days_ago=i + 1,
+            )
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+
+        checklist_signals = [
+            s for s in result.slip_signals if s.signal_type == "missed_in_checklist"
+        ]
+        assert len(checklist_signals) == 0
+
+
+# ===========================================================================
+# [2G-04] evaluate_all_graduated_habits
+# ===========================================================================
+
+
+class TestEvaluateAllGraduatedHabits:
+
+    def test_returns_only_actionable(self, db):
+        """Only habits with recommendation != 'no_action' are returned."""
+        # Graduated habit with recent completions (no slip)
+        good = _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+            status="active", introduced_at=date.today() - timedelta(days=90),
+        )
+        for i in range(5):
+            _create_completion(db, good.id, days_ago=i + 1)
+
+        # Graduated habit with no completions (critical slip)
+        bad = _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+            status="active", introduced_at=date.today() - timedelta(days=90),
+            title="Slipping Habit",
+        )
+
+        results = evaluate_all_graduated_habits(db)
+
+        assert len(results) == 1
+        assert results[0].habit_id == bad.id
+        assert results[0].recommendation == "re_scaffold"
+
+    def test_excludes_non_graduated(self, db):
+        """Accountable and tracking habits are not evaluated."""
+        _create_habit(
+            db, scaffolding_status="accountable", status="active",
+        )
+        _create_habit(
+            db, scaffolding_status="tracking", status="active",
+        )
+
+        results = evaluate_all_graduated_habits(db)
+
+        assert results == []
+
+    def test_excludes_inactive(self, db):
+        """Paused graduated habits are not evaluated."""
+        _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+            status="paused",
+        )
+
+        results = evaluate_all_graduated_habits(db)
+
+        assert results == []
+
+    def test_empty_when_no_graduated(self, db):
+        """No graduated habits → empty list."""
+        results = evaluate_all_graduated_habits(db)
+
+        assert results == []
+
+    def test_multiple_slipping_habits(self, db):
+        """Multiple slipping habits all appear in results."""
+        for i in range(3):
+            _create_habit(
+                db, scaffolding_status="graduated",
+                notification_frequency="graduated",
+                status="active",
+                introduced_at=date.today() - timedelta(days=90),
+                title=f"Slipping {i}",
+            )
+
+        results = evaluate_all_graduated_habits(db)
+
+        assert len(results) == 3
+
+
+# ===========================================================================
+# [2G-04] re_scaffold_habit
+# ===========================================================================
+
+
+class TestReScaffoldHabit:
+
+    def _graduated_habit(self, db, **overrides) -> Habit:
+        """Create a graduated, active habit."""
+        defaults = {
+            "scaffolding_status": "graduated",
+            "notification_frequency": "graduated",
+            "status": "active",
+            "introduced_at": date.today() - timedelta(days=90),
+            "friction_score": 1,
+            "graduation_window": None,
+            "graduation_target": None,
+            "graduation_threshold": None,
+        }
+        defaults.update(overrides)
+        return _create_habit(db, **defaults)
+
+    # --- Successful re-scaffold ---
+
+    def test_successful_re_scaffold(self, db):
+        """Re-scaffold transitions status and frequency correctly."""
+        habit = self._graduated_habit(db)
+
+        result = re_scaffold_habit(db, habit.id)
+
+        assert isinstance(result, ReScaffoldResult)
+        assert result.success is True
+        assert result.previous_scaffolding_status == "graduated"
+        assert result.previous_notification_frequency == "graduated"
+        assert result.new_notification_frequency == "daily"
+        assert result.re_scaffold_count == 1
+
+        db.refresh(habit)
+        assert habit.scaffolding_status == "accountable"
+        assert habit.notification_frequency == "daily"
+
+    def test_re_scaffold_increments_count(self, db):
+        """re_scaffold_count is incremented."""
+        habit = self._graduated_habit(db)
+        assert habit.re_scaffold_count == 0
+
+        result = re_scaffold_habit(db, habit.id)
+
+        assert result.re_scaffold_count == 1
+        db.refresh(habit)
+        assert habit.re_scaffold_count == 1
+
+    def test_re_scaffold_resets_cooldown(self, db):
+        """last_frequency_changed_at is set on re-scaffold."""
+        habit = self._graduated_habit(db)
+        assert habit.last_frequency_changed_at is None
+
+        before = datetime.now(tz=UTC)
+        re_scaffold_habit(db, habit.id)
+        db.refresh(habit)
+
+        assert habit.last_frequency_changed_at is not None
+        changed_at = habit.last_frequency_changed_at
+        if changed_at.tzinfo is None:
+            changed_at = changed_at.replace(tzinfo=UTC)
+        assert changed_at >= before
+
+    def test_re_scaffold_preserves_streaks(self, db):
+        """best_streak and last_completed are NOT reset."""
+        habit = self._graduated_habit(db)
+        habit.best_streak = 21
+        habit.last_completed = date.today() - timedelta(days=3)
+        db.commit()
+        db.refresh(habit)
+
+        re_scaffold_habit(db, habit.id)
+        db.refresh(habit)
+
+        assert habit.best_streak == 21
+        assert habit.last_completed == date.today() - timedelta(days=3)
+
+    def test_tightened_params_in_result(self, db):
+        """Result includes correctly computed tightened graduation criteria."""
+        habit = self._graduated_habit(db, friction_score=1)
+
+        result = re_scaffold_habit(db, habit.id)
+
+        # Friction-1 base: (30, 0.85, 30) → 1 re-scaffold: (37, 0.90, 37)
+        assert result.tightened_params["window_days"] == 37
+        assert result.tightened_params["target_rate"] == pytest.approx(0.90)
+        assert result.tightened_params["threshold_days"] == 37
+
+    def test_activity_log_created(self, db):
+        """Re-scaffold creates an activity log with action_type='reflected'."""
+        habit = self._graduated_habit(db)
+
+        re_scaffold_habit(db, habit.id)
+
+        log = (
+            db.query(ActivityLog)
+            .filter(ActivityLog.habit_id == habit.id)
+            .first()
+        )
+        assert log is not None
+        assert log.action_type == "reflected"
+        assert "re-scaffolded" in log.notes
+        assert habit.title in log.notes
+        assert "#1" in log.notes
+        assert "daily" in log.notes.lower()
+
+    # --- Double re-scaffold (compounded tightening) ---
+
+    def test_double_re_scaffold(self, db):
+        """Second re-scaffold compounds tightening correctly."""
+        habit = self._graduated_habit(db, friction_score=1)
+
+        # First re-scaffold
+        result1 = re_scaffold_habit(db, habit.id)
+        assert result1.re_scaffold_count == 1
+
+        # Simulate re-graduation (set back to graduated)
+        habit.scaffolding_status = "graduated"
+        habit.notification_frequency = "graduated"
+        db.commit()
+        db.refresh(habit)
+
+        # Second re-scaffold
+        result2 = re_scaffold_habit(db, habit.id)
+
+        assert result2.re_scaffold_count == 2
+        # Friction-1: (30, 0.85, 30) → 2x tightening: (46, 0.95, 46)
+        assert result2.tightened_params["window_days"] == 46
+        assert result2.tightened_params["target_rate"] == pytest.approx(0.95)
+        assert result2.tightened_params["threshold_days"] == 46
+
+        db.refresh(habit)
+        assert habit.scaffolding_status == "accountable"
+        assert habit.notification_frequency == "daily"
+
+    # --- Rejection cases ---
+
+    def test_reject_non_graduated(self, db):
+        """Cannot re-scaffold a non-graduated habit."""
+        habit = _create_habit(db, scaffolding_status="accountable", status="active")
+
+        with pytest.raises(Exception) as exc_info:
+            re_scaffold_habit(db, habit.id)
+        assert exc_info.value.status_code == 400
+        assert "accountable" in exc_info.value.detail
+
+    def test_reject_paused(self, db):
+        """Cannot re-scaffold a paused habit."""
+        habit = _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+            status="paused",
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            re_scaffold_habit(db, habit.id)
+        assert exc_info.value.status_code == 400
+        assert "paused" in exc_info.value.detail
+
+    def test_reject_tracking(self, db):
+        """Cannot re-scaffold a tracking habit."""
+        habit = _create_habit(db, scaffolding_status="tracking", status="active")
+
+        with pytest.raises(Exception) as exc_info:
+            re_scaffold_habit(db, habit.id)
+        assert exc_info.value.status_code == 400
+        assert "tracking" in exc_info.value.detail
+
+    def test_nonexistent_habit_404(self, db):
+        """Nonexistent habit_id raises 404."""
+        with pytest.raises(Exception) as exc_info:
+            re_scaffold_habit(db, uuid.uuid4())
+        assert exc_info.value.status_code == 404


### PR DESCRIPTION
## Summary
Implements slip detection and re-scaffolding for graduated habits. When a graduated habit shows signs of regression (missed routine checklists or absent completion records), the system detects the slip and can reverse graduation with tightened criteria for next time.

- `evaluate_graduated_habit_slip()` — evaluates a single graduated habit for two signal types (missed_in_checklist, no_completion_recorded) with warning/critical severity
- `evaluate_all_graduated_habits()` — batch function for the scheduler to call periodically, returns only habits needing attention
- `re_scaffold_habit()` — reverses graduation (graduated → accountable, frequency → daily), increments re_scaffold_count, computes tightened graduation criteria
- Three new Pydantic schemas: `SlipDetectionResult`, `SlipSignal`, `ReScaffoldResult`

## Changes
- `app/services/graduation.py` — Added slip detection constants, 3 schemas, and 3 service functions (316 new lines). Import added for `HabitCompletion` and `sqlalchemy.func`.
- `tests/test_graduation.py` — 31 new tests covering: no slip, warning-only slip, critical slip, standalone habit (Signal 2 only), batch evaluation, re-scaffold execution, double re-scaffold with compounded tightening, rejection cases. Added helpers for creating routines, completions, and routine checklist notifications.

## How to Verify
```bash
git checkout feature/2G-04-re-scaffolding
python -m pytest tests/test_graduation.py -v --tb=short
python -m ruff check app/services/graduation.py tests/test_graduation.py
```

## Deviations
- **Sync Session instead of AsyncSession**: Spec signatures use `AsyncSession` but the entire existing codebase (2G-01 through 2G-03) uses synchronous `Session`. Followed the existing pattern for consistency. Async migration is a separate concern.
- **days_since_graduation approximation**: Used `habit.updated_at` as a proxy since there is no dedicated `graduated_at` column. Acceptable for Phase 2; Phase 3 could add a graduation timestamp.

## Test Results
```
1185 passed in 15.78s (full suite)
112 passed in test_graduation.py (31 new for 2G-04)
ruff: All checks passed
```

## Acceptance Checklist
- [x] `evaluate_graduated_habit_slip()` correctly detects slip signals from checklist responses
- [x] Correctly detects slip signals from missing completion records
- [x] Returns `no_action` for graduated habits with no slip signals
- [x] Returns `monitor` for habits with warning-level signals only
- [x] Returns `re_scaffold` for habits with any critical-level signal
- [x] Standalone habits (no routine) only evaluate Signal 2
- [x] `evaluate_all_graduated_habits()` returns only habits needing attention
- [x] `re_scaffold_habit()` transitions scaffolding_status from graduated to accountable
- [x] Sets notification_frequency to daily
- [x] Increments re_scaffold_count
- [x] Resets last_frequency_changed_at
- [x] Tightened graduation criteria correctly computed and included in result
- [x] Activity log entry created on re-scaffold with new criteria documented
- [x] Re-scaffold rejects non-graduated habits
- [x] Tests cover: no slip, warning-only, critical, standalone, batch, re-scaffold execution, double re-scaffold (compounded tightening)

Closes #148