### PR TITLE
[2G-fix-01]: Add graduated_at timestamp to Habit model

### DIFF
--- a/alembic/versions/016_add_graduated_at_to_habits.py
+++ b/alembic/versions/016_add_graduated_at_to_habits.py
@@ -1,0 +1,45 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Add graduated_at timestamp to habits table.
+
+Revision ID: 16a1b2c3d4e5
+Revises: 15a1b2c3d4e5
+Create Date: 2026-04-15
+
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "16a1b2c3d4e5"
+down_revision: Union[str, None] = "15a1b2c3d4e5"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "habits",
+        sa.Column("graduated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("habits", "graduated_at")

--- a/app/models.py
+++ b/app/models.py
@@ -48,16 +48,21 @@ from app.schemas.rule import RuleAction, RuleEntityType, RuleMetric, RuleOperato
 # Association table: task_tags
 # ---------------------------------------------------------------------------
 
+
 class TaskTag(Base):
     """Many-to-many link between tasks and tags."""
 
     __tablename__ = "task_tags"
 
     task_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tasks.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("tasks.id", ondelete="CASCADE"),
+        primary_key=True,
     )
     tag_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("tags.id", ondelete="CASCADE"),
+        primary_key=True,
     )
 
 
@@ -67,10 +72,14 @@ class ActivityTag(Base):
     __tablename__ = "activity_tags"
 
     activity_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("activity_log.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("activity_log.id", ondelete="CASCADE"),
+        primary_key=True,
     )
     tag_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("tags.id", ondelete="CASCADE"),
+        primary_key=True,
     )
 
 
@@ -80,10 +89,14 @@ class ArtifactTag(Base):
     __tablename__ = "artifact_tags"
 
     artifact_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("artifacts.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("artifacts.id", ondelete="CASCADE"),
+        primary_key=True,
     )
     tag_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("tags.id", ondelete="CASCADE"),
+        primary_key=True,
     )
 
 
@@ -93,10 +106,14 @@ class ProtocolTag(Base):
     __tablename__ = "protocol_tags"
 
     protocol_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("protocols.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("protocols.id", ondelete="CASCADE"),
+        primary_key=True,
     )
     tag_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("tags.id", ondelete="CASCADE"),
+        primary_key=True,
     )
 
 
@@ -106,10 +123,14 @@ class DirectiveTag(Base):
     __tablename__ = "directive_tags"
 
     directive_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("directives.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("directives.id", ondelete="CASCADE"),
+        primary_key=True,
     )
     tag_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("tags.id", ondelete="CASCADE"),
+        primary_key=True,
     )
 
 
@@ -117,16 +138,21 @@ class DirectiveTag(Base):
 # Association tables: skill relationships
 # ---------------------------------------------------------------------------
 
+
 class SkillDomain(Base):
     """Many-to-many link between skills and domains."""
 
     __tablename__ = "skill_domains"
 
     skill_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("skills.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("skills.id", ondelete="CASCADE"),
+        primary_key=True,
     )
     domain_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("domains.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("domains.id", ondelete="CASCADE"),
+        primary_key=True,
     )
 
 
@@ -136,10 +162,14 @@ class SkillProtocol(Base):
     __tablename__ = "skill_protocols"
 
     skill_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("skills.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("skills.id", ondelete="CASCADE"),
+        primary_key=True,
     )
     protocol_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("protocols.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("protocols.id", ondelete="CASCADE"),
+        primary_key=True,
     )
 
 
@@ -149,10 +179,14 @@ class SkillDirective(Base):
     __tablename__ = "skill_directives"
 
     skill_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("skills.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("skills.id", ondelete="CASCADE"),
+        primary_key=True,
     )
     directive_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("directives.id", ondelete="CASCADE"), primary_key=True,
+        UUID(as_uuid=True),
+        ForeignKey("directives.id", ondelete="CASCADE"),
+        primary_key=True,
     )
 
 
@@ -160,31 +194,38 @@ class SkillDirective(Base):
 # Pillar 1: Domains
 # ---------------------------------------------------------------------------
 
+
 class Domain(Base):
     """Top-level life area (House, Network, Finances, Health, etc.)."""
 
     __tablename__ = "domains"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     name: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
     color: Mapped[str | None] = mapped_column(String)
     sort_order: Mapped[int | None] = mapped_column(Integer)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
 
     # Relationships
     goals: Mapped[list["Goal"]] = relationship(
-        back_populates="domain", cascade="all, delete-orphan",
+        back_populates="domain",
+        cascade="all, delete-orphan",
     )
     routines: Mapped[list["Routine"]] = relationship(
-        back_populates="domain", cascade="all, delete-orphan",
+        back_populates="domain",
+        cascade="all, delete-orphan",
     )
     skills: Mapped[list["Skill"]] = relationship(
-        secondary="skill_domains", back_populates="domains",
+        secondary="skill_domains",
+        back_populates="domains",
     )
 
 
@@ -192,25 +233,33 @@ class Domain(Base):
 # Pillar 2: Goals
 # ---------------------------------------------------------------------------
 
+
 class Goal(Base):
     """Desired outcome tied to a domain."""
 
     __tablename__ = "goals"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     domain_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("domains.id", ondelete="CASCADE"), nullable=False,
+        UUID(as_uuid=True),
+        ForeignKey("domains.id", ondelete="CASCADE"),
+        nullable=False,
     )
     title: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
     status: Mapped[str] = mapped_column(String, nullable=False, default="active")
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
     __table_args__ = (
@@ -223,7 +272,8 @@ class Goal(Base):
     # Relationships
     domain: Mapped["Domain"] = relationship(back_populates="goals")
     projects: Mapped[list["Project"]] = relationship(
-        back_populates="goal", cascade="all, delete-orphan",
+        back_populates="goal",
+        cascade="all, delete-orphan",
     )
 
 
@@ -231,16 +281,21 @@ class Goal(Base):
 # Pillar 3: Projects
 # ---------------------------------------------------------------------------
 
+
 class Project(Base):
     """Concrete initiative that advances a goal."""
 
     __tablename__ = "projects"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     goal_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("goals.id", ondelete="CASCADE"), nullable=False,
+        UUID(as_uuid=True),
+        ForeignKey("goals.id", ondelete="CASCADE"),
+        nullable=False,
     )
     title: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
@@ -248,10 +303,13 @@ class Project(Base):
     deadline: Mapped[date | None] = mapped_column(Date)
     progress_pct: Mapped[int] = mapped_column(Integer, default=0)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
     __table_args__ = (
@@ -268,7 +326,8 @@ class Project(Base):
     # Relationships
     goal: Mapped["Goal"] = relationship(back_populates="projects")
     tasks: Mapped[list["Task"]] = relationship(
-        back_populates="project", cascade="all, delete-orphan",
+        back_populates="project",
+        cascade="all, delete-orphan",
     )
 
 
@@ -276,16 +335,20 @@ class Project(Base):
 # Pillar 4: Tasks
 # ---------------------------------------------------------------------------
 
+
 class Task(Base):
     """Actionable item, optionally tied to a project."""
 
     __tablename__ = "tasks"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     project_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"),
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
     )
     title: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
@@ -298,10 +361,13 @@ class Task(Base):
     recurrence_rule: Mapped[str | None] = mapped_column(String)
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
     __table_args__ = (
@@ -331,7 +397,8 @@ class Task(Base):
     # Relationships
     project: Mapped["Project | None"] = relationship(back_populates="tasks")
     tags: Mapped[list["Tag"]] = relationship(
-        secondary="task_tags", back_populates="tasks",
+        secondary="task_tags",
+        back_populates="tasks",
     )
     activity_logs: Mapped[list["ActivityLog"]] = relationship(back_populates="task")
 
@@ -340,32 +407,40 @@ class Task(Base):
 # Pillar 5: Tags
 # ---------------------------------------------------------------------------
 
+
 class Tag(Base):
     """Lightweight label for cross-cutting task categorisation."""
 
     __tablename__ = "tags"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     color: Mapped[str | None] = mapped_column(String)
 
     # Relationships
     tasks: Mapped[list["Task"]] = relationship(
-        secondary="task_tags", back_populates="tags",
+        secondary="task_tags",
+        back_populates="tags",
     )
     activity_logs: Mapped[list["ActivityLog"]] = relationship(
-        secondary="activity_tags", back_populates="tags",
+        secondary="activity_tags",
+        back_populates="tags",
     )
     artifacts: Mapped[list["Artifact"]] = relationship(
-        secondary="artifact_tags", back_populates="tags",
+        secondary="artifact_tags",
+        back_populates="tags",
     )
     protocols: Mapped[list["Protocol"]] = relationship(
-        secondary="protocol_tags", back_populates="tags",
+        secondary="protocol_tags",
+        back_populates="tags",
     )
     directives: Mapped[list["Directive"]] = relationship(
-        secondary="directive_tags", back_populates="tags",
+        secondary="directive_tags",
+        back_populates="tags",
     )
 
 
@@ -373,16 +448,21 @@ class Tag(Base):
 # Pillar 6: Routines & Schedule
 # ---------------------------------------------------------------------------
 
+
 class Routine(Base):
     """Recurring habit tied to a domain."""
 
     __tablename__ = "routines"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     domain_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("domains.id", ondelete="CASCADE"), nullable=False,
+        UUID(as_uuid=True),
+        ForeignKey("domains.id", ondelete="CASCADE"),
+        nullable=False,
     )
     title: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
@@ -394,10 +474,13 @@ class Routine(Base):
     energy_cost: Mapped[int | None] = mapped_column(Integer)
     activation_friction: Mapped[int | None] = mapped_column(Integer)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
     __table_args__ = (
@@ -423,13 +506,16 @@ class Routine(Base):
     # Relationships
     domain: Mapped["Domain"] = relationship(back_populates="routines")
     schedules: Mapped[list["RoutineSchedule"]] = relationship(
-        back_populates="routine", cascade="all, delete-orphan",
+        back_populates="routine",
+        cascade="all, delete-orphan",
     )
     habits: Mapped[list["Habit"]] = relationship(
-        back_populates="routine", cascade="all, delete-orphan",
+        back_populates="routine",
+        cascade="all, delete-orphan",
     )
     completions: Mapped[list["RoutineCompletion"]] = relationship(
-        back_populates="routine", cascade="all, delete-orphan",
+        back_populates="routine",
+        cascade="all, delete-orphan",
     )
     activity_logs: Mapped[list["ActivityLog"]] = relationship(back_populates="routine")
 
@@ -440,10 +526,14 @@ class RoutineSchedule(Base):
     __tablename__ = "routine_schedule"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     routine_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("routines.id", ondelete="CASCADE"), nullable=False,
+        UUID(as_uuid=True),
+        ForeignKey("routines.id", ondelete="CASCADE"),
+        nullable=False,
     )
     day_of_week: Mapped[str | None] = mapped_column(String)
     time_of_day: Mapped[str | None] = mapped_column(String)
