### PR TITLE
2G-05: Stacking Recommendation Engine

### DIFF
--- a/app/services/graduation.py
+++ b/app/services/graduation.py
@@ -14,7 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-"""Graduation evaluation, execution, frequency step-down, re-scaffolding, and stacking recommendation service."""
+"""Graduation evaluation, execution, frequency step-down,
+re-scaffolding, and stacking recommendation service."""
 
 from __future__ import annotations
 

--- a/app/services/graduation.py
+++ b/app/services/graduation.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-"""Graduation evaluation, execution, frequency step-down, and re-scaffolding service."""
+"""Graduation evaluation, execution, frequency step-down, re-scaffolding, and stacking recommendation service."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ from pydantic import BaseModel
 from sqlalchemy import func as sa_func
 from sqlalchemy.orm import Session
 
-from app.models import ActivityLog, Habit, HabitCompletion, NotificationQueue
+from app.models import ActivityLog, Habit, HabitCompletion, NotificationQueue, Routine
 from app.services.graduation_defaults import resolve_graduation_params
 
 
@@ -848,4 +848,266 @@ def re_scaffold_habit(
             f"(#{habit.re_scaffold_count}). "
             f"Returning to daily notifications."
         ),
+    )
+
+
+# ===========================================================================
+# [2G-05] Stacking Recommendation Engine
+# ===========================================================================
+
+STABILITY_MIN_ACCOUNTABLE_DAYS = 14
+STABILITY_NO_MISS_WINDOW_DAYS = 7
+
+
+class HabitStabilityInfo(BaseModel):
+    """Stability assessment for an accountable habit."""
+
+    habit_id: UUID
+    habit_name: str
+    scaffolding_status: str
+    notification_frequency: str
+    is_stable: bool
+    stability_detail: str
+
+
+class SuggestedHabit(BaseModel):
+    """A habit recommended for introduction into the accountability loop."""
+
+    habit_id: UUID
+    habit_name: str
+    source: str  # "queued" | "paused"
+    reason: str
+
+
+class StackingRecommendation(BaseModel):
+    """Result of evaluating a routine's readiness for a new accountable habit."""
+
+    ready: bool
+    routine_id: UUID
+    routine_name: str
+    active_accountable_habits: list[HabitStabilityInfo]
+    blocking_habits: list[HabitStabilityInfo]
+    suggested_next: SuggestedHabit | None
+    message: str
+
+
+def _assess_habit_stability(
+    db: Session,
+    habit: Habit,
+) -> HabitStabilityInfo:
+    """Assess whether an accountable habit is stable enough to allow stacking.
+
+    Uses evaluate_frequency_step_down() in read-only mode to get the current
+    "already done" rate, then applies stability criteria.
+    """
+    # Already at weekly — stable by definition (stepped down to minimum)
+    if habit.notification_frequency == "weekly":
+        return HabitStabilityInfo(
+            habit_id=habit.id,
+            habit_name=habit.title,
+            scaffolding_status=habit.scaffolding_status,
+            notification_frequency=habit.notification_frequency,
+            is_stable=True,
+            stability_detail="At minimum frequency (weekly)",
+        )
+
+    # Use step-down evaluation to get the "already done" rate
+    step_result = evaluate_frequency_step_down(db, habit.id)
+    rate = step_result.current_rate
+
+    # Stable if rate >= 60% (step-down threshold)
+    if rate >= STEP_DOWN_RATE_THRESHOLD:
+        return HabitStabilityInfo(
+            habit_id=habit.id,
+            habit_name=habit.title,
+            scaffolding_status=habit.scaffolding_status,
+            notification_frequency=habit.notification_frequency,
+            is_stable=True,
+            stability_detail=f"Step-down eligible ({rate:.0%} already-done rate)",
+        )
+
+    # Stable if accountable for 14+ days with no missed completions in last 7
+    now = datetime.now(tz=UTC)
+    if habit.introduced_at is not None:
+        days_accountable = (now.date() - habit.introduced_at).days
+        if days_accountable >= STABILITY_MIN_ACCOUNTABLE_DAYS:
+            window_start = now.date() - timedelta(
+                days=STABILITY_NO_MISS_WINDOW_DAYS,
+            )
+            completions_7d = (
+                db.query(sa_func.count(HabitCompletion.id))
+                .filter(
+                    HabitCompletion.habit_id == habit.id,
+                    HabitCompletion.completed_at >= window_start,
+                )
+                .scalar()
+            )
+            # "No missed completions" — at least one completion per day
+            # for the last 7 days
+            if completions_7d >= STABILITY_NO_MISS_WINDOW_DAYS:
+                return HabitStabilityInfo(
+                    habit_id=habit.id,
+                    habit_name=habit.title,
+                    scaffolding_status=habit.scaffolding_status,
+                    notification_frequency=habit.notification_frequency,
+                    is_stable=True,
+                    stability_detail=(
+                        f"Accountable {days_accountable} days, "
+                        f"no missed completions in last "
+                        f"{STABILITY_NO_MISS_WINDOW_DAYS} days"
+                    ),
+                )
+
+    # Not stable — blocking
+    detail_parts = [f"{rate:.0%} already-done rate"]
+    if habit.introduced_at is not None:
+        days = (now.date() - habit.introduced_at).days
+        detail_parts.append(f"{days} days accountable")
+    return HabitStabilityInfo(
+        habit_id=habit.id,
+        habit_name=habit.title,
+        scaffolding_status=habit.scaffolding_status,
+        notification_frequency=habit.notification_frequency,
+        is_stable=False,
+        stability_detail="Not yet stable: " + ", ".join(detail_parts),
+    )
+
+
+def get_stacking_recommendation(
+    db: Session,
+    routine_id: UUID,
+) -> StackingRecommendation:
+    """Evaluate whether a routine is ready for a new accountable habit.
+
+    Assesses stability of all current accountable habits, determines readiness,
+    and suggests the next habit to introduce if ready. Read-only — does not
+    modify any state.
+    """
+    routine = db.query(Routine).filter(Routine.id == routine_id).first()
+    if routine is None:
+        raise HTTPException(status_code=404, detail="Routine not found")
+
+    # Load all habits in this routine
+    active_habits = (
+        db.query(Habit)
+        .filter(Habit.routine_id == routine_id, Habit.status == "active")
+        .all()
+    )
+    paused_habits = (
+        db.query(Habit)
+        .filter(Habit.routine_id == routine_id, Habit.status == "paused")
+        .all()
+    )
+
+    # Freeform routine: no habits at all
+    if not active_habits and not paused_habits:
+        return StackingRecommendation(
+            ready=True,
+            routine_id=routine_id,
+            routine_name=routine.title,
+            active_accountable_habits=[],
+            blocking_habits=[],
+            suggested_next=None,
+            message=(
+                "This is a freeform routine with no habits. "
+                "Stacking doesn't apply."
+            ),
+        )
+
+    # Assess stability of accountable habits
+    accountable_habits = [
+        h for h in active_habits if h.scaffolding_status == "accountable"
+    ]
+    stability_infos: list[HabitStabilityInfo] = []
+    blocking: list[HabitStabilityInfo] = []
+
+    for habit in accountable_habits:
+        info = _assess_habit_stability(db, habit)
+        stability_infos.append(info)
+        if not info.is_stable:
+            blocking.append(info)
+
+    # Determine readiness
+    ready = len(blocking) == 0
+
+    # No accountable habits — ready for first one
+    if not accountable_habits:
+        ready = True
+
+    # Suggest next habit if ready
+    suggested_next: SuggestedHabit | None = None
+
+    if ready:
+        # Priority 1: Paused habits with scaffolding_status='tracking',
+        # ordered by introduced_at (oldest first)
+        paused_tracking = [
+            h for h in paused_habits
+            if h.scaffolding_status == "tracking"
+        ]
+        paused_tracking.sort(
+            key=lambda h: h.introduced_at or datetime.min.date(),
+        )
+
+        if paused_tracking:
+            pick = paused_tracking[0]
+            suggested_next = SuggestedHabit(
+                habit_id=pick.id,
+                habit_name=pick.title,
+                source="paused",
+                reason=(
+                    "Previously started but paused — resuming is preferred "
+                    "over starting something new"
+                ),
+            )
+        else:
+            # Priority 2: Active tracking habits, ordered by created_at
+            # (position field not yet available — using created_at as proxy)
+            active_tracking = [
+                h for h in active_habits
+                if h.scaffolding_status == "tracking"
+            ]
+            active_tracking.sort(key=lambda h: h.created_at)
+
+            if active_tracking:
+                pick = active_tracking[0]
+                suggested_next = SuggestedHabit(
+                    habit_id=pick.id,
+                    habit_name=pick.title,
+                    source="queued",
+                    reason="Next in routine order",
+                )
+
+    # Build context-appropriate message
+    if not ready:
+        # Pick first blocking habit for message
+        blocker = blocking[0]
+        rate_str = blocker.stability_detail
+        message = (
+            f"Hold steady — {blocker.habit_name} needs more time before "
+            f"adding another habit. {rate_str}."
+        )
+    elif not accountable_habits:
+        message = (
+            f"No habits are in the accountability loop for "
+            f"{routine.title} yet. Pick one to start with."
+        )
+    elif suggested_next is not None:
+        message = (
+            f"You've been consistent with your current habits. "
+            f"Ready to add {suggested_next.habit_name} to {routine.title}?"
+        )
+    else:
+        message = (
+            f"All habits in {routine.title} are in the scaffolding "
+            f"pipeline. Nice work."
+        )
+
+    return StackingRecommendation(
+        ready=ready,
+        routine_id=routine_id,
+        routine_name=routine.title,
+        active_accountable_habits=stability_infos,
+        blocking_habits=blocking,
+        suggested_next=suggested_next,
+        message=message,
     )

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -36,7 +36,6 @@ from app.services.graduation import (
     GraduationResult,
     ReScaffoldResult,
     SlipDetectionResult,
-    StackingRecommendation,
     apply_frequency_step_down,
     apply_re_scaffold_tightening,
     evaluate_all_graduated_habits,
@@ -1783,7 +1782,7 @@ class TestGetStackingRecommendation:
             _create_notification(db, habit.id, "Done now", "responded", days_ago=i + 8)
 
         # Add a tracking habit to be suggested
-        tracking = _create_habit(
+        _create_habit(
             db, routine_id=routine.id, scaffolding_status="tracking",
             title="Next Habit",
         )
@@ -1830,7 +1829,8 @@ class TestGetStackingRecommendation:
 
         assert result.ready is True
         assert result.active_accountable_habits[0].is_stable is True
-        assert "no missed completions" in result.active_accountable_habits[0].stability_detail.lower()
+        detail = result.active_accountable_habits[0].stability_detail
+        assert "no missed completions" in detail.lower()
 
     def test_one_blocking_habit(self, db):
         """Not ready when an accountable habit has low rate and no completions."""
@@ -1858,13 +1858,13 @@ class TestGetStackingRecommendation:
         routine = _create_routine(db)
 
         # Active tracking habit created first
-        active_tracking = _create_habit(
+        _create_habit(
             db, routine_id=routine.id, scaffolding_status="tracking",
             status="active", title="Active Tracking",
         )
 
         # Paused tracking habit
-        paused_tracking = _create_habit(
+        _create_habit(
             db, routine_id=routine.id, scaffolding_status="tracking",
             status="paused", title="Paused Tracking",
             introduced_at=date.today() - timedelta(days=30),
@@ -1881,12 +1881,12 @@ class TestGetStackingRecommendation:
         """Multiple paused habits: oldest introduced_at is suggested first."""
         routine = _create_routine(db)
 
-        newer = _create_habit(
+        _create_habit(
             db, routine_id=routine.id, scaffolding_status="tracking",
             status="paused", title="Newer Paused",
             introduced_at=date.today() - timedelta(days=5),
         )
-        older = _create_habit(
+        _create_habit(
             db, routine_id=routine.id, scaffolding_status="tracking",
             status="paused", title="Older Paused",
             introduced_at=date.today() - timedelta(days=30),
@@ -1902,11 +1902,11 @@ class TestGetStackingRecommendation:
         routine = _create_routine(db)
 
         # Create in order — first created should be suggested
-        first = _create_habit(
+        _create_habit(
             db, routine_id=routine.id, scaffolding_status="tracking",
             status="active", title="First Tracking",
         )
-        second = _create_habit(
+        _create_habit(
             db, routine_id=routine.id, scaffolding_status="tracking",
             status="active", title="Second Tracking",
         )

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -36,12 +36,14 @@ from app.services.graduation import (
     GraduationResult,
     ReScaffoldResult,
     SlipDetectionResult,
+    StackingRecommendation,
     apply_frequency_step_down,
     apply_re_scaffold_tightening,
     evaluate_all_graduated_habits,
     evaluate_frequency_step_down,
     evaluate_graduated_habit_slip,
     evaluate_graduation,
+    get_stacking_recommendation,
     graduate_habit,
     next_step_down,
     re_scaffold_habit,
@@ -1722,3 +1724,265 @@ class TestReScaffoldHabit:
         with pytest.raises(Exception) as exc_info:
             re_scaffold_habit(db, uuid.uuid4())
         assert exc_info.value.status_code == 404
+
+
+# ===========================================================================
+# [2G-05] Stacking Recommendation Engine
+# ===========================================================================
+
+
+class TestGetStackingRecommendation:
+    """Tests for get_stacking_recommendation()."""
+
+    def test_nonexistent_routine_404(self, db):
+        """Nonexistent routine_id raises 404."""
+        with pytest.raises(Exception) as exc_info:
+            get_stacking_recommendation(db, uuid.uuid4())
+        assert exc_info.value.status_code == 404
+
+    def test_freeform_routine_no_habits(self, db):
+        """Routine with no habits returns ready=True, no suggestion."""
+        routine = _create_routine(db)
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.ready is True
+        assert result.suggested_next is None
+        assert result.active_accountable_habits == []
+        assert result.blocking_habits == []
+        assert "freeform" in result.message.lower()
+
+    def test_no_accountable_habits_ready(self, db):
+        """Routine with only tracking habits returns ready=True."""
+        routine = _create_routine(db)
+        _create_habit(
+            db, routine_id=routine.id, scaffolding_status="tracking",
+            title="Tracking Habit",
+        )
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.ready is True
+        assert result.active_accountable_habits == []
+        assert result.blocking_habits == []
+        assert "no habits are in the accountability loop" in result.message.lower()
+        assert result.suggested_next is not None
+        assert result.suggested_next.habit_name == "Tracking Habit"
+        assert result.suggested_next.source == "queued"
+
+    def test_all_accountable_stable_rate(self, db):
+        """Ready when all accountable habits have >= 60% already-done rate."""
+        routine = _create_routine(db)
+        habit = _create_habit(
+            db, routine_id=routine.id, scaffolding_status="accountable",
+            title="Stable Habit", notification_frequency="daily",
+            introduced_at=date.today() - timedelta(days=30),
+        )
+        # Create 10 notifications: 7 "Already done" = 70% rate
+        for i in range(7):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+        for i in range(3):
+            _create_notification(db, habit.id, "Done now", "responded", days_ago=i + 8)
+
+        # Add a tracking habit to be suggested
+        tracking = _create_habit(
+            db, routine_id=routine.id, scaffolding_status="tracking",
+            title="Next Habit",
+        )
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.ready is True
+        assert len(result.active_accountable_habits) == 1
+        assert result.active_accountable_habits[0].is_stable is True
+        assert result.blocking_habits == []
+        assert result.suggested_next is not None
+        assert result.suggested_next.habit_name == "Next Habit"
+        assert "ready to add" in result.message.lower()
+
+    def test_accountable_habit_at_weekly_is_stable(self, db):
+        """A habit at weekly frequency is stable regardless of rate."""
+        routine = _create_routine(db)
+        _create_habit(
+            db, routine_id=routine.id, scaffolding_status="accountable",
+            title="Weekly Habit", notification_frequency="weekly",
+            introduced_at=date.today() - timedelta(days=30),
+        )
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.ready is True
+        assert len(result.active_accountable_habits) == 1
+        assert result.active_accountable_habits[0].is_stable is True
+        assert "weekly" in result.active_accountable_habits[0].stability_detail.lower()
+
+    def test_accountable_habit_stable_by_completions(self, db):
+        """Stable via 14+ days accountable with 7 consecutive completions."""
+        routine = _create_routine(db)
+        habit = _create_habit(
+            db, routine_id=routine.id, scaffolding_status="accountable",
+            title="Consistent Habit", notification_frequency="daily",
+            introduced_at=date.today() - timedelta(days=20),
+        )
+        # No notifications (rate would be 0), but 7 completions in last 7 days
+        for i in range(7):
+            _create_completion(db, habit.id, days_ago=i)
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.ready is True
+        assert result.active_accountable_habits[0].is_stable is True
+        assert "no missed completions" in result.active_accountable_habits[0].stability_detail.lower()
+
+    def test_one_blocking_habit(self, db):
+        """Not ready when an accountable habit has low rate and no completions."""
+        routine = _create_routine(db)
+        habit = _create_habit(
+            db, routine_id=routine.id, scaffolding_status="accountable",
+            title="Struggling Habit", notification_frequency="daily",
+            introduced_at=date.today() - timedelta(days=10),
+        )
+        # 10 notifications: 3 "Already done" = 30% rate (below 60%)
+        for i in range(3):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+        for i in range(7):
+            _create_notification(db, habit.id, "Done now", "responded", days_ago=i + 4)
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.ready is False
+        assert len(result.blocking_habits) == 1
+        assert result.blocking_habits[0].habit_name == "Struggling Habit"
+        assert "hold steady" in result.message.lower()
+
+    def test_paused_before_tracking_priority(self, db):
+        """Paused tracking habits are suggested before active tracking habits."""
+        routine = _create_routine(db)
+
+        # Active tracking habit created first
+        active_tracking = _create_habit(
+            db, routine_id=routine.id, scaffolding_status="tracking",
+            status="active", title="Active Tracking",
+        )
+
+        # Paused tracking habit
+        paused_tracking = _create_habit(
+            db, routine_id=routine.id, scaffolding_status="tracking",
+            status="paused", title="Paused Tracking",
+            introduced_at=date.today() - timedelta(days=30),
+        )
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.ready is True
+        assert result.suggested_next is not None
+        assert result.suggested_next.habit_name == "Paused Tracking"
+        assert result.suggested_next.source == "paused"
+
+    def test_paused_ordered_by_introduced_at(self, db):
+        """Multiple paused habits: oldest introduced_at is suggested first."""
+        routine = _create_routine(db)
+
+        newer = _create_habit(
+            db, routine_id=routine.id, scaffolding_status="tracking",
+            status="paused", title="Newer Paused",
+            introduced_at=date.today() - timedelta(days=5),
+        )
+        older = _create_habit(
+            db, routine_id=routine.id, scaffolding_status="tracking",
+            status="paused", title="Older Paused",
+            introduced_at=date.today() - timedelta(days=30),
+        )
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.suggested_next is not None
+        assert result.suggested_next.habit_name == "Older Paused"
+
+    def test_tracking_ordered_by_created_at(self, db):
+        """Multiple tracking habits: ordered by created_at (position proxy)."""
+        routine = _create_routine(db)
+
+        # Create in order — first created should be suggested
+        first = _create_habit(
+            db, routine_id=routine.id, scaffolding_status="tracking",
+            status="active", title="First Tracking",
+        )
+        second = _create_habit(
+            db, routine_id=routine.id, scaffolding_status="tracking",
+            status="active", title="Second Tracking",
+        )
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.suggested_next is not None
+        assert result.suggested_next.habit_name == "First Tracking"
+        assert result.suggested_next.source == "queued"
+
+    def test_all_graduated_no_suggestion(self, db):
+        """All habits graduated — ready but nothing to suggest."""
+        routine = _create_routine(db)
+        _create_habit(
+            db, routine_id=routine.id, scaffolding_status="graduated",
+            status="active", title="Graduated One",
+            notification_frequency="graduated",
+        )
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.ready is True
+        assert result.suggested_next is None
+        assert result.active_accountable_habits == []
+        assert "no habits are in the accountability loop" in result.message.lower()
+
+    def test_all_accountable_or_graduated_no_suggestion(self, db):
+        """All habits are either accountable (stable) or graduated — no tracking left."""
+        routine = _create_routine(db)
+        # Stable accountable habit (weekly)
+        _create_habit(
+            db, routine_id=routine.id, scaffolding_status="accountable",
+            title="Weekly Habit", notification_frequency="weekly",
+        )
+        # Graduated habit
+        _create_habit(
+            db, routine_id=routine.id, scaffolding_status="graduated",
+            status="active", title="Graduated",
+            notification_frequency="graduated",
+        )
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.ready is True
+        assert result.suggested_next is None
+        assert "pipeline" in result.message.lower()
+
+    def test_routine_name_in_response(self, db):
+        """Response includes the routine name."""
+        routine = _create_routine(db)
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.routine_id == routine.id
+        assert result.routine_name == routine.title
+
+    def test_mixed_stable_and_blocking(self, db):
+        """One stable + one blocking = not ready."""
+        routine = _create_routine(db)
+
+        # Stable habit (weekly)
+        _create_habit(
+            db, routine_id=routine.id, scaffolding_status="accountable",
+            title="Stable One", notification_frequency="weekly",
+        )
+        # Blocking habit (low rate, few days)
+        blocking = _create_habit(
+            db, routine_id=routine.id, scaffolding_status="accountable",
+            title="Needs Work", notification_frequency="daily",
+            introduced_at=date.today() - timedelta(days=5),
+        )
+        for i in range(6):
+            _create_notification(db, blocking.id, "Done now", "responded", days_ago=i + 1)
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.ready is False
+        assert len(result.active_accountable_habits) == 2
+        assert len(result.blocking_habits) == 1
+        assert result.blocking_habits[0].habit_name == "Needs Work"


### PR DESCRIPTION
## Summary
Implements the "one habit at a time" stacking recommendation logic — the system's resistance to the ADHD pattern of enthusiastically committing to many habits simultaneously and abandoning all of them. The engine evaluates whether current accountable habits in a routine are stable enough to introduce a new one, and if so, suggests what to introduce next.

## Changes
- **app/services/graduation.py** — Added `get_stacking_recommendation()` service function with three new Pydantic schemas (`StackingRecommendation`, `HabitStabilityInfo`, `SuggestedHabit`). Added private `_assess_habit_stability()` helper that reuses `evaluate_frequency_step_down()` in read-only mode. Added module-level constants for stability criteria (14-day minimum, 7-day no-miss window).
- **tests/test_graduation.py** — Added `TestGetStackingRecommendation` class with 14 tests covering all acceptance criteria.

## How to Verify
```bash
cd brain3
git checkout feature/2G-05-stacking-recommendation
python -m pytest tests/test_graduation.py -v -k "TestGetStacking"
# All 14 tests should pass
python -m pytest tests/test_graduation.py -v
# Full suite: 126 passed, 0 failures
```

## Deviations
- **Sync instead of async:** Spec defines `async def get_stacking_recommendation(db: AsyncSession, ...)` but the existing codebase uses synchronous `Session` throughout. Followed the established pattern to maintain consistency. When the codebase migrates to async, this function moves with it.
- **`created_at` instead of `position`:** Spec references a `position` field from Stream A for ordering tracking habits within a routine. This field does not exist on the Habit model. Used `created_at` as an ordering proxy. When `position` is added, the sort key can be swapped in one line.

## Test Results
```
14 passed (stacking recommendation tests)
126 passed total (full graduation suite, 0 regressions)
```

## Acceptance Checklist
- [x] `get_stacking_recommendation()` returns `ready=True` when all accountable habits are stable
- [x] Returns `ready=True` when no habits are accountable yet (first habit scenario)
- [x] Returns `ready=False` when any accountable habit is blocking, with details
- [x] Suggests paused habits before tracking habits (priority order)
- [x] Orders paused suggestions by `introduced_at` (oldest first)
- [x] Orders tracking suggestions by `created_at` (position proxy)
- [x] Returns `suggested_next=None` when all habits are accountable or graduated
- [x] Handles freeform routines gracefully (no habits → ready, no suggestion)
- [x] Returns 404 for non-existent routine
- [x] Messages are context-appropriate and human-readable
- [x] Tests cover: all stable, one blocking, no accountable, all graduated, paused available, only tracking, freeform routine, nonexistent routine, mixed stable+blocking