### PR TITLE
fix: [2G-Gap-01] Auto-populate introduced_at on transition to accountable

### DIFF
--- a/app/routers/habits.py
+++ b/app/routers/habits.py
@@ -45,7 +45,14 @@ def create_habit(payload: HabitCreate, db: Session = Depends(get_db)) -> Habit:
         if not routine:
             raise HTTPException(status_code=400, detail="Routine not found")
 
-    habit = Habit(**payload.model_dump())
+    fields = payload.model_dump()
+
+    # [2G-Gap-01] Auto-populate introduced_at when creating an accountable
+    # habit without an explicit date. Graduation needs a start anchor.
+    if fields.get("scaffolding_status") == "accountable" and fields.get("introduced_at") is None:
+        fields["introduced_at"] = date.today()
+
+    habit = Habit(**fields)
     db.add(habit)
     db.commit()
     db.refresh(habit)
@@ -122,6 +129,16 @@ def update_habit(
         and updates["notification_frequency"] != habit.notification_frequency
     ):
         updates["last_frequency_changed_at"] = datetime.now(tz=UTC)
+
+    # [2G-Gap-01] Auto-populate introduced_at on transition to accountable.
+    # Graduation evaluation reads introduced_at to compute days_since_introduction;
+    # without an anchor date it cannot produce a correct result.
+    if (
+        updates.get("scaffolding_status") == "accountable"
+        and "introduced_at" not in updates
+        and habit.introduced_at is None
+    ):
+        updates["introduced_at"] = date.today()
 
     for field, value in updates.items():
         setattr(habit, field, value)

--- a/tests/test_habits.py
+++ b/tests/test_habits.py
@@ -16,6 +16,8 @@
 
 """Tests for Habit CRUD endpoints."""
 
+from datetime import date
+
 from tests.conftest import FAKE_UUID, make_domain, make_habit, make_routine
 
 # ---------------------------------------------------------------------------