@@ -457,54 +547,77 @@ class RoutineSchedule(Base):
 # Habits — atomic behavioral units (standalone or under a routine)
 # ---------------------------------------------------------------------------
 
+
 class Habit(Base):
     """Atomic behavioral unit that can exist standalone or nested under a routine."""
 
     __tablename__ = "habits"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     routine_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("routines.id", ondelete="CASCADE"),
+        UUID(as_uuid=True),
+        ForeignKey("routines.id", ondelete="CASCADE"),
     )
     title: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
     status: Mapped[str] = mapped_column(
-        String, nullable=False, server_default="active",
+        String,
+        nullable=False,
+        server_default="active",
     )
     frequency: Mapped[str | None] = mapped_column(String)
     notification_frequency: Mapped[str] = mapped_column(
-        String, nullable=False, server_default="none",
+        String,
+        nullable=False,
+        server_default="none",
     )
     scaffolding_status: Mapped[str] = mapped_column(
-        String, nullable=False, server_default="tracking",
+        String,
+        nullable=False,
+        server_default="tracking",
     )
     introduced_at: Mapped[date | None] = mapped_column(Date)
     graduation_window: Mapped[int | None] = mapped_column(Integer, default=30)
     graduation_target: Mapped[float | None] = mapped_column(
-        Numeric(precision=3, scale=2), default=0.85,
+        Numeric(precision=3, scale=2),
+        default=0.85,
     )
     graduation_threshold: Mapped[int | None] = mapped_column(Integer, default=30)
     friction_score: Mapped[int | None] = mapped_column(Integer)
     re_scaffold_count: Mapped[int] = mapped_column(
-        Integer, nullable=False, server_default=text("0"),
+        Integer,
+        nullable=False,
+        server_default=text("0"),
     )
     last_frequency_changed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
     )
+    graduated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+    )
     current_streak: Mapped[int] = mapped_column(
-        Integer, nullable=False, server_default=text("0"),
+        Integer,
+        nullable=False,
+        server_default=text("0"),
     )
     best_streak: Mapped[int] = mapped_column(
-        Integer, nullable=False, server_default=text("0"),
+        Integer,
+        nullable=False,
+        server_default=text("0"),
     )
     last_completed: Mapped[date | None] = mapped_column(Date)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
     __table_args__ = (
@@ -537,7 +650,8 @@ class Habit(Base):
     # Relationships
     routine: Mapped["Routine | None"] = relationship(back_populates="habits")
     completions: Mapped[list["HabitCompletion"]] = relationship(
-        back_populates="habit", cascade="all, delete-orphan",
+        back_populates="habit",
+        cascade="all, delete-orphan",
     )
     activity_logs: Mapped[list["ActivityLog"]] = relationship(back_populates="habit")
 
@@ -546,13 +660,16 @@ class Habit(Base):
 # Habit Completions — per-event completion records
 # ---------------------------------------------------------------------------
 
+
 class HabitCompletion(Base):
     """Record of a single habit completion event."""
 
     __tablename__ = "habit_completions"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     habit_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
@@ -563,12 +680,14 @@ class HabitCompletion(Base):
     source: Mapped[str] = mapped_column(String, nullable=False)
     notes: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
 
     __table_args__ = (
         UniqueConstraint(
-            "habit_id", "completed_at",
+            "habit_id",
+            "completed_at",
             name="uq_habit_completions_habit_date",
         ),
         CheckConstraint(
@@ -585,13 +704,16 @@ class HabitCompletion(Base):
 # Routine Completions — per-event routine completion records
 # ---------------------------------------------------------------------------
 
+
 class RoutineCompletion(Base):
     """Record of a single routine completion event."""
 
     __tablename__ = "routine_completions"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     routine_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
@@ -602,7 +724,9 @@ class RoutineCompletion(Base):
     status: Mapped[str] = mapped_column(String, nullable=False)
     freeform_note: Mapped[str | None] = mapped_column(Text)
     reconciled: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("false"),
+        Boolean,
+        nullable=False,
+        server_default=text("false"),
     )
     reconciled_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
@@ -615,7 +739,8 @@ class RoutineCompletion(Base):
         ),
         Index(
             "ix_routine_completions_routine_completed",
-            "routine_id", "completed_at",
+            "routine_id",
+            "completed_at",
         ),
         Index("ix_routine_completions_reconciled", "reconciled"),
     )
@@ -628,13 +753,16 @@ class RoutineCompletion(Base):
 # Pillar 7a: State Check-ins
 # ---------------------------------------------------------------------------
 
+
 class StateCheckin(Base):
     """Point-in-time self-assessment of energy, mood, and focus."""
 
     __tablename__ = "state_checkins"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     checkin_type: Mapped[str] = mapped_column(String, nullable=False)
     energy_level: Mapped[int | None] = mapped_column(Integer)
@@ -643,7 +771,8 @@ class StateCheckin(Base):
     freeform_note: Mapped[str | None] = mapped_column(Text)
     context: Mapped[str | None] = mapped_column(String)
     logged_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
 
     __table_args__ = (
@@ -673,25 +802,32 @@ class StateCheckin(Base):
 # Pillar 7b: Activity Log
 # ---------------------------------------------------------------------------
 
+
 class ActivityLog(Base):
     """Record of an action taken — completed task, skipped routine, check-in, etc."""
 
     __tablename__ = "activity_log"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     task_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("tasks.id", ondelete="SET NULL"),
+        UUID(as_uuid=True),
+        ForeignKey("tasks.id", ondelete="SET NULL"),
     )
     routine_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("routines.id", ondelete="SET NULL"),
+        UUID(as_uuid=True),
+        ForeignKey("routines.id", ondelete="SET NULL"),
     )
     checkin_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("state_checkins.id", ondelete="SET NULL"),
+        UUID(as_uuid=True),
+        ForeignKey("state_checkins.id", ondelete="SET NULL"),
     )
     habit_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("habits.id", ondelete="SET NULL"),
+        UUID(as_uuid=True),
+        ForeignKey("habits.id", ondelete="SET NULL"),
     )
     action_type: Mapped[str] = mapped_column(String, nullable=False)
     notes: Mapped[str | None] = mapped_column(Text)
@@ -701,7 +837,8 @@ class ActivityLog(Base):
     friction_actual: Mapped[int | None] = mapped_column(Integer)
     duration_minutes: Mapped[int | None] = mapped_column(Integer)
     logged_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
 
     __table_args__ = (
@@ -736,7 +873,8 @@ class ActivityLog(Base):
     checkin: Mapped["StateCheckin | None"] = relationship(back_populates="activity_logs")
     habit: Mapped["Habit | None"] = relationship(back_populates="activity_logs")
     tags: Mapped[list["Tag"]] = relationship(
-        secondary="activity_tags", back_populates="activity_logs",
+        secondary="activity_tags",
+        back_populates="activity_logs",
     )
 
 
@@ -744,13 +882,16 @@ class ActivityLog(Base):
 # Artifacts — living reference documents
 # ---------------------------------------------------------------------------
 
+
 class Artifact(Base):
     """Stored document with versioning, multi-part grouping, and tagging."""
 
     __tablename__ = "artifacts"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     title: Mapped[str] = mapped_column(String, nullable=False)
     artifact_type: Mapped[str] = mapped_column(String, nullable=False)
@@ -758,14 +899,18 @@ class Artifact(Base):
     content_size: Mapped[int] = mapped_column(Integer, nullable=False)
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     parent_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("artifacts.id", ondelete="SET NULL"),
+        UUID(as_uuid=True),
+        ForeignKey("artifacts.id", ondelete="SET NULL"),
     )
     is_seedable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
     __table_args__ = (
@@ -785,13 +930,16 @@ class Artifact(Base):
 
     # Relationships
     tags: Mapped[list["Tag"]] = relationship(
-        secondary="artifact_tags", back_populates="artifacts",
+        secondary="artifact_tags",
+        back_populates="artifacts",
     )
     parent: Mapped["Artifact | None"] = relationship(
-        remote_side=[id], foreign_keys=[parent_id],
+        remote_side=[id],
+        foreign_keys=[parent_id],
     )
     children: Mapped[list["Artifact"]] = relationship(
-        foreign_keys=[parent_id], overlaps="parent",
+        foreign_keys=[parent_id],
+        overlaps="parent",
     )
     protocols: Mapped[list["Protocol"]] = relationship(back_populates="artifact")
     skills: Mapped[list["Skill"]] = relationship(back_populates="artifact")
@@ -801,40 +949,47 @@ class Artifact(Base):
 # Protocols — step-by-step procedures
 # ---------------------------------------------------------------------------
 
+
 class Protocol(Base):
     """Repeatable behavioral pattern with ordered steps (JSONB)."""
 
     __tablename__ = "protocols"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     description: Mapped[str | None] = mapped_column(Text)
     steps: Mapped[list | None] = mapped_column(JSON().with_variant(JSONB, "postgresql"))
     artifact_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("artifacts.id", ondelete="SET NULL"),
+        UUID(as_uuid=True),
+        ForeignKey("artifacts.id", ondelete="SET NULL"),
     )
     is_seedable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
-    __table_args__ = (
-        Index("ix_protocols_is_seedable", "is_seedable"),
-    )
+    __table_args__ = (Index("ix_protocols_is_seedable", "is_seedable"),)
 
     # Relationships
     tags: Mapped[list["Tag"]] = relationship(
-        secondary="protocol_tags", back_populates="protocols",
+        secondary="protocol_tags",
+        back_populates="protocols",
     )
     artifact: Mapped["Artifact | None"] = relationship(back_populates="protocols")
     skills: Mapped[list["Skill"]] = relationship(
-        secondary="skill_protocols", back_populates="protocols",
+        secondary="skill_protocols",
+        back_populates="protocols",
     )
 
 
@@ -842,13 +997,16 @@ class Protocol(Base):
 # Directives — principles and guardrails
 # ---------------------------------------------------------------------------
 
+
 class Directive(Base):
     """Declarative rule or guardrail with scope-based resolution."""
 
     __tablename__ = "directives"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     name: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
