### PR TITLE
2G-06: Graduation API Endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.routers import (
     directives,
     domains,
     goals,
+    graduation,
     habits,
     notification,
     projects,
@@ -105,6 +106,12 @@ app.include_router(
     notification.router, prefix="/api/notifications", tags=["Notifications"],
 )
 app.include_router(rules.router, prefix="/api/rules", tags=["Rules"])
+app.include_router(
+    graduation.habit_graduation_router, prefix="/api/habits", tags=["Graduation"],
+)
+app.include_router(
+    graduation.graduation_router, prefix="/api/graduation", tags=["Graduation"],
+)
 app.include_router(
     skills.skill_domains_router, prefix="/api/skills", tags=["Skill Domains"],
 )

--- a/app/routers/graduation.py
+++ b/app/routers/graduation.py
@@ -43,8 +43,8 @@ from app.services.graduation import (
     apply_frequency_step_down,
     evaluate_all_graduated_habits,
     evaluate_frequency_step_down,
-    evaluate_graduation,
     evaluate_graduated_habit_slip,
+    evaluate_graduation,
     get_stacking_recommendation,
     graduate_habit,
     re_scaffold_habit,
@@ -127,7 +127,10 @@ def evaluate_graduation_endpoint(
     if habit.scaffolding_status != "accountable":
         raise HTTPException(
             status_code=422,
-            detail=f"Habit scaffolding_status is '{habit.scaffolding_status}', must be 'accountable'",
+            detail=(
+                f"Habit scaffolding_status is '{habit.scaffolding_status}', "
+                "must be 'accountable'"
+            ),
         )
 
     return evaluate_graduation(db, habit_id)
@@ -167,7 +170,10 @@ def graduate_habit_endpoint(
     if habit.scaffolding_status != "accountable":
         raise HTTPException(
             status_code=422,
-            detail=f"Habit scaffolding_status is '{habit.scaffolding_status}', must be 'accountable'",
+            detail=(
+                f"Habit scaffolding_status is '{habit.scaffolding_status}', "
+                "must be 'accountable'"
+            ),
         )
 
     result = graduate_habit(db, habit_id, force=force)
@@ -178,7 +184,10 @@ def graduate_habit_endpoint(
             status_code=422,
             detail={
                 "message": "Habit is not eligible for graduation",
-                "evaluation": result.evaluation.model_dump(mode="json") if result.evaluation else None,
+                "evaluation": (
+                    result.evaluation.model_dump(mode="json")
+                    if result.evaluation else None
+                ),
             },
         )
 

--- a/app/routers/graduation.py
+++ b/app/routers/graduation.py
@@ -1,0 +1,433 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Graduation API endpoints — thin wrappers over the graduation service layer.
+
+Habit-scoped endpoints (evaluate-graduation, graduate, evaluate-frequency,
+step-down-frequency, evaluate-slip, re-scaffold, graduation-status) are
+mounted under /api/habits/{habit_id}/... via habit_graduation_router.
+
+Graduation-scoped endpoints (suggest-next, evaluate-all-slips) are mounted
+under /api/graduation/... via graduation_router.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import Habit
+from app.services.graduation import (
+    FrequencyChangeResult,
+    FrequencyStepResult,
+    GraduationExecutionResult,
+    GraduationResult,
+    ReScaffoldResult,
+    SlipDetectionResult,
+    StackingRecommendation,
+    apply_frequency_step_down,
+    evaluate_all_graduated_habits,
+    evaluate_frequency_step_down,
+    evaluate_graduation,
+    evaluate_graduated_habit_slip,
+    get_stacking_recommendation,
+    graduate_habit,
+    re_scaffold_habit,
+)
+from app.services.graduation_defaults import resolve_graduation_params
+
+# ---------------------------------------------------------------------------
+# Routers
+# ---------------------------------------------------------------------------
+
+# Mounted at /api/habits in main.py (alongside existing habits router)
+habit_graduation_router = APIRouter()
+
+# Mounted at /api/graduation in main.py
+graduation_router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+
+class GraduateRequest(BaseModel):
+    """Request body for the graduate endpoint."""
+    force: bool = False
+
+
+class GraduationStatusResponse(BaseModel):
+    """Composite graduation status for dashboard display."""
+    habit_id: UUID
+    habit_name: str
+    scaffolding_status: str
+    notification_frequency: str
+    friction_score: int | None
+    re_scaffold_count: int
+    introduced_at: str | None
+    days_since_introduction: int
+    graduation_params: dict
+    current_metrics: dict
+    progress_summary: str
+    frequency_step_down: dict
+
+
+class BatchSlipResponse(BaseModel):
+    """Response from batch slip evaluation."""
+    evaluated_count: int
+    attention_needed: list[SlipDetectionResult]
+
+
+# ---------------------------------------------------------------------------
+# Helper — resolve habit or 404
+# ---------------------------------------------------------------------------
+
+def _get_habit_or_404(db: Session, habit_id: UUID) -> Habit:
+    """Fetch a habit by ID or raise 404."""
+    habit = db.query(Habit).filter(Habit.id == habit_id).first()
+    if habit is None:
+        raise HTTPException(status_code=404, detail="Habit not found")
+    return habit
+
+
+# ---------------------------------------------------------------------------
+# 1. POST /api/habits/{habit_id}/evaluate-graduation
+# ---------------------------------------------------------------------------
+
+@habit_graduation_router.post(
+    "/{habit_id}/evaluate-graduation",
+    response_model=GraduationResult,
+)
+def evaluate_graduation_endpoint(
+    habit_id: UUID, db: Session = Depends(get_db),
+) -> GraduationResult:
+    """Dry-run graduation evaluation. Returns eligibility metrics without changing state."""
+    habit = _get_habit_or_404(db, habit_id)
+
+    if habit.status != "active":
+        raise HTTPException(
+            status_code=422,
+            detail=f"Habit status is '{habit.status}', must be 'active'",
+        )
+    if habit.scaffolding_status != "accountable":
+        raise HTTPException(
+            status_code=422,
+            detail=f"Habit scaffolding_status is '{habit.scaffolding_status}', must be 'accountable'",
+        )
+
+    return evaluate_graduation(db, habit_id)
+
+
+# ---------------------------------------------------------------------------
+# 2. POST /api/habits/{habit_id}/graduate
+# ---------------------------------------------------------------------------
+
+@habit_graduation_router.post(
+    "/{habit_id}/graduate",
+    response_model=GraduationExecutionResult,
+)
+def graduate_habit_endpoint(
+    habit_id: UUID,
+    payload: GraduateRequest | None = None,
+    db: Session = Depends(get_db),
+) -> GraduationExecutionResult:
+    """Execute graduation. Optionally force-graduate."""
+    habit = _get_habit_or_404(db, habit_id)
+
+    force = payload.force if payload else False
+
+    # Already graduated — 409
+    if habit.scaffolding_status == "graduated":
+        raise HTTPException(
+            status_code=409,
+            detail="Habit is already graduated",
+        )
+
+    # Status preconditions — 422
+    if habit.status != "active":
+        raise HTTPException(
+            status_code=422,
+            detail=f"Habit status is '{habit.status}', must be 'active'",
+        )
+    if habit.scaffolding_status != "accountable":
+        raise HTTPException(
+            status_code=422,
+            detail=f"Habit scaffolding_status is '{habit.scaffolding_status}', must be 'accountable'",
+        )
+
+    result = graduate_habit(db, habit_id, force=force)
+
+    # If the service returned success=False (not eligible, force=False), return 422
+    if not result.success and not force:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": "Habit is not eligible for graduation",
+                "evaluation": result.evaluation.model_dump(mode="json") if result.evaluation else None,
+            },
+        )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 3. POST /api/habits/{habit_id}/evaluate-frequency
+# ---------------------------------------------------------------------------
+
+@habit_graduation_router.post(
+    "/{habit_id}/evaluate-frequency",
+    response_model=FrequencyStepResult,
+)
+def evaluate_frequency_endpoint(
+    habit_id: UUID, db: Session = Depends(get_db),
+) -> FrequencyStepResult:
+    """Check if a habit should step down its notification frequency. Read-only."""
+    _get_habit_or_404(db, habit_id)
+    return evaluate_frequency_step_down(db, habit_id)
+
+
+# ---------------------------------------------------------------------------
+# 4. POST /api/habits/{habit_id}/step-down-frequency
+# ---------------------------------------------------------------------------
+
+@habit_graduation_router.post(
+    "/{habit_id}/step-down-frequency",
+    response_model=FrequencyChangeResult,
+)
+def step_down_frequency_endpoint(
+    habit_id: UUID, db: Session = Depends(get_db),
+) -> FrequencyChangeResult:
+    """Apply a one-level frequency reduction. Validates recommendation first."""
+    _get_habit_or_404(db, habit_id)
+
+    # Evaluate first
+    eval_result = evaluate_frequency_step_down(db, habit_id)
+    if not eval_result.recommend_step_down:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": "Step-down not recommended",
+                "evaluation": eval_result.model_dump(mode="json"),
+            },
+        )
+
+    return apply_frequency_step_down(db, habit_id, eval_result.recommended_frequency)
+
+
+# ---------------------------------------------------------------------------
+# 5. POST /api/habits/{habit_id}/evaluate-slip
+# ---------------------------------------------------------------------------
+
+@habit_graduation_router.post(
+    "/{habit_id}/evaluate-slip",
+    response_model=SlipDetectionResult,
+)
+def evaluate_slip_endpoint(
+    habit_id: UUID, db: Session = Depends(get_db),
+) -> SlipDetectionResult:
+    """Check if a graduated habit shows signs of regression. Read-only."""
+    habit = _get_habit_or_404(db, habit_id)
+
+    if habit.scaffolding_status != "graduated":
+        raise HTTPException(
+            status_code=422,
+            detail=f"Habit scaffolding_status is '{habit.scaffolding_status}', must be 'graduated'",
+        )
+
+    return evaluate_graduated_habit_slip(db, habit_id)
+
+
+# ---------------------------------------------------------------------------
+# 6. POST /api/habits/{habit_id}/re-scaffold
+# ---------------------------------------------------------------------------
+
+@habit_graduation_router.post(
+    "/{habit_id}/re-scaffold",
+    response_model=ReScaffoldResult,
+)
+def re_scaffold_endpoint(
+    habit_id: UUID, db: Session = Depends(get_db),
+) -> ReScaffoldResult:
+    """Reverse graduation and return a habit to daily accountability."""
+    habit = _get_habit_or_404(db, habit_id)
+
+    if habit.scaffolding_status != "graduated":
+        raise HTTPException(
+            status_code=422,
+            detail=f"Habit scaffolding_status is '{habit.scaffolding_status}', must be 'graduated'",
+        )
+
+    return re_scaffold_habit(db, habit_id)
+
+
+# ---------------------------------------------------------------------------
+# 7. GET /api/habits/{habit_id}/graduation-status
+# ---------------------------------------------------------------------------
+
+@habit_graduation_router.get(
+    "/{habit_id}/graduation-status",
+    response_model=GraduationStatusResponse,
+)
+def graduation_status_endpoint(
+    habit_id: UUID, db: Session = Depends(get_db),
+) -> dict:
+    """User-facing dashboard data. Composites evaluation + frequency data."""
+    habit = _get_habit_or_404(db, habit_id)
+
+    # Resolve graduation params
+    from app.services.graduation import apply_re_scaffold_tightening
+
+    window, target, threshold = resolve_graduation_params(habit)
+    source = "per_habit" if any([
+        habit.graduation_window is not None,
+        habit.graduation_target is not None,
+        habit.graduation_threshold is not None,
+    ]) else "friction_default"
+
+    if habit.re_scaffold_count > 0:
+        window, target, threshold = apply_re_scaffold_tightening(
+            window, target, threshold, habit.re_scaffold_count,
+        )
+
+    # Days since introduction
+    from datetime import UTC, datetime
+    now = datetime.now(tz=UTC)
+    if habit.introduced_at is not None:
+        days_since_introduction = (now.date() - habit.introduced_at).days
+    else:
+        days_since_introduction = 0
+
+    # Current metrics — only if accountable
+    current_rate = 0.0
+    total_notifications = 0
+    already_done_count = 0
+    if habit.scaffolding_status == "accountable":
+        try:
+            grad_result = evaluate_graduation(db, habit_id)
+            current_rate = grad_result.current_rate
+            total_notifications = grad_result.total_notifications
+            already_done_count = grad_result.already_done_count
+        except ValueError:
+            pass
+
+    # Build progress summary
+    if habit.scaffolding_status == "graduated":
+        progress_summary = "Habit has graduated."
+    elif habit.scaffolding_status == "tracking":
+        progress_summary = "Habit is in tracking mode. Not yet in accountability loop."
+    else:
+        rate_pct = int(current_rate * 100)
+        target_pct = int(target * 100)
+        remaining_days = max(0, threshold - days_since_introduction)
+        if remaining_days > 0:
+            progress_summary = (
+                f"{rate_pct}% of the way to graduation target ({target_pct}%). "
+                f"{remaining_days} more days until minimum threshold met."
+            )
+        elif current_rate >= target:
+            progress_summary = (
+                f"Meeting graduation target ({rate_pct}% >= {target_pct}%). "
+                f"Ready for graduation evaluation."
+            )
+        else:
+            progress_summary = (
+                f"{rate_pct}% of the way to graduation target ({target_pct}%). "
+                f"Minimum time threshold met."
+            )
+
+    # Frequency step-down info
+    freq_eligible = False
+    freq_recommended = None
+    freq_rate = 0.0
+    if habit.scaffolding_status == "accountable":
+        try:
+            freq_result = evaluate_frequency_step_down(db, habit_id)
+            freq_eligible = freq_result.recommend_step_down
+            freq_recommended = freq_result.recommended_frequency
+            freq_rate = freq_result.current_rate
+        except ValueError:
+            pass
+
+    return {
+        "habit_id": habit.id,
+        "habit_name": habit.title,
+        "scaffolding_status": habit.scaffolding_status,
+        "notification_frequency": habit.notification_frequency,
+        "friction_score": habit.friction_score,
+        "re_scaffold_count": habit.re_scaffold_count,
+        "introduced_at": str(habit.introduced_at) if habit.introduced_at else None,
+        "days_since_introduction": days_since_introduction,
+        "graduation_params": {
+            "window_days": window,
+            "target_rate": target,
+            "threshold_days": threshold,
+            "source": source,
+        },
+        "current_metrics": {
+            "already_done_rate": current_rate,
+            "total_notifications": total_notifications,
+            "already_done_count": already_done_count,
+        },
+        "progress_summary": progress_summary,
+        "frequency_step_down": {
+            "eligible": freq_eligible,
+            "recommended_frequency": freq_recommended,
+            "current_rate_over_recent": freq_rate,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# 8. GET /api/graduation/suggest-next?routine_id={routine_id}
+# ---------------------------------------------------------------------------
+
+@graduation_router.get(
+    "/suggest-next",
+    response_model=StackingRecommendation,
+)
+def suggest_next_endpoint(
+    routine_id: UUID = Query(..., description="The routine to evaluate"),
+    db: Session = Depends(get_db),
+) -> StackingRecommendation:
+    """Check if a routine is ready for a new habit and suggest what to introduce."""
+    return get_stacking_recommendation(db, routine_id)
+
+
+# ---------------------------------------------------------------------------
+# 9. POST /api/graduation/evaluate-all-slips
+# ---------------------------------------------------------------------------
+
+@graduation_router.post(
+    "/evaluate-all-slips",
+    response_model=BatchSlipResponse,
+)
+def evaluate_all_slips_endpoint(
+    db: Session = Depends(get_db),
+) -> dict:
+    """Scheduler endpoint. Evaluates all graduated habits for slip signals."""
+    results = evaluate_all_graduated_habits(db)
+    # The service already filters to only attention-needed results
+    all_graduated = (
+        db.query(Habit)
+        .filter(Habit.scaffolding_status == "graduated", Habit.status == "active")
+        .count()
+    )
+    return {
+        "evaluated_count": all_graduated,
+        "attention_needed": results,
+    }

--- a/tests/test_graduation_endpoints.py
+++ b/tests/test_graduation_endpoints.py
@@ -1,0 +1,567 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for graduation API endpoints ([2G-06])."""
+
+import uuid
+from datetime import UTC, date, datetime, timedelta
+
+from app.models import Domain, Habit, HabitCompletion, NotificationQueue, Routine
+from tests.conftest import FAKE_UUID, make_habit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_habit(db, **overrides) -> Habit:
+    """Insert a Habit directly via ORM."""
+    nullable_grad_fields = ("graduation_window", "graduation_target", "graduation_threshold")
+    force_null = {k for k in nullable_grad_fields if k in overrides and overrides[k] is None}
+    constructor_overrides = {k: v for k, v in overrides.items() if k not in force_null}
+
+    defaults = {
+        "id": uuid.uuid4(),
+        "title": "Test Habit",
+        "status": "active",
+        "frequency": "daily",
+        "notification_frequency": "daily",
+        "scaffolding_status": "accountable",
+        "introduced_at": date.today() - timedelta(days=60),
+    }
+    defaults.update(constructor_overrides)
+    habit = Habit(**defaults)
+    db.add(habit)
+    db.commit()
+
+    if force_null:
+        for field in force_null:
+            setattr(habit, field, None)
+        db.commit()
+
+    db.refresh(habit)
+    return habit
+
+
+def _create_notification(db, habit_id, response, status, days_ago=5):
+    """Insert a notification_queue entry for a habit."""
+    n = NotificationQueue(
+        id=uuid.uuid4(),
+        notification_type="habit_nudge",
+        delivery_type="notification",
+        status=status,
+        scheduled_at=datetime.now(tz=UTC) - timedelta(days=days_ago),
+        target_entity_type="habit",
+        target_entity_id=habit_id,
+        message="Time for your habit!",
+        response=response,
+        scheduled_by="system",
+    )
+    db.add(n)
+    db.commit()
+    return n
+
+
+def _create_routine(db) -> Routine:
+    """Insert a Domain + Routine and return the Routine."""
+    domain = Domain(id=uuid.uuid4(), name="Test Domain")
+    db.add(domain)
+    db.commit()
+    routine = Routine(
+        id=uuid.uuid4(),
+        domain_id=domain.id,
+        title="Test Routine",
+        frequency="daily",
+    )
+    db.add(routine)
+    db.commit()
+    return routine
+
+
+def _create_completion(db, habit_id, days_ago=0):
+    """Insert a habit completion record."""
+    c = HabitCompletion(
+        id=uuid.uuid4(),
+        habit_id=habit_id,
+        completed_at=date.today() - timedelta(days=days_ago),
+        source="individual",
+    )
+    db.add(c)
+    db.commit()
+    return c
+
+
+def _eligible_habit(db, **overrides) -> Habit:
+    """Create a habit that meets graduation criteria."""
+    defaults = {
+        "introduced_at": date.today() - timedelta(days=60),
+        "scaffolding_status": "accountable",
+        "notification_frequency": "daily",
+        "status": "active",
+    }
+    defaults.update(overrides)
+    habit = _create_habit(db, **defaults)
+    for i in range(9):
+        _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+    _create_notification(db, habit.id, "Skip today", "responded", days_ago=10)
+    return habit
+
+
+# ===========================================================================
+# 1. POST /api/habits/{habit_id}/evaluate-graduation
+# ===========================================================================
+
+
+class TestEvaluateGraduationEndpoint:
+
+    def test_happy_path(self, client, db):
+        """Eligible accountable habit returns GraduationResult with eligible=True."""
+        habit = _eligible_habit(db)
+        resp = client.post(f"/api/habits/{habit.id}/evaluate-graduation")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["eligible"] is True
+        assert data["habit_id"] == str(habit.id)
+        assert data["meets_rate"] is True
+        assert data["meets_threshold"] is True
+
+    def test_not_found(self, client):
+        """Nonexistent habit returns 404."""
+        resp = client.post(f"/api/habits/{FAKE_UUID}/evaluate-graduation")
+        assert resp.status_code == 404
+
+    def test_wrong_scaffolding_status(self, client, db):
+        """Habit with scaffolding_status != accountable returns 422."""
+        habit = _create_habit(db, scaffolding_status="tracking")
+        resp = client.post(f"/api/habits/{habit.id}/evaluate-graduation")
+        assert resp.status_code == 422
+        assert "accountable" in resp.json()["detail"]
+
+    def test_graduated_habit_rejected(self, client, db):
+        """Already graduated habit returns 422."""
+        habit = _create_habit(db, scaffolding_status="graduated",
+                              notification_frequency="graduated")
+        resp = client.post(f"/api/habits/{habit.id}/evaluate-graduation")
+        assert resp.status_code == 422
+
+    def test_paused_habit_rejected(self, client, db):
+        """Paused habit returns 422 (wrong status)."""
+        habit = _create_habit(db, status="paused", scaffolding_status="accountable")
+        resp = client.post(f"/api/habits/{habit.id}/evaluate-graduation")
+        assert resp.status_code == 422
+        assert "active" in resp.json()["detail"]
+
+
+# ===========================================================================
+# 2. POST /api/habits/{habit_id}/graduate
+# ===========================================================================
+
+
+class TestGraduateEndpoint:
+
+    def test_happy_path(self, client, db):
+        """Eligible habit graduates successfully."""
+        habit = _eligible_habit(db)
+        resp = client.post(f"/api/habits/{habit.id}/graduate")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert "graduated successfully" in data["message"]
+
+        db.refresh(habit)
+        assert habit.scaffolding_status == "graduated"
+
+    def test_force_graduation(self, client, db):
+        """Force graduation bypasses eligibility check."""
+        habit = _create_habit(db)  # No notifications — not eligible
+        resp = client.post(
+            f"/api/habits/{habit.id}/graduate", json={"force": True},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert "(forced)" in data["message"]
+
+    def test_ineligible_returns_422(self, client, db):
+        """Ineligible habit without force returns 422."""
+        habit = _create_habit(db)  # No notifications — not eligible
+        resp = client.post(f"/api/habits/{habit.id}/graduate")
+        assert resp.status_code == 422
+
+    def test_already_graduated_409(self, client, db):
+        """Already graduated habit returns 409."""
+        habit = _create_habit(db, scaffolding_status="graduated",
+                              notification_frequency="graduated")
+        resp = client.post(f"/api/habits/{habit.id}/graduate")
+        assert resp.status_code == 409
+        assert "already graduated" in resp.json()["detail"]
+
+    def test_not_found(self, client):
+        """Nonexistent habit returns 404."""
+        resp = client.post(f"/api/habits/{FAKE_UUID}/graduate")
+        assert resp.status_code == 404
+
+    def test_wrong_scaffolding_status_422(self, client, db):
+        """Tracking habit returns 422."""
+        habit = _create_habit(db, scaffolding_status="tracking")
+        resp = client.post(f"/api/habits/{habit.id}/graduate")
+        assert resp.status_code == 422
+
+    def test_paused_status_422(self, client, db):
+        """Paused habit returns 422."""
+        habit = _create_habit(db, status="paused", scaffolding_status="accountable")
+        resp = client.post(f"/api/habits/{habit.id}/graduate")
+        assert resp.status_code == 422
+
+
+# ===========================================================================
+# 3. POST /api/habits/{habit_id}/evaluate-frequency
+# ===========================================================================
+
+
+class TestEvaluateFrequencyEndpoint:
+
+    def test_happy_path(self, client, db):
+        """Habit with high rate recommends step-down."""
+        habit = _create_habit(db, notification_frequency="daily")
+        for i in range(10):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+
+        resp = client.post(f"/api/habits/{habit.id}/evaluate-frequency")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["recommend_step_down"] is True
+        assert data["recommended_frequency"] == "every_other_day"
+
+    def test_not_found(self, client):
+        """Nonexistent habit returns 404."""
+        resp = client.post(f"/api/habits/{FAKE_UUID}/evaluate-frequency")
+        assert resp.status_code == 404
+
+    def test_no_recommendation(self, client, db):
+        """Habit with low rate returns recommend_step_down=False."""
+        habit = _create_habit(db, notification_frequency="daily")
+        for i in range(10):
+            _create_notification(db, habit.id, "Skip today", "responded", days_ago=i + 1)
+
+        resp = client.post(f"/api/habits/{habit.id}/evaluate-frequency")
+        assert resp.status_code == 200
+        assert resp.json()["recommend_step_down"] is False
+
+
+# ===========================================================================
+# 4. POST /api/habits/{habit_id}/step-down-frequency
+# ===========================================================================
+
+
+class TestStepDownFrequencyEndpoint:
+
+    def test_happy_path(self, client, db):
+        """Step-down applies when recommended."""
+        habit = _create_habit(db, notification_frequency="daily")
+        for i in range(10):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+
+        resp = client.post(f"/api/habits/{habit.id}/step-down-frequency")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["previous_frequency"] == "daily"
+        assert data["new_frequency"] == "every_other_day"
+
+        db.refresh(habit)
+        assert habit.notification_frequency == "every_other_day"
+
+    def test_not_recommended_422(self, client, db):
+        """Step-down returns 422 when not recommended."""
+        habit = _create_habit(db, notification_frequency="daily")
+        for i in range(10):
+            _create_notification(db, habit.id, "Skip today", "responded", days_ago=i + 1)
+
+        resp = client.post(f"/api/habits/{habit.id}/step-down-frequency")
+        assert resp.status_code == 422
+        assert "not recommended" in resp.json()["detail"]["message"].lower()
+
+    def test_not_found(self, client):
+        """Nonexistent habit returns 404."""
+        resp = client.post(f"/api/habits/{FAKE_UUID}/step-down-frequency")
+        assert resp.status_code == 404
+
+
+# ===========================================================================
+# 5. POST /api/habits/{habit_id}/evaluate-slip
+# ===========================================================================
+
+
+class TestEvaluateSlipEndpoint:
+
+    def test_happy_path_no_slip(self, client, db):
+        """Graduated habit with recent completions shows no slip."""
+        habit = _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+        )
+        for i in range(5):
+            _create_completion(db, habit.id, days_ago=i + 1)
+
+        resp = client.post(f"/api/habits/{habit.id}/evaluate-slip")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["slip_detected"] is False
+        assert data["recommendation"] == "no_action"
+
+    def test_slip_detected(self, client, db):
+        """Graduated habit with no completions shows critical slip."""
+        habit = _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+        )
+        # No completions at all
+
+        resp = client.post(f"/api/habits/{habit.id}/evaluate-slip")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["slip_detected"] is True
+        assert data["recommendation"] == "re_scaffold"
+
+    def test_not_graduated_422(self, client, db):
+        """Non-graduated habit returns 422."""
+        habit = _create_habit(db, scaffolding_status="accountable")
+        resp = client.post(f"/api/habits/{habit.id}/evaluate-slip")
+        assert resp.status_code == 422
+        assert "graduated" in resp.json()["detail"]
+
+    def test_not_found(self, client):
+        """Nonexistent habit returns 404."""
+        resp = client.post(f"/api/habits/{FAKE_UUID}/evaluate-slip")
+        assert resp.status_code == 404
+
+
+# ===========================================================================
+# 6. POST /api/habits/{habit_id}/re-scaffold
+# ===========================================================================
+
+
+class TestReScaffoldEndpoint:
+
+    def test_happy_path(self, client, db):
+        """Graduated habit is re-scaffolded to daily accountability."""
+        habit = _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+            friction_score=1, graduation_window=None, graduation_target=None,
+            graduation_threshold=None,
+        )
+        resp = client.post(f"/api/habits/{habit.id}/re-scaffold")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["previous_scaffolding_status"] == "graduated"
+        assert data["new_notification_frequency"] == "daily"
+        assert data["re_scaffold_count"] == 1
+
+        db.refresh(habit)
+        assert habit.scaffolding_status == "accountable"
+        assert habit.notification_frequency == "daily"
+
+    def test_not_graduated_422(self, client, db):
+        """Non-graduated habit returns 422."""
+        habit = _create_habit(db, scaffolding_status="accountable")
+        resp = client.post(f"/api/habits/{habit.id}/re-scaffold")
+        assert resp.status_code == 422
+        assert "graduated" in resp.json()["detail"]
+
+    def test_not_found(self, client):
+        """Nonexistent habit returns 404."""
+        resp = client.post(f"/api/habits/{FAKE_UUID}/re-scaffold")
+        assert resp.status_code == 404
+
+
+# ===========================================================================
+# 7. GET /api/habits/{habit_id}/graduation-status
+# ===========================================================================
+
+
+class TestGraduationStatusEndpoint:
+
+    def test_happy_path_accountable(self, client, db):
+        """Accountable habit returns composite graduation status."""
+        habit = _eligible_habit(db, friction_score=3)
+        resp = client.get(f"/api/habits/{habit.id}/graduation-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["habit_id"] == str(habit.id)
+        assert data["scaffolding_status"] == "accountable"
+        assert "graduation_params" in data
+        assert "current_metrics" in data
+        assert "progress_summary" in data
+        assert "frequency_step_down" in data
+        assert data["current_metrics"]["total_notifications"] > 0
+
+    def test_graduated_habit_status(self, client, db):
+        """Graduated habit returns appropriate progress summary."""
+        habit = _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+        )
+        resp = client.get(f"/api/habits/{habit.id}/graduation-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["scaffolding_status"] == "graduated"
+        assert "graduated" in data["progress_summary"].lower()
+
+    def test_tracking_habit_status(self, client, db):
+        """Tracking habit returns appropriate progress summary."""
+        habit = _create_habit(db, scaffolding_status="tracking")
+        resp = client.get(f"/api/habits/{habit.id}/graduation-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["scaffolding_status"] == "tracking"
+        assert "tracking" in data["progress_summary"].lower()
+
+    def test_not_found(self, client):
+        """Nonexistent habit returns 404."""
+        resp = client.get(f"/api/habits/{FAKE_UUID}/graduation-status")
+        assert resp.status_code == 404
+
+    def test_includes_frequency_step_down(self, client, db):
+        """Status response includes frequency step-down evaluation."""
+        habit = _create_habit(db, notification_frequency="daily")
+        for i in range(10):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+
+        resp = client.get(f"/api/habits/{habit.id}/graduation-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["frequency_step_down"]["eligible"] is True
+        assert data["frequency_step_down"]["recommended_frequency"] == "every_other_day"
+
+
+# ===========================================================================
+# 8. GET /api/graduation/suggest-next?routine_id={routine_id}
+# ===========================================================================
+
+
+class TestSuggestNextEndpoint:
+
+    def test_happy_path(self, client, db):
+        """Routine with stable habits returns a suggestion."""
+        routine = _create_routine(db)
+        # Stable accountable habit (weekly)
+        _create_habit(
+            db, routine_id=routine.id, scaffolding_status="accountable",
+            title="Weekly Habit", notification_frequency="weekly",
+        )
+        # Tracking habit to suggest
+        _create_habit(
+            db, routine_id=routine.id, scaffolding_status="tracking",
+            title="Next Habit",
+        )
+
+        resp = client.get(
+            "/api/graduation/suggest-next", params={"routine_id": str(routine.id)},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ready"] is True
+        assert data["suggested_next"] is not None
+        assert data["suggested_next"]["habit_name"] == "Next Habit"
+
+    def test_missing_routine_id_422(self, client):
+        """Missing routine_id query param returns 422."""
+        resp = client.get("/api/graduation/suggest-next")
+        assert resp.status_code == 422
+
+    def test_routine_not_found(self, client):
+        """Nonexistent routine returns 404."""
+        resp = client.get(
+            "/api/graduation/suggest-next", params={"routine_id": FAKE_UUID},
+        )
+        assert resp.status_code == 404
+
+    def test_freeform_routine(self, client, db):
+        """Routine with no habits returns ready=True."""
+        routine = _create_routine(db)
+        resp = client.get(
+            "/api/graduation/suggest-next", params={"routine_id": str(routine.id)},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ready"] is True
+        assert data["suggested_next"] is None
+
+
+# ===========================================================================
+# 9. POST /api/graduation/evaluate-all-slips
+# ===========================================================================
+
+
+class TestEvaluateAllSlipsEndpoint:
+
+    def test_happy_path_no_slips(self, client, db):
+        """No graduated habits returns evaluated_count=0."""
+        resp = client.post("/api/graduation/evaluate-all-slips")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["evaluated_count"] == 0
+        assert data["attention_needed"] == []
+
+    def test_with_slipping_habit(self, client, db):
+        """Graduated habit with no completions appears in attention_needed."""
+        habit = _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+            title="Slipping Habit",
+        )
+
+        resp = client.post("/api/graduation/evaluate-all-slips")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["evaluated_count"] == 1
+        assert len(data["attention_needed"]) == 1
+        assert data["attention_needed"][0]["habit_id"] == str(habit.id)
+
+    def test_healthy_graduated_not_in_attention(self, client, db):
+        """Graduated habit with recent completions is NOT in attention_needed."""
+        habit = _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+        )
+        for i in range(5):
+            _create_completion(db, habit.id, days_ago=i + 1)
+
+        resp = client.post("/api/graduation/evaluate-all-slips")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["evaluated_count"] == 1
+        assert data["attention_needed"] == []
+
+    def test_mixed_graduated_habits(self, client, db):
+        """Only slipping habits appear in attention_needed."""
+        # Healthy graduated habit
+        good = _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+            title="Healthy",
+        )
+        for i in range(5):
+            _create_completion(db, good.id, days_ago=i + 1)
+
+        # Slipping graduated habit
+        bad = _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+            title="Slipping",
+        )
+
+        resp = client.post("/api/graduation/evaluate-all-slips")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["evaluated_count"] == 2
+        assert len(data["attention_needed"]) == 1
+        assert data["attention_needed"][0]["habit_id"] == str(bad.id)

--- a/tests/test_graduation_endpoints.py
+++ b/tests/test_graduation_endpoints.py
@@ -19,9 +19,8 @@
 import uuid
 from datetime import UTC, date, datetime, timedelta
 
-from app.models import Domain, Habit, HabitCompletion, NotificationQueue, Routine
-from tests.conftest import FAKE_UUID, make_habit
-
+from app.models import Domain, Habit, HabitCompletion, NotificationQueue, Routine  # noqa: I001
+from tests.conftest import FAKE_UUID
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary
Implements 9 REST API endpoints that expose the graduation service layer (2G-01 through 2G-05) over HTTP. Thin wrappers — all business logic remains in `app/services/graduation.py`. Two routers: `habit_graduation_router` mounted at `/api/habits` for habit-scoped operations, and `graduation_router` mounted at `/api/graduation` for cross-cutting operations.

## Changes
- **app/routers/graduation.py** (new): 9 endpoints across two routers. Request/response schemas (`GraduateRequest`, `GraduationStatusResponse`, `BatchSlipResponse`) defined inline. Helper `_get_habit_or_404` for DRY 404 handling.
- **app/main.py**: Import graduation module and register both routers with `/api/habits` and `/api/graduation` prefixes under the "Graduation" tag.
- **tests/test_graduation_endpoints.py** (new): 38 HTTP-layer tests covering all 9 endpoints — happy paths, 404s, 422s, 409, and filter behaviors.

## How to Verify
1. `python -m pytest tests/test_graduation_endpoints.py -v` — 38 tests pass
2. `python -m pytest` — full suite (1237 tests) passes with no regressions
3. Start the dev server and check `/docs` for the Graduation tag — all 9 endpoints visible
4. Test manually: create a habit, POST to `/api/habits/{id}/evaluate-graduation`

## Deviations
- **Spec says 400 for missing routine_id on suggest-next**: FastAPI returns 422 for missing required query params. This is standard FastAPI behavior and consistent with every other endpoint in the project. Not worth overriding.
- **Spec says graduation-status endpoint returns `introduced_at` as a date**: Returning as ISO string for consistency with JSON serialization.

## Test Results
```
38 passed in 0.57s (endpoint tests)
1237 passed in 15.91s (full suite)
```

## Acceptance Checklist
- [x] All 9 endpoints return correct response schemas
- [x] All endpoints return appropriate HTTP status codes for error cases (404, 409, 422)
- [x] Evaluate endpoints are read-only — no state changes
- [x] Action endpoints (graduate, step-down, re-scaffold) validate preconditions before acting
- [x] Graduate endpoint respects `force` flag
- [x] Step-down endpoint runs evaluation before applying
- [x] Graduation status endpoint composites data from multiple service functions
- [x] Stacking endpoint returns 422 for missing routine_id (FastAPI standard, see Deviations)
- [x] Batch slip evaluation returns only habits needing attention
- [x] Tests cover all happy paths and error cases per org standards
- [x] Router registered in main app with correct prefix