@@ -376,6 +378,121 @@ class TestUpdateHabit:
             f"/api/habits/{habit['id']}", json={"graduation_target": 2.0},
         )
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# [2G-Gap-01] Auto-populate introduced_at on transition to accountable
+# ---------------------------------------------------------------------------
+
+
+class TestIntroducedAtAutoPopulate:
+
+    def test_create_accountable_without_introduced_at_sets_today(self, client):
+        """POST with scaffolding_status=accountable and no introduced_at → today."""
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Meditate",
+                "frequency": "daily",
+                "scaffolding_status": "accountable",
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json()["introduced_at"] == date.today().isoformat()
+
+    def test_create_accountable_with_explicit_introduced_at_respected(self, client):
+        """POST with explicit introduced_at is never overwritten."""
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Meditate",
+                "frequency": "daily",
+                "scaffolding_status": "accountable",
+                "introduced_at": "2026-01-15",
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json()["introduced_at"] == "2026-01-15"
+
+    def test_create_tracking_leaves_introduced_at_null(self, client):
+        """POST with scaffolding_status=tracking does not auto-set introduced_at."""
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Journal",
+                "frequency": "daily",
+                "scaffolding_status": "tracking",
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json()["introduced_at"] is None
+
+    def test_patch_transition_to_accountable_sets_today(self, client):
+        """PATCH transition tracking → accountable with no prior value → today."""
+        habit = make_habit(client, scaffolding_status="tracking")
+        assert habit["introduced_at"] is None
+
+        resp = client.patch(
+            f"/api/habits/{habit['id']}",
+            json={"scaffolding_status": "accountable"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["scaffolding_status"] == "accountable"
+        assert body["introduced_at"] == date.today().isoformat()
+
+    def test_patch_transition_with_explicit_introduced_at_respected(self, client):
+        """PATCH transition with explicit introduced_at uses the provided value."""
+        habit = make_habit(client, scaffolding_status="tracking")
+        resp = client.patch(
+            f"/api/habits/{habit['id']}",
+            json={
+                "scaffolding_status": "accountable",
+                "introduced_at": "2026-03-01",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["introduced_at"] == "2026-03-01"
+
+    def test_patch_unchanged_scaffolding_does_not_touch_introduced_at(self, client):
+        """PATCH that doesn't change scaffolding_status never modifies introduced_at."""
+        habit = make_habit(client, scaffolding_status="tracking")
+        resp = client.patch(
+            f"/api/habits/{habit['id']}",
+            json={"title": "Rename only"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["introduced_at"] is None
+
+    def test_patch_already_accountable_with_value_not_overwritten(self, client):
+        """PATCH on a habit already accountable with introduced_at set never mutates it."""
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Meditate",
+                "frequency": "daily",
+                "scaffolding_status": "accountable",
+                "introduced_at": "2026-02-20",
+            },
+        )
+        assert resp.status_code == 201
+        habit = resp.json()
+
+        # PATCH something unrelated — introduced_at must survive untouched.
+        resp = client.patch(
+            f"/api/habits/{habit['id']}", json={"title": "Meditate (renamed)"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["introduced_at"] == "2026-02-20"
+
+        # Re-sending scaffolding_status=accountable on a habit already at that
+        # value + with a date set must also leave the date unchanged.
+        resp = client.patch(
+            f"/api/habits/{habit['id']}",
+            json={"scaffolding_status": "accountable"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["introduced_at"] == "2026-02-20"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Plugged the spec-to-implementation gap where `habit.introduced_at` never got populated when a habit became `accountable`. Graduation evaluation reads that date to compute `days_since_introduction`; without it, any habit promoted to `accountable` without the client supplying the date by hand produced incorrect or zero-backed graduation math.

The fix adds two symmetric hooks in `app/routers/habits.py`:

- **POST** — when `scaffolding_status == "accountable"` and no `introduced_at` was provided, default it to `date.today()` before persisting.
- **PATCH** — when the payload sets `scaffolding_status = "accountable"`, no `introduced_at` is in the same payload, and the habit currently has `introduced_at is None`, default to `date.today()`.

Explicit client-supplied values are always respected. Habits already at `accountable` with an `introduced_at` set are never mutated. The pattern mirrors the existing `notification_frequency` → `last_frequency_changed_at` hook directly above it.

## Changes

- `app/routers/habits.py` — `create_habit` now builds a mutable `fields` dict from the payload, applies the auto-set predicate, then hands it to the `Habit` constructor. `update_habit` gains a second post-hook (next to the `last_frequency_changed_at` one) that injects `introduced_at` into `updates` when the predicate holds.
- `tests/test_habits.py` — new `TestIntroducedAtAutoPopulate` class covering all six acceptance paths plus a guard case for already-accountable habits receiving a no-op scaffolding PATCH. Adds a `from datetime import date` import for `date.today()` comparisons.

## How to Verify

1. `pytest tests/test_habits.py -v` — 55 tests, all pass (7 new).
2. `pytest` — full suite runs 1262 tests, all pass.
3. `ruff check app/routers/habits.py tests/test_habits.py` — clean.
4. Manual sanity:
   - `POST /api/habits {"title":"x","frequency":"daily","scaffolding_status":"accountable"}` → response `introduced_at` equals today.
   - `PATCH /api/habits/{id} {"scaffolding_status":"accountable"}` on a tracking habit with null `introduced_at` → response `introduced_at` equals today.
   - Either request with explicit `introduced_at` in the body → response echoes the provided value.
   - `PATCH /api/habits/{id} {"title":"rename"}` → `introduced_at` unchanged.

## Deviations

None. Implementation follows the Pass 1 recommendation and the Pass 2 brief's Work Item 3 exactly. Both create and update paths got the hook per the PO-settled decision in the issue.

## Test Results

```
pytest
============================ 1262 passed in 16.51s ============================
```

```
pytest tests/test_habits.py -v
============================= 55 passed in 0.90s ==============================
```

```
ruff check app/routers/habits.py tests/test_habits.py
All checks passed!
```

## Acceptance Checklist

- [x] Update endpoint auto-sets `introduced_at = date.today()` when transitioning to `accountable` and `introduced_at` is `None` and not in the payload.
- [x] Create endpoint auto-sets `introduced_at = date.today()` when `scaffolding_status == "accountable"` and `introduced_at` is not in the payload.
- [x] Explicit `introduced_at` in payload is always respected (never overwritten).
- [x] Existing habits already at `accountable` with `introduced_at` set are never mutated.
- [x] Tests for both paths:
  - [x] Create with `scaffolding_status=accountable`, no `introduced_at` → auto-set to today.
  - [x] Create with `scaffolding_status=accountable`, explicit `introduced_at` → respected.
  - [x] Create with `scaffolding_status=tracking` → `introduced_at` stays `None`.
  - [x] Update from `tracking` to `accountable`, no `introduced_at` → auto-set.
  - [x] Update from `tracking` to `accountable`, explicit `introduced_at` → respected.
  - [x] Update of an already-`accountable` habit with `introduced_at` set → no change.
- [x] Graduation evaluation runs end-to-end against an auto-populated habit without erroring on `days_since_introduction` — covered by the existing `test_graduation.py` suite which continues to pass after this change (verified by the full 1262-test run).

Closes #166