@@ -857,10 +1015,13 @@ class Directive(Base):
     priority: Mapped[int] = mapped_column(Integer, nullable=False, default=5)
     is_seedable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
     __table_args__ = (
@@ -878,10 +1039,12 @@ class Directive(Base):
 
     # Relationships
     tags: Mapped[list["Tag"]] = relationship(
-        secondary="directive_tags", back_populates="directives",
+        secondary="directive_tags",
+        back_populates="directives",
     )
     skills: Mapped[list["Skill"]] = relationship(
-        secondary="skill_directives", back_populates="directives",
+        secondary="skill_directives",
+        back_populates="directives",
     )
 
 
@@ -889,27 +1052,34 @@ class Directive(Base):
 # Skills — contextual operating modes
 # ---------------------------------------------------------------------------
 
+
 class Skill(Base):
     """Contextual mode that composes protocols, directives, and domains."""
 
     __tablename__ = "skills"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     description: Mapped[str | None] = mapped_column(Text)
     adhd_patterns: Mapped[str | None] = mapped_column(Text)
     artifact_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("artifacts.id", ondelete="SET NULL"),
+        UUID(as_uuid=True),
+        ForeignKey("artifacts.id", ondelete="SET NULL"),
     )
     is_seedable: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
     __table_args__ = (
@@ -919,13 +1089,16 @@ class Skill(Base):
 
     # Relationships
     domains: Mapped[list["Domain"]] = relationship(
-        secondary="skill_domains", back_populates="skills",
+        secondary="skill_domains",
+        back_populates="skills",
     )
     protocols: Mapped[list["Protocol"]] = relationship(
-        secondary="skill_protocols", back_populates="skills",
+        secondary="skill_protocols",
+        back_populates="skills",
     )
     directives: Mapped[list["Directive"]] = relationship(
-        secondary="skill_directives", back_populates="skills",
+        secondary="skill_directives",
+        back_populates="skills",
     )
     artifact: Mapped["Artifact | None"] = relationship(back_populates="skills")
 
@@ -934,27 +1107,36 @@ class Skill(Base):
 # Notification Queue — proactive notification system
 # ---------------------------------------------------------------------------
 
+
 class NotificationQueue(Base):
     """Queued notification awaiting delivery and optional user response."""
 
     __tablename__ = "notification_queue"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     notification_type: Mapped[str] = mapped_column(String, nullable=False)
     delivery_type: Mapped[str] = mapped_column(
-        String, nullable=False, server_default="notification",
+        String,
+        nullable=False,
+        server_default="notification",
     )
     status: Mapped[str] = mapped_column(
-        String, nullable=False, server_default="pending",
+        String,
+        nullable=False,
+        server_default="pending",
     )
     scheduled_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False,
+        DateTime(timezone=True),
+        nullable=False,
     )
     target_entity_type: Mapped[str] = mapped_column(String, nullable=False)
     target_entity_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), nullable=False,
+        UUID(as_uuid=True),
+        nullable=False,
     )
     message: Mapped[str] = mapped_column(Text, nullable=False)
     canned_responses: Mapped[list | None] = mapped_column(
@@ -970,13 +1152,17 @@ class NotificationQueue(Base):
     )
     scheduled_by: Mapped[str] = mapped_column(String, nullable=False)
     rule_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("rules.id", ondelete="SET NULL"),
+        UUID(as_uuid=True),
+        ForeignKey("rules.id", ondelete="SET NULL"),
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
     __table_args__ = (
@@ -1013,24 +1199,30 @@ class NotificationQueue(Base):
 # Rules Engine — conditional logic layer for automated notifications
 # ---------------------------------------------------------------------------
 
+
 class Rule(Base):
     """A rule that watches an entity metric and fires a notification."""
 
     __tablename__ = "rules"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4,
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
     )
     name: Mapped[str] = mapped_column(String(200), nullable=False)
     entity_type: Mapped[RuleEntityType] = mapped_column(
-        SAEnum(RuleEntityType, native_enum=False), nullable=False,
+        SAEnum(RuleEntityType, native_enum=False),
+        nullable=False,
     )
     entity_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
     metric: Mapped[RuleMetric] = mapped_column(
-        SAEnum(RuleMetric, native_enum=False), nullable=False,
+        SAEnum(RuleMetric, native_enum=False),
+        nullable=False,
     )
     operator: Mapped[RuleOperator] = mapped_column(
-        SAEnum(RuleOperator, native_enum=False), nullable=False,
+        SAEnum(RuleOperator, native_enum=False),
+        nullable=False,
     )
     threshold: Mapped[int] = mapped_column(Integer, nullable=False)
     action: Mapped[RuleAction] = mapped_column(
@@ -1041,22 +1233,31 @@ class Rule(Base):
     notification_type: Mapped[str] = mapped_column(String, nullable=False)
     message_template: Mapped[str] = mapped_column(Text, nullable=False)
     enabled: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("true"),
+        Boolean,
+        nullable=False,
+        server_default=text("true"),
     )
     cooldown_hours: Mapped[int] = mapped_column(
-        Integer, nullable=False, server_default=text("24"),
+        Integer,
+        nullable=False,
+        server_default=text("24"),
     )
     is_default: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("false"),
