### PR TITLE
[2G-fix-02]: Add position field to Habit model for routine ordering

### DIFF
--- a/alembic/versions/017_add_position_to_habits.py
+++ b/alembic/versions/017_add_position_to_habits.py
@@ -1,0 +1,45 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Add position column to habits table for routine ordering.
+
+Revision ID: 17a1b2c3d4e5
+Revises: 16a1b2c3d4e5
+Create Date: 2026-04-15
+
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "17a1b2c3d4e5"
+down_revision: Union[str, None] = "16a1b2c3d4e5"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "habits",
+        sa.Column("position", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("habits", "position")

--- a/app/models.py
+++ b/app/models.py
@@ -588,6 +588,7 @@ class Habit(Base):
     )
     graduation_threshold: Mapped[int | None] = mapped_column(Integer, default=30)
     friction_score: Mapped[int | None] = mapped_column(Integer)
+    position: Mapped[int | None] = mapped_column(Integer)
     re_scaffold_count: Mapped[int] = mapped_column(
         Integer,
         nullable=False,

--- a/app/schemas/habits.py
+++ b/app/schemas/habits.py
@@ -47,6 +47,7 @@ class HabitCreate(BaseModel):
     graduation_target: float | None = None
     graduation_threshold: int | None = None
     friction_score: int | None = None
+    position: int | None = None
 
     @field_validator("graduation_target")
     @classmethod
@@ -87,6 +88,7 @@ class HabitUpdate(BaseModel):
     graduation_target: float | None = None
     graduation_threshold: int | None = None
     friction_score: int | None = None
+    position: int | None = None
 
     @field_validator("graduation_target")
     @classmethod
@@ -123,6 +125,7 @@ class HabitResponse(BaseModel):
     graduation_target: float | None = None
     graduation_threshold: int | None = None
     friction_score: int | None = None
+    position: int | None = None
     re_scaffold_count: int
     last_frequency_changed_at: datetime | None = None
     graduated_at: datetime | None = None

--- a/app/services/graduation.py
+++ b/app/services/graduation.py
@@ -1033,7 +1033,10 @@ def get_stacking_recommendation(
         # ordered by introduced_at (oldest first)
         paused_tracking = [h for h in paused_habits if h.scaffolding_status == "tracking"]
         paused_tracking.sort(
-            key=lambda h: h.introduced_at or datetime.min.date(),
+            key=lambda h: (
+                h.position if h.position is not None else float("inf"),
+                h.introduced_at or datetime.min.date(),
+            ),
         )
 
         if paused_tracking:
@@ -1048,10 +1051,14 @@ def get_stacking_recommendation(
                 ),
             )
         else:
-            # Priority 2: Active tracking habits, ordered by created_at
-            # (position field not yet available — using created_at as proxy)
+            # Priority 2: Active tracking habits, ordered by position then created_at
             active_tracking = [h for h in active_habits if h.scaffolding_status == "tracking"]
-            active_tracking.sort(key=lambda h: h.created_at)
+            active_tracking.sort(
+                key=lambda h: (
+                    h.position if h.position is not None else float("inf"),
+                    h.created_at,
+                ),
+            )
 
             if active_tracking:
                 pick = active_tracking[0]

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -2331,3 +2331,179 @@ class TestGraduatedAtTimestamp:
         habit = _create_habit(db, scaffolding_status="accountable")
         response = HabitResponse.model_validate(habit)
         assert response.graduated_at is None
+
+
+# ===========================================================================
+# [2G-fix-02] position field for routine ordering
+# ===========================================================================
+
+
+class TestHabitPositionField:
+    """Tests for the position column added by 2G-fix-02."""
+
+    def test_position_accepted_on_create(self, client):
+        """POST /api/habits accepts position field."""
+        from tests.conftest import make_habit
+
+        habit = make_habit(client, position=3)
+        assert habit["position"] == 3
+
+    def test_position_accepted_on_update(self, client):
+        """PATCH /api/habits/{id} accepts position field."""
+        from tests.conftest import make_habit
+
+        habit = make_habit(client)
+        assert habit["position"] is None
+
+        resp = client.patch(f"/api/habits/{habit['id']}", json={"position": 5})
+        assert resp.status_code == 200
+        assert resp.json()["position"] == 5
+
+    def test_position_in_response(self, client):
+        """HabitResponse includes position field."""
+        from tests.conftest import make_habit
+
+        habit = make_habit(client, position=1)
+        resp = client.get(f"/api/habits/{habit['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["position"] == 1
+
+    def test_position_defaults_to_null(self, client):
+        """Position is null when not specified."""
+        from tests.conftest import make_habit
+
+        habit = make_habit(client)
+        assert habit["position"] is None
+
+    def test_tracking_ordered_by_position_then_created_at(self, db):
+        """Active tracking habits sorted by position first, then created_at."""
+        routine = _create_routine(db)
+
+        # Create habits in reverse position order
+        _create_habit(
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="active",
+            title="Position 2",
+            position=2,
+        )
+        _create_habit(
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="active",
+            title="Position 1",
+            position=1,
+        )
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.suggested_next is not None
+        assert result.suggested_next.habit_name == "Position 1"
+
+    def test_null_position_sorts_after_explicit(self, db):
+        """Habits with null position sort after habits with explicit positions."""
+        routine = _create_routine(db)
+
+        # Null position created first (would win on created_at alone)
+        _create_habit(
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="active",
+            title="No Position",
+            position=None,
+        )
+        _create_habit(
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="active",
+            title="Has Position",
+            position=10,
+        )
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.suggested_next is not None
+        assert result.suggested_next.habit_name == "Has Position"
+
+    def test_paused_ordered_by_position_then_introduced_at(self, db):
+        """Paused tracking habits sorted by position first, then introduced_at."""
+        routine = _create_routine(db)
+
+        _create_habit(
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="paused",
+            title="Paused Pos 3",
+            position=3,
+            introduced_at=date.today() - timedelta(days=60),
+        )
+        _create_habit(
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="paused",
+            title="Paused Pos 1",
+            position=1,
+            introduced_at=date.today() - timedelta(days=5),
+        )
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.suggested_next is not None
+        assert result.suggested_next.habit_name == "Paused Pos 1"
+        assert result.suggested_next.source == "paused"
+
+    def test_paused_null_position_falls_back_to_introduced_at(self, db):
+        """Paused habits with null position fall back to introduced_at ordering."""
+        routine = _create_routine(db)
+
+        _create_habit(
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="paused",
+            title="Newer Paused",
+            introduced_at=date.today() - timedelta(days=5),
+        )
+        _create_habit(
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="paused",
+            title="Older Paused",
+            introduced_at=date.today() - timedelta(days=30),
+        )
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.suggested_next is not None
+        assert result.suggested_next.habit_name == "Older Paused"
+
+    def test_created_at_fallback_when_all_positions_null(self, db):
+        """With no position set, falls back to created_at ordering."""
+        routine = _create_routine(db)
+
+        _create_habit(
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="active",
+            title="First Created",
+        )
+        _create_habit(
+            db,
+            routine_id=routine.id,
+            scaffolding_status="tracking",
+            status="active",
+            title="Second Created",
+        )
+
+        result = get_stacking_recommendation(db, routine.id)
+
+        assert result.suggested_next is not None
+        assert result.suggested_next.habit_name == "First Created"


### PR DESCRIPTION
## Summary
Replaces the `created_at` proxy in stacking recommendation ordering with a dedicated `position` column on the Habit model. Habits with explicit positions sort before those without, with `created_at`/`introduced_at` as tiebreaker/fallback.

## Changes
- **Migration** (`alembic/versions/017_add_position_to_habits.py`): Adds nullable `position` column (Integer) to the `habits` table.
- **Model** (`app/models.py`): Adds `position: Mapped[int | None]` to the `Habit` class.
- **Schema** (`app/schemas/habits.py`): Adds `position: int | None = None` to `HabitCreate`, `HabitUpdate`, and `HabitResponse`.
- **Service** (`app/services/graduation.py`):
  - Active tracking habits sort by `(position, created_at)` with null positions at the end.
  - Paused tracking habits sort by `(position, introduced_at)` with null positions at the end.
  - Removed the proxy comment noting the workaround.
- **Tests** (`tests/test_graduation.py`): 9 new tests in `TestHabitPositionField` covering position on create/update/response, position-based ordering for both active and paused habits, null position fallback behavior, and created_at fallback when all positions are null.

## How to Verify
1. `pip install -r requirements.txt` (if needed)
2. `pytest -v tests/test_graduation.py::TestHabitPositionField` — all 9 tests pass
3. `pytest -v` — full suite (1255 tests) passes
4. `ruff check .` — clean
5. For deployed environment: run `alembic upgrade head` to apply migration 017

## Deviations
None. Fully aligned with issue #163 spec.

## Test Results
```
pytest -v: 1255 passed in 17.38s
ruff check: All checks passed
```

## Acceptance Checklist
- [x] `position` column exists on Habit model (nullable Integer)
- [x] `HabitCreate` and `HabitUpdate` accept `position`
- [x] `HabitResponse` includes `position`
- [x] Stacking recommendation sorts by `position` first, then `created_at`
- [x] Habits with null `position` sort after habits with explicit positions
- [x] Paused habit suggestions also respect `position` ordering
- [x] All existing tests still pass
- [x] New tests cover position-based ordering

Closes #163