+        Boolean,
+        nullable=False,
+        server_default=text("false"),
     )
     last_triggered_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(),
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
     )
 
     __table_args__ = (

--- a/app/schemas/habits.py
+++ b/app/schemas/habits.py
@@ -68,9 +68,7 @@ class HabitCreate(BaseModel):
     def standalone_requires_frequency(self) -> HabitCreate:
         """Standalone habits (no routine_id) must specify a frequency."""
         if self.routine_id is None and self.frequency is None:
-            raise ValueError(
-                "frequency is required for standalone habits (no routine_id)"
-            )
+            raise ValueError("frequency is required for standalone habits (no routine_id)")
         return self
 
 
@@ -127,6 +125,7 @@ class HabitResponse(BaseModel):
     friction_score: int | None = None
     re_scaffold_count: int
     last_frequency_changed_at: datetime | None = None
+    graduated_at: datetime | None = None
     current_streak: int
     best_streak: int
     last_completed: date | None = None

--- a/app/services/graduation.py
+++ b/app/services/graduation.py
@@ -60,7 +60,10 @@ class GraduationExecutionResult(BaseModel):
 
 
 def apply_re_scaffold_tightening(
-    window: int, target: float, threshold: int, re_scaffold_count: int,
+    window: int,
+    target: float,
+    threshold: int,
+    re_scaffold_count: int,
 ) -> tuple[int, float, int]:
     """Tighten graduation criteria based on re-scaffold history."""
     for _ in range(re_scaffold_count):
@@ -108,7 +111,10 @@ def evaluate_graduation(
     # Apply re-scaffold tightening if applicable
     if habit.re_scaffold_count > 0:
         window, target, threshold = apply_re_scaffold_tightening(
-            window, target, threshold, habit.re_scaffold_count,
+            window,
+            target,
+            threshold,
+            habit.re_scaffold_count,
         )
 
     now = datetime.now(tz=UTC)
@@ -154,9 +160,7 @@ def evaluate_graduation(
             blocking_reasons=["No notification data in evaluation window"],
         )
 
-    already_done_count = sum(
-        1 for n in notifications if n.response == "Already done"
-    )
+    already_done_count = sum(1 for n in notifications if n.response == "Already done")
     current_rate = already_done_count / total_notifications
 
     meets_rate = current_rate >= target
@@ -164,9 +168,7 @@ def evaluate_graduation(
     # Build blocking reasons
     blocking_reasons: list[str] = []
     if not meets_rate:
-        blocking_reasons.append(
-            f"Rate {current_rate:.0%} below target {target:.0%}"
-        )
+        blocking_reasons.append(f"Rate {current_rate:.0%} below target {target:.0%}")
     if not meets_threshold:
         blocking_reasons.append(
             f"{days_since_introduction} days since introduction, need {threshold}"
@@ -248,14 +250,14 @@ def graduate_habit(
             previous_notification_frequency=previous_frequency,
             evaluation=evaluation,
             message=(
-                "Habit does not meet graduation criteria. "
-                + "; ".join(evaluation.blocking_reasons)
+                "Habit does not meet graduation criteria. " + "; ".join(evaluation.blocking_reasons)
             ),
         )
 
     # Execute transition
     habit.scaffolding_status = "graduated"
     habit.notification_frequency = "graduated"
+    habit.graduated_at = datetime.now(tz=UTC)
 
     # Log activity entry
     forced_label = " (forced)" if force else ""
@@ -384,8 +386,7 @@ def evaluate_frequency_step_down(
     if habit.notification_frequency not in FREQUENCY_ORDER:
         return _no_recommendation(
             reasons=[
-                f"Frequency '{habit.notification_frequency}' is not in the "
-                "step-down progression"
+                f"Frequency '{habit.notification_frequency}' is not in the step-down progression"
             ],
         )
 
@@ -436,9 +437,7 @@ def evaluate_frequency_step_down(
         )
 
     # Compute "already done" rate
-    already_done_count = sum(
-        1 for n in notifications if n.response == "Already done"
-    )
+    already_done_count = sum(1 for n in notifications if n.response == "Already done")
     rate = already_done_count / total
 
     # Check if already at minimum stepped frequency
@@ -458,10 +457,7 @@ def evaluate_frequency_step_down(
         return _no_recommendation(
             rate=rate,
             evaluated=total,
-            reasons=[
-                f"Rate {rate:.0%} below step-down threshold "
-                f"{STEP_DOWN_RATE_THRESHOLD:.0%}"
-            ],
+            reasons=[f"Rate {rate:.0%} below step-down threshold {STEP_DOWN_RATE_THRESHOLD:.0%}"],
         )
 
     return FrequencyStepResult(
@@ -520,8 +516,7 @@ def apply_frequency_step_down(
     activity = ActivityLog(
         action_type="completed",
         notes=(
-            f"Notification frequency stepped down: {habit.title}. "
-            f"{previous} → {new_frequency}."
+            f"Notification frequency stepped down: {habit.title}. {previous} → {new_frequency}."
         ),
         habit_id=habit_id,
     )
@@ -534,10 +529,7 @@ def apply_frequency_step_down(
         habit_id=habit_id,
         previous_frequency=previous,
         new_frequency=new_frequency,
-        message=(
-            f"Frequency stepped down for '{habit.title}': "
-            f"{previous} → {new_frequency}"
-        ),
+        message=(f"Frequency stepped down for '{habit.title}': {previous} → {new_frequency}"),
     )
 
 
@@ -614,14 +606,13 @@ def evaluate_graduated_habit_slip(
     now = datetime.now(tz=UTC)
     window_start = now - timedelta(days=SLIP_DETECTION_WINDOW_DAYS)
 
-    # Compute days since graduation (approximate — use updated_at as proxy
-    # since we don't have a dedicated graduated_at column)
+    # Compute days since graduation using dedicated graduated_at column
     days_since_graduation = 0
-    if habit.updated_at is not None:
-        updated = habit.updated_at
-        if updated.tzinfo is None:
-            updated = updated.replace(tzinfo=UTC)
-        days_since_graduation = (now - updated).days
+    if habit.graduated_at is not None:
+        grad_ts = habit.graduated_at
+        if grad_ts.tzinfo is None:
+            grad_ts = grad_ts.replace(tzinfo=UTC)
+        days_since_graduation = (now - grad_ts).days
 
     signals: list[SlipSignal] = []
 
@@ -640,28 +631,31 @@ def evaluate_graduated_habit_slip(
         )
 
         miss_count = sum(
-            1 for n in checklist_notifications
-            if n.response == "Partial" or n.status == "expired"
+            1 for n in checklist_notifications if n.response == "Partial" or n.status == "expired"
         )
 
         if miss_count >= CHECKLIST_CRITICAL_THRESHOLD:
-            signals.append(SlipSignal(
-                signal_type="missed_in_checklist",
-                detail=(
-                    f"{miss_count} partial/expired routine checklists in "
-                    f"the last {SLIP_DETECTION_WINDOW_DAYS} days"
-                ),
-                severity="critical",
-            ))
+            signals.append(
+                SlipSignal(
+                    signal_type="missed_in_checklist",
+                    detail=(
+                        f"{miss_count} partial/expired routine checklists in "
+                        f"the last {SLIP_DETECTION_WINDOW_DAYS} days"
+                    ),
+                    severity="critical",
+                )
+            )
         elif miss_count >= CHECKLIST_WARNING_THRESHOLD:
-            signals.append(SlipSignal(
-                signal_type="missed_in_checklist",
-                detail=(
-                    f"{miss_count} partial/expired routine checklists in "
-                    f"the last {SLIP_DETECTION_WINDOW_DAYS} days"
-                ),
-                severity="warning",
-            ))
+            signals.append(
+                SlipSignal(
+                    signal_type="missed_in_checklist",
+                    detail=(
+                        f"{miss_count} partial/expired routine checklists in "
+                        f"the last {SLIP_DETECTION_WINDOW_DAYS} days"
+                    ),
+                    severity="warning",
+                )
+            )
 
     # Signal 2: No completion recorded
     window_7 = now - timedelta(days=COMPLETION_WARNING_DAYS)
@@ -677,14 +671,13 @@ def evaluate_graduated_habit_slip(
 
     if completions_14d == 0:
         # Zero completions in full 14-day window → critical
-        signals.append(SlipSignal(
-            signal_type="no_completion_recorded",
-            detail=(
-                f"No completions recorded in the last "
-                f"{SLIP_DETECTION_WINDOW_DAYS} days"
-            ),
-            severity="critical",
-        ))
+        signals.append(
+            SlipSignal(
+                signal_type="no_completion_recorded",
+                detail=(f"No completions recorded in the last {SLIP_DETECTION_WINDOW_DAYS} days"),
+                severity="critical",
+            )
+        )
     else:
         completions_7d = (
             db.query(sa_func.count(HabitCompletion.id))
@@ -697,14 +690,16 @@ def evaluate_graduated_habit_slip(
 
         if completions_7d == 0:
             # Zero completions in last 7 days but some in 14-day window → warning
-            signals.append(SlipSignal(
-                signal_type="no_completion_recorded",
-                detail=(
-                    f"No completions in the last {COMPLETION_WARNING_DAYS} days "
-                    f"(last completion was more than a week ago)"
-                ),
-                severity="warning",
-            ))
+            signals.append(
+                SlipSignal(
+                    signal_type="no_completion_recorded",
+                    detail=(
+                        f"No completions in the last {COMPLETION_WARNING_DAYS} days "
+                        f"(last completion was more than a week ago)"
+                    ),
+                    severity="warning",
+                )
+            )
 
     # Determine recommendation
     has_critical = any(s.severity == "critical" for s in signals)
@@ -802,6 +797,7 @@ def re_scaffold_habit(
     # Reverse graduation
     habit.scaffolding_status = "accountable"
     habit.notification_frequency = "daily"
+    habit.graduated_at = None
 
     # Increment re-scaffold count
     habit.re_scaffold_count += 1
@@ -812,7 +808,10 @@ def re_scaffold_habit(
     # Compute tightened criteria for informational purposes
     window, target, threshold = resolve_graduation_params(habit)
     window, target, threshold = apply_re_scaffold_tightening(
-        window, target, threshold, habit.re_scaffold_count,
+        window,
+        target,
+        threshold,
+        habit.re_scaffold_count,
     )
     tightened_params = {
         "window_days": window,
@@ -990,14 +989,10 @@ def get_stacking_recommendation(
 
     # Load all habits in this routine
     active_habits = (
-        db.query(Habit)
-        .filter(Habit.routine_id == routine_id, Habit.status == "active")
-        .all()
+        db.query(Habit).filter(Habit.routine_id == routine_id, Habit.status == "active").all()
     )
     paused_habits = (
-        db.query(Habit)
-        .filter(Habit.routine_id == routine_id, Habit.status == "paused")
-        .all()
+        db.query(Habit).filter(Habit.routine_id == routine_id, Habit.status == "paused").all()
     )
 
     # Freeform routine: no habits at all
@@ -1009,16 +1004,11 @@ def get_stacking_recommendation(
             active_accountable_habits=[],
             blocking_habits=[],
             suggested_next=None,
-            message=(
-                "This is a freeform routine with no habits. "
-                "Stacking doesn't apply."
-            ),
+            message=("This is a freeform routine with no habits. Stacking doesn't apply."),
         )
 
     # Assess stability of accountable habits
-    accountable_habits = [
-        h for h in active_habits if h.scaffolding_status == "accountable"
-    ]
+    accountable_habits = [h for h in active_habits if h.scaffolding_status == "accountable"]
     stability_infos: list[HabitStabilityInfo] = []
     blocking: list[HabitStabilityInfo] = []
 
@@ -1041,10 +1031,7 @@ def get_stacking_recommendation(
     if ready:
         # Priority 1: Paused habits with scaffolding_status='tracking',
         # ordered by introduced_at (oldest first)
-        paused_tracking = [
-            h for h in paused_habits
-            if h.scaffolding_status == "tracking"
-        ]
+        paused_tracking = [h for h in paused_habits if h.scaffolding_status == "tracking"]
         paused_tracking.sort(
             key=lambda h: h.introduced_at or datetime.min.date(),
         )
@@ -1063,10 +1050,7 @@ def get_stacking_recommendation(
         else:
             # Priority 2: Active tracking habits, ordered by created_at
             # (position field not yet available — using created_at as proxy)
-            active_tracking = [
-                h for h in active_habits
-                if h.scaffolding_status == "tracking"
-            ]
+            active_tracking = [h for h in active_habits if h.scaffolding_status == "tracking"]
             active_tracking.sort(key=lambda h: h.created_at)
 
             if active_tracking:
@@ -1098,10 +1082,7 @@ def get_stacking_recommendation(
             f"Ready to add {suggested_next.habit_name} to {routine.title}?"
         )
     else:
-        message = (
-            f"All habits in {routine.title} are in the scaffolding "
-            f"pipeline. Nice work."
-        )
+        message = f"All habits in {routine.title} are in the scaffolding pipeline. Nice work."
 
     return StackingRecommendation(
         ready=ready,

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -54,6 +54,7 @@ from tests.conftest import make_habit
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _create_habit(db, **overrides) -> Habit:
     """Insert a Habit directly via ORM.
 
@@ -65,9 +66,7 @@ def _create_habit(db, **overrides) -> Habit:
     nullable_grad_fields = ("graduation_window", "graduation_target", "graduation_threshold")
     force_null = {k for k in nullable_grad_fields if k in overrides and overrides[k] is None}
 
-    constructor_overrides = {
-        k: v for k, v in overrides.items() if k not in force_null
-    }
+    constructor_overrides = {k: v for k, v in overrides.items() if k not in force_null}
 
     defaults = {
         "id": uuid.uuid4(),
@@ -122,8 +121,9 @@ def _create_completion(db, habit_id: uuid.UUID, days_ago: int = 0) -> HabitCompl
     return c
 
 
-def _create_routine_checklist(db, routine_id: uuid.UUID, response: str | None,
-                              status: str, days_ago: int = 5) -> NotificationQueue:
+def _create_routine_checklist(
+    db, routine_id: uuid.UUID, response: str | None, status: str, days_ago: int = 5
+) -> NotificationQueue:
     """Insert a routine_checklist notification for a routine."""
     n = NotificationQueue(
         id=uuid.uuid4(),
@@ -142,8 +142,9 @@ def _create_routine_checklist(db, routine_id: uuid.UUID, response: str | None,
     return n
 
 
-def _create_notification(db, habit_id: uuid.UUID, response: str | None,
-                         status: str, days_ago: int = 5) -> NotificationQueue:
+def _create_notification(
+    db, habit_id: uuid.UUID, response: str | None, status: str, days_ago: int = 5
+) -> NotificationQueue:
     """Insert a notification_queue entry for a habit."""
     n = NotificationQueue(
         id=uuid.uuid4(),
@@ -168,30 +169,49 @@ def _create_notification(db, habit_id: uuid.UUID, response: str | None,
 
 
 class TestResolveGraduationParams:
-
     def test_all_defaults_friction_none(self, db):
         """Habit with no overrides and no friction_score gets middle-tier defaults."""
-        habit = _create_habit(db, graduation_window=None, graduation_target=None,
-                              graduation_threshold=None, friction_score=None)
+        habit = _create_habit(
+            db,
+            graduation_window=None,
+            graduation_target=None,
+            graduation_threshold=None,
+            friction_score=None,
+        )
         window, target, threshold = resolve_graduation_params(habit)
         assert (window, target, threshold) == (45, 0.85, 45)
 
     def test_friction_1_defaults(self, db):
-        habit = _create_habit(db, friction_score=1, graduation_window=None,
-                              graduation_target=None, graduation_threshold=None)
+        habit = _create_habit(
+            db,
+            friction_score=1,
+            graduation_window=None,
+            graduation_target=None,
+            graduation_threshold=None,
+        )
         window, target, threshold = resolve_graduation_params(habit)
         assert (window, target, threshold) == (30, 0.85, 30)
 
     def test_friction_5_defaults(self, db):
-        habit = _create_habit(db, friction_score=5, graduation_window=None,
-                              graduation_target=None, graduation_threshold=None)
+        habit = _create_habit(
+            db,
+            friction_score=5,
+            graduation_window=None,
+            graduation_target=None,
+            graduation_threshold=None,
+        )
         window, target, threshold = resolve_graduation_params(habit)
         assert (window, target, threshold) == (60, 0.80, 60)
 
     def test_per_habit_overrides(self, db):
         """Per-habit values take precedence over friction defaults."""
-        habit = _create_habit(db, friction_score=1, graduation_window=90,
-                              graduation_target=0.70, graduation_threshold=90)
+        habit = _create_habit(
+            db,
+            friction_score=1,
+            graduation_window=90,
+            graduation_target=0.70,
+            graduation_threshold=90,
+        )
         window, target, threshold = resolve_graduation_params(habit)
         assert window == 90
         assert target == 0.70
@@ -199,8 +219,13 @@ class TestResolveGraduationParams:
 
     def test_partial_override(self, db):
         """One override, rest from friction tier."""
-        habit = _create_habit(db, friction_score=4, graduation_window=100,
-                              graduation_target=None, graduation_threshold=None)
+        habit = _create_habit(
+            db,
+            friction_score=4,
+            graduation_window=100,
+            graduation_target=None,
+            graduation_threshold=None,
+        )
         window, target, threshold = resolve_graduation_params(habit)
         assert window == 100
         assert target == 0.80  # friction-4 default
@@ -213,14 +238,13 @@ class TestResolveGraduationParams:
 
 
 class TestReScaffoldTightening:
-
     def test_no_tightening(self):
         w, t, th = apply_re_scaffold_tightening(30, 0.85, 30, 0)
         assert (w, t, th) == (30, 0.85, 30)
 
     def test_single_re_scaffold(self):
         w, t, th = apply_re_scaffold_tightening(30, 0.85, 30, 1)
-        assert w == 37   # int(30 * 1.25)
+        assert w == 37  # int(30 * 1.25)
         assert t == 0.90  # 0.85 + 0.05
         assert th == 37  # int(30 * 1.25)
 
@@ -253,7 +277,6 @@ class TestReScaffoldTightening:
 
 
 class TestEvaluateGraduation:
-
     def test_eligible_habit(self, db):
         """Habit that meets both rate and threshold is eligible."""
         habit = _create_habit(db, introduced_at=date.today() - timedelta(days=60))
@@ -452,37 +475,56 @@ class TestEvaluateGraduation:
 
 
 class TestFrictionScoreValidation:
-
     def test_create_with_valid_friction_score(self, client):
-        resp = client.post("/api/habits", json={
-            "title": "Test", "frequency": "daily", "friction_score": 3,
-        })
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Test",
+                "frequency": "daily",
+                "friction_score": 3,
+            },
+        )
         assert resp.status_code == 201
         assert resp.json()["friction_score"] == 3
 
     def test_create_with_null_friction_score(self, client):
-        resp = client.post("/api/habits", json={
-            "title": "Test", "frequency": "daily",
-        })
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Test",
+                "frequency": "daily",
+            },
+        )
         assert resp.status_code == 201
         assert resp.json()["friction_score"] is None
 
     def test_create_friction_score_too_low(self, client):
-        resp = client.post("/api/habits", json={
-            "title": "Test", "frequency": "daily", "friction_score": 0,
-        })
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Test",
+                "frequency": "daily",
+                "friction_score": 0,
+            },
+        )
         assert resp.status_code == 422
 
     def test_create_friction_score_too_high(self, client):
-        resp = client.post("/api/habits", json={
-            "title": "Test", "frequency": "daily", "friction_score": 6,
-        })
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Test",
+                "frequency": "daily",
+                "friction_score": 6,
+            },
+        )
         assert resp.status_code == 422
 
     def test_update_friction_score(self, client):
         habit = make_habit(client)
         resp = client.patch(
-            f"/api/habits/{habit['id']}", json={"friction_score": 5},
+            f"/api/habits/{habit['id']}",
+            json={"friction_score": 5},
         )
         assert resp.status_code == 200
         assert resp.json()["friction_score"] == 5
@@ -490,7 +532,8 @@ class TestFrictionScoreValidation:
     def test_update_friction_score_invalid(self, client):
         habit = make_habit(client)
         resp = client.patch(
-            f"/api/habits/{habit['id']}", json={"friction_score": 10},
+            f"/api/habits/{habit['id']}",
+            json={"friction_score": 10},
         )
         assert resp.status_code == 422
 
@@ -577,7 +620,9 @@ class TestGraduateHabit:
     def test_graduation_preserves_streak_history(self, db):
         """best_streak and last_completed are unchanged after graduation."""
         habit = self._eligible_habit(
-            db, best_streak=15, last_completed=date.today() - timedelta(days=1),
+            db,
+            best_streak=15,
+            last_completed=date.today() - timedelta(days=1),
         )
         # Force the values in since _create_habit defaults may not set them
         habit.best_streak = 15
@@ -613,11 +658,7 @@ class TestGraduateHabit:
         habit = self._ineligible_habit(db)
         graduate_habit(db, habit.id, force=True)
 
-        log = (
-            db.query(ActivityLog)
-            .filter(ActivityLog.habit_id == habit.id)
-            .first()
-        )
+        log = db.query(ActivityLog).filter(ActivityLog.habit_id == habit.id).first()
         assert log is not None
         assert "(forced)" in log.notes
 
@@ -643,7 +684,9 @@ class TestGraduateHabit:
     def test_paused_habit_rejected(self, db):
         """Cannot graduate a paused habit."""
         habit = _create_habit(
-            db, status="paused", scaffolding_status="accountable",
+            db,
+            status="paused",
+            scaffolding_status="accountable",
             notification_frequency="daily",
         )
         with pytest.raises(Exception) as exc_info:
@@ -654,7 +697,9 @@ class TestGraduateHabit:
     def test_abandoned_habit_rejected(self, db):
         """Cannot graduate an abandoned habit."""
         habit = _create_habit(
-            db, status="abandoned", scaffolding_status="accountable",
+            db,
+            status="abandoned",
+            scaffolding_status="accountable",
             notification_frequency="daily",
         )
         with pytest.raises(Exception) as exc_info:
@@ -667,7 +712,9 @@ class TestGraduateHabit:
     def test_tracking_scaffolding_rejected(self, db):
         """Cannot graduate from 'tracking' scaffolding_status."""
         habit = _create_habit(
-            db, scaffolding_status="tracking", notification_frequency="daily",
+            db,
+            scaffolding_status="tracking",
+            notification_frequency="daily",
         )
         with pytest.raises(Exception) as exc_info:
             graduate_habit(db, habit.id)
@@ -679,7 +726,9 @@ class TestGraduateHabit:
     def test_already_graduated_returns_failure(self, db):
         """Already graduated habit returns success=False (not an exception)."""
         habit = _create_habit(
-            db, scaffolding_status="graduated", notification_frequency="graduated",
+            db,
+            scaffolding_status="graduated",
+            notification_frequency="graduated",
         )
 
         result = graduate_habit(db, habit.id)
@@ -703,11 +752,7 @@ class TestGraduateHabit:
         habit = self._eligible_habit(db)
         graduate_habit(db, habit.id)
 
-        log = (
-            db.query(ActivityLog)
-            .filter(ActivityLog.habit_id == habit.id)
-            .first()
-        )
+        log = db.query(ActivityLog).filter(ActivityLog.habit_id == habit.id).first()
         assert log is not None
         assert log.action_type == "completed"
         assert habit.title in log.notes
@@ -720,11 +765,7 @@ class TestGraduateHabit:
         habit = self._ineligible_habit(db)
         graduate_habit(db, habit.id, force=False)
 
-        log_count = (
-            db.query(ActivityLog)
-            .filter(ActivityLog.habit_id == habit.id)
-            .count()
-        )
+        log_count = db.query(ActivityLog).filter(ActivityLog.habit_id == habit.id).count()
         assert log_count == 0
 
     def test_evaluated_graduation_no_forced_label(self, db):
@@ -732,11 +773,7 @@ class TestGraduateHabit:
         habit = self._eligible_habit(db)
         graduate_habit(db, habit.id)
 
-        log = (
-            db.query(ActivityLog)
-            .filter(ActivityLog.habit_id == habit.id)
-            .first()
-        )
+        log = db.query(ActivityLog).filter(ActivityLog.habit_id == habit.id).first()
         assert "(forced)" not in log.notes
 
 
@@ -746,7 +783,6 @@ class TestGraduateHabit:
 
 
 class TestNextStepDown:
-
     def test_daily_to_every_other_day(self):
         assert next_step_down("daily") == "every_other_day"
 
@@ -775,11 +811,17 @@ class TestNextStepDown:
 
 
 class TestEvaluateFrequencyStepDown:
-
     def _habit_with_notifications(
-        self, db, *, notification_frequency="daily", already_done=10,
-        other_response=4, status="active", scaffolding_status="accountable",
-        last_frequency_changed_at=None, **habit_overrides,
+        self,
+        db,
+        *,
+        notification_frequency="daily",
+        already_done=10,
+        other_response=4,
+        status="active",
+        scaffolding_status="accountable",
+        last_frequency_changed_at=None,
+        **habit_overrides,
     ) -> Habit:
         """Create a habit with a mix of notification responses."""
         habit = _create_habit(
@@ -792,11 +834,18 @@ class TestEvaluateFrequencyStepDown:
         )
         for i in range(already_done):
             _create_notification(
-                db, habit.id, "Already done", "responded", days_ago=i + 1,
+                db,
+                habit.id,
+                "Already done",
+                "responded",
+                days_ago=i + 1,
             )
         for i in range(other_response):
             _create_notification(
-                db, habit.id, "Skip today", "responded",
+                db,
+                habit.id,
+                "Skip today",
+                "responded",
                 days_ago=already_done + i + 1,
             )
         return habit
@@ -806,7 +855,10 @@ class TestEvaluateFrequencyStepDown:
     def test_daily_step_down_recommended(self, db):
         """Daily habit with >= 60% already-done rate recommends every_other_day."""
         habit = self._habit_with_notifications(
-            db, notification_frequency="daily", already_done=9, other_response=5,
+            db,
+            notification_frequency="daily",
+            already_done=9,
+            other_response=5,
         )
         result = evaluate_frequency_step_down(db, habit.id)
 
@@ -822,8 +874,10 @@ class TestEvaluateFrequencyStepDown:
     def test_every_other_day_step_down(self, db):
         """every_other_day → twice_week when rate meets threshold."""
         habit = self._habit_with_notifications(
-            db, notification_frequency="every_other_day",
-            already_done=10, other_response=4,
+            db,
+            notification_frequency="every_other_day",
+            already_done=10,
+            other_response=4,
         )
         result = evaluate_frequency_step_down(db, habit.id)
 
@@ -833,8 +887,10 @@ class TestEvaluateFrequencyStepDown:
     def test_twice_week_step_down(self, db):
         """twice_week → weekly when rate meets threshold."""
         habit = self._habit_with_notifications(
-            db, notification_frequency="twice_week",
-            already_done=10, other_response=4,
+            db,
+            notification_frequency="twice_week",
+            already_done=10,
+            other_response=4,
         )
         result = evaluate_frequency_step_down(db, habit.id)
 
@@ -845,8 +901,10 @@ class TestEvaluateFrequencyStepDown:
         """Exactly 60% rate still recommends step-down."""
         # 6 out of 10 = 60%
         habit = self._habit_with_notifications(
-            db, notification_frequency="daily",
-            already_done=6, other_response=4,
+            db,
+            notification_frequency="daily",
+            already_done=6,
+            other_response=4,
         )
         result = evaluate_frequency_step_down(db, habit.id)
 
@@ -858,8 +916,10 @@ class TestEvaluateFrequencyStepDown:
     def test_weekly_no_step_down(self, db):
         """Weekly habit cannot step down further — graduation is separate."""
         habit = self._habit_with_notifications(
-            db, notification_frequency="weekly",
-            already_done=14, other_response=0,
+            db,
+            notification_frequency="weekly",
+            already_done=14,
+            other_response=0,
         )
         result = evaluate_frequency_step_down(db, habit.id)
 
@@ -870,8 +930,10 @@ class TestEvaluateFrequencyStepDown:
     def test_graduated_no_step_down(self, db):
         """Graduated frequency is not in the progression."""
         habit = self._habit_with_notifications(
-            db, notification_frequency="graduated",
-            already_done=10, other_response=4,
+            db,
+            notification_frequency="graduated",
+            already_done=10,
+            other_response=4,
         )
         result = evaluate_frequency_step_down(db, habit.id)
 
@@ -881,8 +943,10 @@ class TestEvaluateFrequencyStepDown:
     def test_none_frequency_no_step_down(self, db):
         """'none' frequency is not in the progression."""
         habit = self._habit_with_notifications(
-            db, notification_frequency="none",
-            already_done=10, other_response=4,
+            db,
+            notification_frequency="none",
+            already_done=10,
+            other_response=4,
         )
         result = evaluate_frequency_step_down(db, habit.id)
 
@@ -892,8 +956,10 @@ class TestEvaluateFrequencyStepDown:
         """Rate below 60% does not recommend step-down."""
         # 5 out of 14 = ~36%
         habit = self._habit_with_notifications(
-            db, notification_frequency="daily",
-            already_done=5, other_response=9,
+            db,
+            notification_frequency="daily",
+            already_done=5,
+            other_response=9,
         )
         result = evaluate_frequency_step_down(db, habit.id)
 
@@ -904,8 +970,10 @@ class TestEvaluateFrequencyStepDown:
     def test_insufficient_notifications(self, db):
         """Fewer than 5 notifications returns no recommendation."""
         habit = self._habit_with_notifications(
-            db, notification_frequency="daily",
-            already_done=3, other_response=1,
+            db,
+            notification_frequency="daily",
+            already_done=3,
+            other_response=1,
         )
         result = evaluate_frequency_step_down(db, habit.id)
 
@@ -916,8 +984,10 @@ class TestEvaluateFrequencyStepDown:
     def test_zero_notifications(self, db):
         """No notifications at all returns no recommendation."""
         habit = self._habit_with_notifications(
-            db, notification_frequency="daily",
-            already_done=0, other_response=0,
+            db,
+            notification_frequency="daily",
+            already_done=0,
+            other_response=0,
         )
         result = evaluate_frequency_step_down(db, habit.id)
 
@@ -930,8 +1000,10 @@ class TestEvaluateFrequencyStepDown:
         """Habit with recent frequency change is in cooldown."""
         recent = datetime.now(tz=UTC) - timedelta(days=3)
         habit = self._habit_with_notifications(
-            db, notification_frequency="daily",
-            already_done=14, other_response=0,
+            db,
+            notification_frequency="daily",
+            already_done=14,
+            other_response=0,
             last_frequency_changed_at=recent,
         )
         result = evaluate_frequency_step_down(db, habit.id)
@@ -945,8 +1017,10 @@ class TestEvaluateFrequencyStepDown:
         """Habit with frequency change > 7 days ago is past cooldown."""
         old = datetime.now(tz=UTC) - timedelta(days=10)
         habit = self._habit_with_notifications(
-            db, notification_frequency="daily",
-            already_done=14, other_response=0,
+            db,
+            notification_frequency="daily",
+            already_done=14,
+            other_response=0,
             last_frequency_changed_at=old,
         )
         result = evaluate_frequency_step_down(db, habit.id)
@@ -958,8 +1032,10 @@ class TestEvaluateFrequencyStepDown:
         """Frequency change exactly 7 days ago — cooldown has expired."""
         boundary = datetime.now(tz=UTC) - timedelta(days=7)
         habit = self._habit_with_notifications(
-            db, notification_frequency="daily",
-            already_done=14, other_response=0,
+            db,
+            notification_frequency="daily",
+            already_done=14,
+            other_response=0,
             last_frequency_changed_at=boundary,
         )
         result = evaluate_frequency_step_down(db, habit.id)
@@ -972,8 +1048,10 @@ class TestEvaluateFrequencyStepDown:
     def test_paused_habit_rejected(self, db):
         """Paused habits are not evaluated for step-down."""
         habit = self._habit_with_notifications(
-            db, notification_frequency="daily",
-            already_done=14, other_response=0,
+            db,
+            notification_frequency="daily",
+            already_done=14,
+            other_response=0,
             status="paused",
         )
         result = evaluate_frequency_step_down(db, habit.id)
@@ -984,8 +1062,10 @@ class TestEvaluateFrequencyStepDown:
     def test_tracking_scaffolding_rejected(self, db):
         """Tracking habits are not evaluated for step-down."""
         habit = self._habit_with_notifications(
-            db, notification_frequency="daily",
-            already_done=14, other_response=0,
+            db,
+            notification_frequency="daily",
+            already_done=14,
+            other_response=0,
             scaffolding_status="tracking",
         )
         result = evaluate_frequency_step_down(db, habit.id)
@@ -1005,12 +1085,20 @@ class TestEvaluateFrequencyStepDown:
         # 14 recent "Already done"
         for i in range(14):
             _create_notification(
-                db, habit.id, "Already done", "responded", days_ago=i + 1,
+                db,
+                habit.id,
+                "Already done",
+                "responded",
+                days_ago=i + 1,
             )
         # 10 older "Skip today" — should be excluded by LIMIT
         for i in range(10):
             _create_notification(
-                db, habit.id, "Skip today", "responded", days_ago=20 + i,
+                db,
+                habit.id,
+                "Skip today",
+                "responded",
+                days_ago=20 + i,
             )
 
         result = evaluate_frequency_step_down(db, habit.id)
@@ -1024,7 +1112,11 @@ class TestEvaluateFrequencyStepDown:
         habit = _create_habit(db, notification_frequency="daily")
         for i in range(10):
             _create_notification(
-                db, habit.id, "Already done", "responded", days_ago=i + 1,
+                db,
+                habit.id,
+                "Already done",
+                "responded",
+                days_ago=i + 1,
             )
         _create_notification(db, habit.id, None, "pending", days_ago=1)
         _create_notification(db, habit.id, None, "delivered", days_ago=1)
@@ -1040,7 +1132,6 @@ class TestEvaluateFrequencyStepDown:
 
 
 class TestApplyFrequencyStepDown:
-
     def _accountable_habit(self, db, notification_frequency="daily") -> Habit:
         return _create_habit(
             db,
@@ -1084,11 +1175,7 @@ class TestApplyFrequencyStepDown:
         habit = self._accountable_habit(db)
         apply_frequency_step_down(db, habit.id, "every_other_day")
 
-        log = (
-            db.query(ActivityLog)
-            .filter(ActivityLog.habit_id == habit.id)
-            .first()
-        )
+        log = db.query(ActivityLog).filter(ActivityLog.habit_id == habit.id).first()
         assert log is not None
         assert log.action_type == "completed"
         assert "stepped down" in log.notes
@@ -1148,11 +1235,9 @@ class TestApplyFrequencyStepDown:
 
 
 class TestManualFrequencyOverrideCooldown:
-
     def test_manual_change_sets_last_frequency_changed_at(self, client):
         """Changing notification_frequency via PATCH sets last_frequency_changed_at."""
-        habit = make_habit(client, notification_frequency="daily",
-                          scaffolding_status="accountable")
+        habit = make_habit(client, notification_frequency="daily", scaffolding_status="accountable")
 
         resp = client.patch(
             f"/api/habits/{habit['id']}",
@@ -1165,8 +1250,7 @@ class TestManualFrequencyOverrideCooldown:
 
     def test_same_frequency_does_not_reset_cooldown(self, client):
         """Setting notification_frequency to the same value does NOT reset cooldown."""
-        habit = make_habit(client, notification_frequency="daily",
-                          scaffolding_status="accountable")
+        habit = make_habit(client, notification_frequency="daily", scaffolding_status="accountable")
 
         resp = client.patch(
             f"/api/habits/{habit['id']}",
@@ -1177,8 +1261,9 @@ class TestManualFrequencyOverrideCooldown:
 
     def test_manual_override_then_cooldown_respected(self, client, db):
         """After manual override, step-down evaluation sees cooldown."""
-        habit_data = make_habit(client, notification_frequency="daily",
-                                scaffolding_status="accountable")
+        habit_data = make_habit(
+            client, notification_frequency="daily", scaffolding_status="accountable"
+        )
 
         # Manual override to weekly
         client.patch(
@@ -1190,7 +1275,11 @@ class TestManualFrequencyOverrideCooldown:
         habit_id = uuid.UUID(habit_data["id"])
         for i in range(14):
             _create_notification(
-                db, habit_id, "Already done", "responded", days_ago=i + 1,
+                db,
+                habit_id,
+                "Already done",
+                "responded",
+                days_ago=i + 1,
             )
 
         result = evaluate_frequency_step_down(db, habit_id)
@@ -1304,9 +1393,7 @@ class TestEvaluateGraduatedHabitSlip:
 
         assert result.slip_detected is False
         # No checklist signals even if we somehow had checklist notifications
-        assert all(
-            s.signal_type != "missed_in_checklist" for s in result.slip_signals
-        )
+        assert all(s.signal_type != "missed_in_checklist" for s in result.slip_signals)
 
     def test_checklist_warning_3_misses(self, db):
         """3 partial/expired routine checklists in 14 days → warning signal."""
@@ -1318,7 +1405,11 @@ class TestEvaluateGraduatedHabitSlip:
         # 3 partial checklist responses
         for i in range(3):
             _create_routine_checklist(
-                db, routine.id, "Partial", "responded", days_ago=i + 1,
+                db,
+                routine.id,
+                "Partial",
+                "responded",
+                days_ago=i + 1,
             )
 
         result = evaluate_graduated_habit_slip(db, habit.id)
@@ -1341,11 +1432,19 @@ class TestEvaluateGraduatedHabitSlip:
         # 5 partial/expired checklist responses
         for i in range(3):
             _create_routine_checklist(
-                db, routine.id, "Partial", "responded", days_ago=i + 1,
+                db,
+                routine.id,
+                "Partial",
+                "responded",
+                days_ago=i + 1,
             )
         for i in range(2):
             _create_routine_checklist(
-                db, routine.id, None, "expired", days_ago=i + 4,
+                db,
+                routine.id,
+                None,
+                "expired",
+                days_ago=i + 4,
             )
 
         result = evaluate_graduated_habit_slip(db, habit.id)
@@ -1366,7 +1465,11 @@ class TestEvaluateGraduatedHabitSlip:
             _create_completion(db, habit.id, days_ago=i + 1)
         for i in range(2):
             _create_routine_checklist(
-                db, routine.id, "Partial", "responded", days_ago=i + 1,
+                db,
+                routine.id,
+                "Partial",
+                "responded",
+                days_ago=i + 1,
             )
 
         result = evaluate_graduated_habit_slip(db, habit.id)
@@ -1385,7 +1488,11 @@ class TestEvaluateGraduatedHabitSlip:
         # 3 expired checklists
         for i in range(3):
             _create_routine_checklist(
-                db, routine.id, None, "expired", days_ago=i + 1,
+                db,
+                routine.id,
+                None,
+                "expired",
+                days_ago=i + 1,
             )
 
         result = evaluate_graduated_habit_slip(db, habit.id)
@@ -1406,7 +1513,11 @@ class TestEvaluateGraduatedHabitSlip:
         # 5 partial checklists (Signal 1 critical)
         for i in range(5):
             _create_routine_checklist(
-                db, routine.id, "Partial", "responded", days_ago=i + 1,
+                db,
+                routine.id,
+                "Partial",
+                "responded",
+                days_ago=i + 1,
             )
 
         result = evaluate_graduated_habit_slip(db, habit.id)
@@ -1424,7 +1535,11 @@ class TestEvaluateGraduatedHabitSlip:
         # 3 partial checklists (Signal 1 warning)
         for i in range(3):
             _create_routine_checklist(
-                db, routine.id, "Partial", "responded", days_ago=i + 1,
+                db,
+                routine.id,
+                "Partial",
+                "responded",
+                days_ago=i + 1,
             )
 
         result = evaluate_graduated_habit_slip(db, habit.id)
@@ -1441,7 +1556,11 @@ class TestEvaluateGraduatedHabitSlip:
         # 3 partial checklists → warning only (Signal 1)
         for i in range(3):
             _create_routine_checklist(
-                db, routine.id, "Partial", "responded", days_ago=i + 1,
+                db,
+                routine.id,
+                "Partial",
+                "responded",
+                days_ago=i + 1,
             )
 
         result = evaluate_graduated_habit_slip(db, habit.id)
@@ -1460,7 +1579,11 @@ class TestEvaluateGraduatedHabitSlip:
         # 5 complete checklists — should NOT trigger
         for i in range(5):
             _create_routine_checklist(
-                db, routine.id, "Complete", "responded", days_ago=i + 1,
+                db,
+                routine.id,
+                "Complete",
+                "responded",
+                days_ago=i + 1,
             )
 
         result = evaluate_graduated_habit_slip(db, habit.id)
@@ -1477,21 +1600,26 @@ class TestEvaluateGraduatedHabitSlip:
 
 
 class TestEvaluateAllGraduatedHabits:
-
     def test_returns_only_actionable(self, db):
         """Only habits with recommendation != 'no_action' are returned."""
         # Graduated habit with recent completions (no slip)
         good = _create_habit(
-            db, scaffolding_status="graduated", notification_frequency="graduated",
-            status="active", introduced_at=date.today() - timedelta(days=90),
+            db,
+            scaffolding_status="graduated",
+            notification_frequency="graduated",
+            status="active",
+            introduced_at=date.today() - timedelta(days=90),
         )
         for i in range(5):
             _create_completion(db, good.id, days_ago=i + 1)
 
         # Graduated habit with no completions (critical slip)
         bad = _create_habit(
-            db, scaffolding_status="graduated", notification_frequency="graduated",
-            status="active", introduced_at=date.today() - timedelta(days=90),
+            db,
+            scaffolding_status="graduated",
+            notification_frequency="graduated",
+            status="active",
+            introduced_at=date.today() - timedelta(days=90),
             title="Slipping Habit",
         )
 
@@ -1504,10 +1632,14 @@ class TestEvaluateAllGraduatedHabits:
     def test_excludes_non_graduated(self, db):
         """Accountable and tracking habits are not evaluated."""
         _create_habit(
-            db, scaffolding_status="accountable", status="active",
+            db,
+            scaffolding_status="accountable",
+            status="active",
         )
         _create_habit(
-            db, scaffolding_status="tracking", status="active",
+            db,
+            scaffolding_status="tracking",
+            status="active",
         )
 
         results = evaluate_all_graduated_habits(db)
@@ -1517,7 +1649,9 @@ class TestEvaluateAllGraduatedHabits:
     def test_excludes_inactive(self, db):
         """Paused graduated habits are not evaluated."""
         _create_habit(
-            db, scaffolding_status="graduated", notification_frequency="graduated",
+            db,
+            scaffolding_status="graduated",
+            notification_frequency="graduated",
             status="paused",
         )
 
@@ -1535,7 +1669,8 @@ class TestEvaluateAllGraduatedHabits:
         """Multiple slipping habits all appear in results."""
         for i in range(3):
             _create_habit(
-                db, scaffolding_status="graduated",
+                db,
+                scaffolding_status="graduated",
                 notification_frequency="graduated",
                 status="active",
                 introduced_at=date.today() - timedelta(days=90),
@@ -1553,7 +1688,6 @@ class TestEvaluateAllGraduatedHabits:
 
 
 class TestReScaffoldHabit:
-
     def _graduated_habit(self, db, **overrides) -> Habit:
         """Create a graduated, active habit."""
         defaults = {
@@ -1645,11 +1779,7 @@ class TestReScaffoldHabit:
 
         re_scaffold_habit(db, habit.id)
 
-        log = (
-            db.query(ActivityLog)
-            .filter(ActivityLog.habit_id == habit.id)
-            .first()
-        )
+        log = db.query(ActivityLog).filter(ActivityLog.habit_id == habit.id).first()
         assert log is not None
         assert log.action_type == "reflected"
         assert "re-scaffolded" in log.notes
@@ -1700,7 +1830,9 @@ class TestReScaffoldHabit:
     def test_reject_paused(self, db):
         """Cannot re-scaffold a paused habit."""
         habit = _create_habit(
-            db, scaffolding_status="graduated", notification_frequency="graduated",
+            db,
+            scaffolding_status="graduated",
+            notification_frequency="graduated",
             status="paused",
         )
 
@@ -1754,7 +1886,9 @@ class TestGetStackingRecommendation:
         """Routine with only tracking habits returns ready=True."""
         routine = _create_routine(db)
         _create_habit(
-            db, routine_id=routine.id, scaffolding_status="tracking",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
             title="Tracking Habit",
         )
         result = get_stacking_recommendation(db, routine.id)
@@ -1771,8 +1905,11 @@ class TestGetStackingRecommendation:
         """Ready when all accountable habits have >= 60% already-done rate."""
         routine = _create_routine(db)
         habit = _create_habit(
-            db, routine_id=routine.id, scaffolding_status="accountable",
-            title="Stable Habit", notification_frequency="daily",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="accountable",
+            title="Stable Habit",
+            notification_frequency="daily",
             introduced_at=date.today() - timedelta(days=30),
         )
         # Create 10 notifications: 7 "Already done" = 70% rate
@@ -1783,7 +1920,9 @@ class TestGetStackingRecommendation:
 
         # Add a tracking habit to be suggested
         _create_habit(
-            db, routine_id=routine.id, scaffolding_status="tracking",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
             title="Next Habit",
         )
 
@@ -1801,8 +1940,11 @@ class TestGetStackingRecommendation:
         """A habit at weekly frequency is stable regardless of rate."""
         routine = _create_routine(db)
         _create_habit(
-            db, routine_id=routine.id, scaffolding_status="accountable",
-            title="Weekly Habit", notification_frequency="weekly",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="accountable",
+            title="Weekly Habit",
+            notification_frequency="weekly",
             introduced_at=date.today() - timedelta(days=30),
         )
 
@@ -1817,8 +1959,11 @@ class TestGetStackingRecommendation:
         """Stable via 14+ days accountable with 7 consecutive completions."""
         routine = _create_routine(db)
         habit = _create_habit(
-            db, routine_id=routine.id, scaffolding_status="accountable",
-            title="Consistent Habit", notification_frequency="daily",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="accountable",
+            title="Consistent Habit",
+            notification_frequency="daily",
             introduced_at=date.today() - timedelta(days=20),
         )
         # No notifications (rate would be 0), but 7 completions in last 7 days
@@ -1836,8 +1981,11 @@ class TestGetStackingRecommendation:
         """Not ready when an accountable habit has low rate and no completions."""
         routine = _create_routine(db)
         habit = _create_habit(
-            db, routine_id=routine.id, scaffolding_status="accountable",
-            title="Struggling Habit", notification_frequency="daily",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="accountable",
+            title="Struggling Habit",
+            notification_frequency="daily",
             introduced_at=date.today() - timedelta(days=10),
         )
         # 10 notifications: 3 "Already done" = 30% rate (below 60%)
@@ -1859,14 +2007,20 @@ class TestGetStackingRecommendation:
 
         # Active tracking habit created first
         _create_habit(
-            db, routine_id=routine.id, scaffolding_status="tracking",
-            status="active", title="Active Tracking",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="active",
+            title="Active Tracking",
         )
 
         # Paused tracking habit
         _create_habit(
-            db, routine_id=routine.id, scaffolding_status="tracking",
-            status="paused", title="Paused Tracking",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="paused",
+            title="Paused Tracking",
             introduced_at=date.today() - timedelta(days=30),
         )
 
@@ -1882,13 +2036,19 @@ class TestGetStackingRecommendation:
         routine = _create_routine(db)
 
         _create_habit(
-            db, routine_id=routine.id, scaffolding_status="tracking",
-            status="paused", title="Newer Paused",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="paused",
+            title="Newer Paused",
             introduced_at=date.today() - timedelta(days=5),
         )
         _create_habit(
-            db, routine_id=routine.id, scaffolding_status="tracking",
-            status="paused", title="Older Paused",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="paused",
+            title="Older Paused",
             introduced_at=date.today() - timedelta(days=30),
         )
 
@@ -1903,12 +2063,18 @@ class TestGetStackingRecommendation:
 
         # Create in order — first created should be suggested
         _create_habit(
-            db, routine_id=routine.id, scaffolding_status="tracking",
-            status="active", title="First Tracking",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="active",
+            title="First Tracking",
         )
         _create_habit(
-            db, routine_id=routine.id, scaffolding_status="tracking",
-            status="active", title="Second Tracking",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="active",
+            title="Second Tracking",
         )
 
         result = get_stacking_recommendation(db, routine.id)
@@ -1921,8 +2087,11 @@ class TestGetStackingRecommendation:
         """All habits graduated — ready but nothing to suggest."""
         routine = _create_routine(db)
         _create_habit(
-            db, routine_id=routine.id, scaffolding_status="graduated",
-            status="active", title="Graduated One",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="graduated",
+            status="active",
+            title="Graduated One",
             notification_frequency="graduated",
         )
 
@@ -1938,13 +2107,19 @@ class TestGetStackingRecommendation:
         routine = _create_routine(db)
         # Stable accountable habit (weekly)
         _create_habit(
-            db, routine_id=routine.id, scaffolding_status="accountable",
-            title="Weekly Habit", notification_frequency="weekly",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="accountable",
+            title="Weekly Habit",
+            notification_frequency="weekly",
         )
         # Graduated habit
         _create_habit(
-            db, routine_id=routine.id, scaffolding_status="graduated",
-            status="active", title="Graduated",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="graduated",
+            status="active",
+            title="Graduated",
             notification_frequency="graduated",
         )
 
@@ -1968,13 +2143,19 @@ class TestGetStackingRecommendation:
 
         # Stable habit (weekly)
         _create_habit(
-            db, routine_id=routine.id, scaffolding_status="accountable",
-            title="Stable One", notification_frequency="weekly",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="accountable",
+            title="Stable One",
+            notification_frequency="weekly",
         )
         # Blocking habit (low rate, few days)
         blocking = _create_habit(
-            db, routine_id=routine.id, scaffolding_status="accountable",
-            title="Needs Work", notification_frequency="daily",
+            db,
+            routine_id=routine.id,
+            scaffolding_status="accountable",
+            title="Needs Work",
+            notification_frequency="daily",
             introduced_at=date.today() - timedelta(days=5),
         )
         for i in range(6):
@@ -1986,3 +2167,167 @@ class TestGetStackingRecommendation:
         assert len(result.active_accountable_habits) == 2
         assert len(result.blocking_habits) == 1
         assert result.blocking_habits[0].habit_name == "Needs Work"
+
+
+# ===========================================================================
+# [2G-fix-01] graduated_at timestamp lifecycle
+# ===========================================================================
+
+
+class TestGraduatedAtTimestamp:
+    """Tests for the graduated_at column added by 2G-fix-01."""
+
+    def _eligible_habit(self, db, **overrides) -> Habit:
+        """Create an accountable habit that meets graduation criteria."""
+        defaults = {
+            "scaffolding_status": "accountable",
+            "notification_frequency": "daily",
+            "introduced_at": date.today() - timedelta(days=60),
+            "friction_score": 1,
+        }
+        defaults.update(overrides)
+        habit = _create_habit(db, **defaults)
+        # 10 notifications, 9 "Already done" = 90% rate (mirrors TestGraduateHabit)
+        for i in range(9):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+        _create_notification(db, habit.id, "Skip today", "responded", days_ago=10)
+        return habit
+
+    def test_graduation_sets_graduated_at(self, db):
+        """graduate_habit() sets graduated_at to a UTC timestamp."""
+        habit = self._eligible_habit(db)
+        assert habit.graduated_at is None
+
+        before = datetime.now(tz=UTC)
+        graduate_habit(db, habit.id)
+        after = datetime.now(tz=UTC)
+
+        db.refresh(habit)
+        assert habit.graduated_at is not None
+        # SQLite returns naive datetimes — normalize for comparison
+        grad_ts = habit.graduated_at
+        if grad_ts.tzinfo is None:
+            grad_ts = grad_ts.replace(tzinfo=UTC)
+        assert before <= grad_ts <= after
+
+    def test_forced_graduation_sets_graduated_at(self, db):
+        """Forced graduation also sets graduated_at."""
+        habit = _create_habit(
+            db,
+            scaffolding_status="accountable",
+            notification_frequency="daily",
+            introduced_at=date.today() - timedelta(days=5),
+        )
+
+        graduate_habit(db, habit.id, force=True)
+        db.refresh(habit)
+
+        assert habit.graduated_at is not None
+
+    def test_already_graduated_does_not_update_graduated_at(self, db):
+        """Idempotent guard: re-graduating doesn't overwrite graduated_at."""
+        habit = self._eligible_habit(db)
+        graduate_habit(db, habit.id)
+        db.refresh(habit)
+        original_graduated_at = habit.graduated_at
+
+        result = graduate_habit(db, habit.id)
+
+        assert result.success is False
+        db.refresh(habit)
+        assert habit.graduated_at == original_graduated_at
+
+    def test_re_scaffold_clears_graduated_at(self, db):
+        """re_scaffold_habit() sets graduated_at back to None."""
+        habit = self._eligible_habit(db)
+        graduate_habit(db, habit.id)
+        db.refresh(habit)
+        assert habit.graduated_at is not None
+
+        re_scaffold_habit(db, habit.id)
+        db.refresh(habit)
+        assert habit.graduated_at is None
+
+    def test_slip_detection_uses_graduated_at_not_updated_at(self, db):
+        """days_since_graduation reflects graduated_at, not updated_at."""
+        habit = _create_habit(
+            db,
+            scaffolding_status="graduated",
+            notification_frequency="graduated",
+            introduced_at=date.today() - timedelta(days=90),
+        )
+        # Set graduated_at to 20 days ago
+        grad_time = datetime.now(tz=UTC) - timedelta(days=20)
+        habit.graduated_at = grad_time
+        db.commit()
+        db.refresh(habit)
+
+        # Add completions so we don't trigger slip signals
+        for i in range(5):
+            _create_completion(db, habit.id, days_ago=i + 1)
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+        assert result.days_since_graduation == 20
+
+    def test_patch_does_not_affect_days_since_graduation(self, db):
+        """Editing a graduated habit's description does not reset days_since_graduation."""
+        habit = _create_habit(
+            db,
+            scaffolding_status="graduated",
+            notification_frequency="graduated",
+            introduced_at=date.today() - timedelta(days=90),
+        )
+        # Graduate 15 days ago
+        grad_time = datetime.now(tz=UTC) - timedelta(days=15)
+        habit.graduated_at = grad_time
+        db.commit()
+        db.refresh(habit)
+
+        # Simulate a PATCH — change description, which triggers updated_at change
+        habit.description = "Updated description after graduation"
+        db.commit()
+        db.refresh(habit)
+
+        # Add completions so we don't trigger slip signals
+        for i in range(5):
+            _create_completion(db, habit.id, days_ago=i + 1)
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+        assert result.days_since_graduation == 15
+
+    def test_graduated_at_null_falls_back_to_zero(self, db):
+        """If graduated_at is None (legacy data), days_since_graduation is 0."""
+        habit = _create_habit(
+            db,
+            scaffolding_status="graduated",
+            notification_frequency="graduated",
+            introduced_at=date.today() - timedelta(days=90),
+        )
+        # graduated_at is None by default (no migration backfill)
+        assert habit.graduated_at is None
+
+        for i in range(5):
+            _create_completion(db, habit.id, days_ago=i + 1)
+
+        result = evaluate_graduated_habit_slip(db, habit.id)
+        assert result.days_since_graduation == 0
+
+    def test_graduated_at_in_response_schema(self, db):
+        """HabitResponse includes graduated_at field."""
+        from app.schemas.habits import HabitResponse
+
+        habit = self._eligible_habit(db)
+        graduate_habit(db, habit.id)
+        db.refresh(habit)
+
+        response = HabitResponse.model_validate(habit)
+        assert response.graduated_at is not None
+        assert response.graduated_at == habit.graduated_at
+
+    def test_graduated_at_null_in_response_schema(self, db):
+        """HabitResponse shows None for non-graduated habits."""
+        from app.schemas.habits import HabitResponse
+
+        habit = _create_habit(db, scaffolding_status="accountable")
+        response = HabitResponse.model_validate(habit)
+        assert response.graduated_at is None


### PR DESCRIPTION
## Summary
Replaces the `updated_at` proxy in slip detection with a dedicated `graduated_at` column on the Habit model. Any PATCH to a graduated habit previously reset `days_since_graduation` to 0 silently — this fix ensures graduation timing is stable and accurate.

## Changes
- **Migration** (`alembic/versions/016_add_graduated_at_to_habits.py`): Adds nullable `graduated_at` column (TIMESTAMPTZ) to the `habits` table.
- **Model** (`app/models.py`): Adds `graduated_at: Mapped[datetime | None]` to the `Habit` class.
- **Schema** (`app/schemas/habits.py`): Adds `graduated_at: datetime | None = None` to `HabitResponse`.
- **Service** (`app/services/graduation.py`):
  - `graduate_habit()`: Sets `graduated_at = datetime.now(tz=UTC)` alongside the scaffolding transition.
  - `re_scaffold_habit()`: Clears `graduated_at = None` when reversing graduation.
  - `evaluate_graduated_habit_slip()`: Replaces `updated_at` proxy block with `graduated_at` for `days_since_graduation` calculation.
- **Tests** (`tests/test_graduation.py`): 9 new tests in `TestGraduatedAtTimestamp` covering the full lifecycle — graduation sets it, re-scaffolding clears it, slip detection uses it, PATCH doesn't affect it, NULL fallback works, schema inclusion verified.

## How to Verify
1. `pip install -r requirements.txt` (if needed)
2. `pytest -v tests/test_graduation.py::TestGraduatedAtTimestamp` — all 9 tests pass
3. `pytest -v` — full suite (1246 tests) passes
4. `ruff check .` — clean
5. For deployed environment: run `alembic upgrade head` to apply migration 016

## Deviations
None. Fully aligned with issue #162 spec.

## Test Results
```
pytest -v: 1246 passed in 17.76s
ruff check: All checks passed
```

## Acceptance Checklist
- [x] `graduated_at` column exists on Habit model (nullable TIMESTAMPTZ)
- [x] `graduate_habit()` sets `graduated_at` to current UTC timestamp
- [x] `re_scaffold_habit()` clears `graduated_at` to None
- [x] `evaluate_graduated_habit_slip()` uses `graduated_at` instead of `updated_at`
- [x] `HabitResponse` includes `graduated_at`
- [x] PATCHing a graduated habit does not change `days_since_graduation`
- [x] All existing tests still pass
- [x] New tests cover graduation timestamp lifecycle

Closes #162