### PR TITLE
[2F-Bug-02] ruleoperator Postgres enum mismatched with ORM binding

### DIFF
--- a/alembic/versions/018_migrate_ruleoperator_to_wordform.py
+++ b/alembic/versions/018_migrate_ruleoperator_to_wordform.py
@@ -1,0 +1,79 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Migrate ruleoperator Postgres enum from symbols to word-form labels.
+
+Revision ID: 18a1b2c3d4e5
+Revises: 17a1b2c3d4e5
+Create Date: 2026-04-17
+
+Migration 013 created the ``ruleoperator`` Postgres enum with labels
+``('>=', '<=', '==')`` (the Python enum values). The SQLAlchemy model
+binding uses ``native_enum=False``, which serializes enum names on write
+(``'gte'``, ``'lte'``, ``'eq'``). The two disagree on every insert, so
+``create_rule`` 500s on Postgres. See BRAIN artifact 30ea0871 for the
+full investigation.
+
+This migration rotates the native enum labels to match what the ORM
+already writes — the word-form names. Paired with a one-line model flip
+to ``native_enum=True`` on the ``operator`` column, it unifies the
+declaration with the schema. Rows are re-coerced via an explicit
+``CASE`` mapping.
+"""
+
+from typing import Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "18a1b2c3d4e5"
+down_revision: Union[str, None] = "17a1b2c3d4e5"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE TYPE ruleoperator_new AS ENUM ('gte', 'lte', 'eq')")
+    op.execute(
+        """
+        ALTER TABLE rules
+        ALTER COLUMN operator TYPE ruleoperator_new
+        USING CASE operator::text
+            WHEN '>=' THEN 'gte'
+            WHEN '<=' THEN 'lte'
+            WHEN '==' THEN 'eq'
+        END::ruleoperator_new
+        """,
+    )
+    op.execute("DROP TYPE ruleoperator")
+    op.execute("ALTER TYPE ruleoperator_new RENAME TO ruleoperator")
+
+
+def downgrade() -> None:
+    op.execute("CREATE TYPE ruleoperator_old AS ENUM ('>=', '<=', '==')")
+    op.execute(
+        """
+        ALTER TABLE rules
+        ALTER COLUMN operator TYPE ruleoperator_old
+        USING CASE operator::text
+            WHEN 'gte' THEN '>='
+            WHEN 'lte' THEN '<='
+            WHEN 'eq'  THEN '=='
+        END::ruleoperator_old
+        """,
+    )
+    op.execute("DROP TYPE ruleoperator")
+    op.execute("ALTER TYPE ruleoperator_old RENAME TO ruleoperator")

--- a/app/models.py
+++ b/app/models.py
@@ -1222,7 +1222,7 @@ class Rule(Base):
         nullable=False,
     )
     operator: Mapped[RuleOperator] = mapped_column(
-        SAEnum(RuleOperator, native_enum=False),
+        SAEnum(RuleOperator, native_enum=True),
         nullable=False,
     )
     threshold: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/tests/test_rules_postgres.py
+++ b/tests/test_rules_postgres.py
@@ -1,0 +1,230 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Postgres-backed integration tests for the Rules API.
+
+The in-memory SQLite harness (``tests/conftest.py``) synthesizes the schema
+from ``Base.metadata`` and cannot observe defects that live in Alembic
+migrations or in the disagreement between the ORM binding and a native
+Postgres enum type. This module exercises ``create_rule`` end-to-end
+against a real Postgres instance migrated via Alembic — the only path
+that reproduces ``[2F-Bug-02]``.
+
+The module is skipped when no Postgres is reachable so the default
+``pytest -v`` run stays green on machines without Docker. Set
+``BRAIN3_TEST_POSTGRES_URL`` to override the server connection (for CI
+or non-default credentials). The test DB itself is created, migrated,
+and dropped per session.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.config import settings
+from app.database import get_db
+from app.main import app
+
+# ---------------------------------------------------------------------------
+# Connection — server-level URL (for CREATE/DROP DATABASE) and per-test DB
+# ---------------------------------------------------------------------------
+
+_TEST_DB_NAME = "brain3_test_ruleoperator"
+
+
+def _pg_host() -> str:
+    """Host to reach Postgres from the test runner.
+
+    Settings defaults ``POSTGRES_HOST`` to ``db`` (the compose service name)
+    so the API container can resolve it. Tests run on the host machine and
+    need ``localhost``. Honour an override so CI can point elsewhere.
+    """
+    return os.environ.get("BRAIN3_TEST_POSTGRES_HOST", "localhost")
+
+
+def _server_url() -> str:
+    """URL for the Postgres server's default ``postgres`` database."""
+    return (
+        f"postgresql://{settings.POSTGRES_USER}:{settings.POSTGRES_PASSWORD}"
+        f"@{_pg_host()}:{settings.POSTGRES_PORT}/postgres"
+    )
+
+
+def _test_db_url() -> str:
+    base = _server_url().rsplit("/", 1)[0]
+    return f"{base}/{_TEST_DB_NAME}"
+
+
+def _postgres_available() -> bool:
+    try:
+        engine = create_engine(_server_url(), isolation_level="AUTOCOMMIT")
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        engine.dispose()
+    except Exception:
+        return False
+    return True
+
+
+pytestmark = pytest.mark.skipif(
+    not _postgres_available(),
+    reason="Postgres not reachable — set BRAIN3_TEST_POSTGRES_URL or start brain3-dev",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def pg_engine() -> Generator[Engine, None, None]:
+    """Create a fresh test DB, run Alembic migrations against it, tear down."""
+    # The autouse setup_database fixture in tests/conftest.py calls
+    # Base.metadata.create_all against the SQLite engine for every test. That
+    # is harmless here — we build an independent Postgres engine and override
+    # get_db per test.
+    server = create_engine(_server_url(), isolation_level="AUTOCOMMIT")
+    with server.connect() as conn:
+        conn.execute(
+            text(f"DROP DATABASE IF EXISTS {_TEST_DB_NAME} WITH (FORCE)"),
+        )
+        conn.execute(text(f"CREATE DATABASE {_TEST_DB_NAME}"))
+
+    # alembic/env.py re-reads settings.database_url on every invocation, so we
+    # point settings at the test DB before command.upgrade runs and restore
+    # the originals after. Mutating settings in-place is safe: no live app
+    # code path is bound to this module's lifecycle.
+    from alembic import command
+    from alembic.config import Config
+
+    saved = (settings.POSTGRES_HOST, settings.POSTGRES_DB)
+    settings.POSTGRES_HOST = _pg_host()
+    settings.POSTGRES_DB = _TEST_DB_NAME
+    try:
+        alembic_cfg = Config(str(_repo_root() / "alembic.ini"))
+        alembic_cfg.set_main_option(
+            "script_location", str(_repo_root() / "alembic"),
+        )
+        command.upgrade(alembic_cfg, "head")
+    finally:
+        settings.POSTGRES_HOST, settings.POSTGRES_DB = saved
+
+    engine = create_engine(_test_db_url())
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+        with server.connect() as conn:
+            conn.execute(
+                text(f"DROP DATABASE IF EXISTS {_TEST_DB_NAME} WITH (FORCE)"),
+            )
+        server.dispose()
+
+
+@pytest.fixture
+def pg_client(pg_engine: Engine) -> Generator[TestClient, None, None]:
+    """TestClient bound to the Postgres test DB via a get_db override."""
+    TestingSession = sessionmaker(bind=pg_engine, autocommit=False, autoflush=False)
+
+    def _override_get_db() -> Generator[Session, None, None]:
+        session = TestingSession()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.fixture(autouse=True)
+def _clean_rules(pg_engine: Engine) -> Generator[None, None, None]:
+    """Truncate rules between tests so each starts from a known state."""
+    with pg_engine.begin() as conn:
+        conn.execute(text("TRUNCATE TABLE rules RESTART IDENTITY CASCADE"))
+    yield
+
+
+def _repo_root():
+    from pathlib import Path
+
+    return Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+_BASE_PAYLOAD = {
+    "name": "Postgres round-trip",
+    "entity_type": "habit",
+    "metric": "consecutive_skips",
+    "threshold": 3,
+    "notification_type": "pattern_observation",
+    "message_template": "{entity_name} skipped {metric_value} times",
+}
+
+
+@pytest.mark.parametrize("operator", [">=", "<=", "=="])
+def test_create_rule_round_trips_operator_on_postgres(
+    pg_client: TestClient, operator: str,
+) -> None:
+    """create_rule must succeed and return the original operator symbol.
+
+    Before [2F-Bug-02]'s fix the ORM wrote ``'gte'`` while the Postgres enum
+    only accepted ``'>='`` — this assertion regresses to a 500 on every
+    operator value.
+    """
+    payload = {**_BASE_PAYLOAD, "operator": operator}
+
+    resp = pg_client.post("/api/rules/", json=payload)
+
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["operator"] == operator
+    rule_id = body["id"]
+
+    # Explicit read-back confirms the value survives a second round trip
+    # through hydration (enum name in DB → enum value on the wire).
+    get_resp = pg_client.get(f"/api/rules/{rule_id}")
+    assert get_resp.status_code == 200, get_resp.text
+    assert get_resp.json()["operator"] == operator
+
+
+def test_ruleoperator_enum_labels_are_wordform(pg_engine: Engine) -> None:
+    """The Postgres enum type must carry word-form labels after migration 018."""
+    with pg_engine.connect() as conn:
+        labels = conn.execute(
+            text(
+                "SELECT enumlabel FROM pg_enum "
+                "JOIN pg_type ON pg_type.oid = pg_enum.enumtypid "
+                "WHERE pg_type.typname = 'ruleoperator' "
+                "ORDER BY enumsortorder",
+            ),
+        ).scalars().all()
+
+    assert labels == ["gte", "lte", "eq"]

--- a/tests/test_rules_postgres.py
+++ b/tests/test_rules_postgres.py
@@ -41,6 +41,8 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
 
+from alembic import command
+from alembic import config as alembic_config
 from app.config import settings
 from app.database import get_db
 from app.main import app
@@ -114,14 +116,11 @@ def pg_engine() -> Generator[Engine, None, None]:
     # point settings at the test DB before command.upgrade runs and restore
     # the originals after. Mutating settings in-place is safe: no live app
     # code path is bound to this module's lifecycle.
-    from alembic import command
-    from alembic.config import Config
-
     saved = (settings.POSTGRES_HOST, settings.POSTGRES_DB)
     settings.POSTGRES_HOST = _pg_host()
     settings.POSTGRES_DB = _TEST_DB_NAME
     try:
-        alembic_cfg = Config(str(_repo_root() / "alembic.ini"))
+        alembic_cfg = alembic_config.Config(str(_repo_root() / "alembic.ini"))
         alembic_cfg.set_main_option(
             "script_location", str(_repo_root() / "alembic"),
         )


### PR DESCRIPTION
## Summary

Unblocks every Stream F write path. `ruleoperator` — the one Postgres native enum in the schema where Python enum names (`gte/lte/eq`) differ from values (`>=/<=/==`) — had the SA model declaring `native_enum=False` (which serializes names) while migration 013 created a native Postgres enum with the symbol labels. Every `create_rule` / `update_rule` against Postgres 500'd with `invalid input value for enum ruleoperator: "gte"`. The existing SQLite test harness synthesizes schema from `Base.metadata` and therefore never saw it; PR brain3-mcp#59 removed the upstream Pydantic gate that had been masking it.

This PR rotates the Postgres enum labels to match what the ORM already writes (the names), flips the operator column's SA binding to `native_enum=True` so the declaration matches the schema, and adds a Postgres-backed integration test for `create_rule` so the test-visibility gap that let this ship closes with it.

Stellan's full investigation: BRAIN artifact `30ea0871-d21b-4254-99c3-8a1e1d448a70`.

## Changes

- **`alembic/versions/018_migrate_ruleoperator_to_wordform.py`** (new) — standard Postgres enum rename-dance: create `ruleoperator_new` with `('gte','lte','eq')`, `ALTER TABLE ... USING CASE` with an explicit mapping, drop the old type, rename the new one back. Downgrade reverses the CASE mapping.
- **`app/models.py`** (1 line) — operator column flipped from `SAEnum(RuleOperator, native_enum=False)` to `native_enum=True`. Scoped to `operator` only per Stellan's recommendation; the other three rule columns keep `native_enum=False` because their names equal their values and the two bindings are functionally equivalent for them.
- **`tests/test_rules_postgres.py`** (new) — module creates a dedicated Postgres test DB, runs Alembic migrations against it, then parametrises `create_rule` over all three operator symbols via the real HTTP stack. Also asserts `pg_enum` labels are `{gte, lte, eq}` post-migration. Skips cleanly when Postgres is unreachable so the default `pytest -v` stays portable; honours `BRAIN3_TEST_POSTGRES_HOST` for CI.

## How to Verify

1. Start the dev Postgres: `docker compose -f docker-compose.dev.yml up -d postgres`
2. Apply migrations against a clean DB:
   ```
   createdb -h localhost -U brain3 brain3_verify
   POSTGRES_HOST=localhost POSTGRES_DB=brain3_verify alembic upgrade head
   psql -h localhost -U brain3 -d brain3_verify -c "\dT+ ruleoperator"
   ```
   Expect labels `{gte, lte, eq}`.
3. Confirm reversibility: `alembic downgrade -1`, re-inspect — labels revert to `{>=, <=, ==}`. `alembic upgrade head` to restore.
4. Run the full suite from the repo root: `pytest -v`. The four `test_rules_postgres` cases must pass when Postgres is reachable.
5. Stash this PR (`git stash` on a clean check-out of this branch) and re-run `pytest tests/test_rules_postgres.py` — all four must fail, proving the test is a valid regression detector.
6. Run `ruff check .` — must be clean.

## Deviations

None. Implements Stellan's Option A (migration + one-line model cleanup + Postgres-backed integration test). Option B (`values_callable` only) was explicitly not chosen.

## Test Results

```
$ pytest -v
...
============================ 1266 passed in 18.43s ============================

$ ruff check .
All checks passed!
```

The four Postgres-backed tests:
```
tests/test_rules_postgres.py::test_create_rule_round_trips_operator_on_postgres[>=] PASSED
tests/test_rules_postgres.py::test_create_rule_round_trips_operator_on_postgres[<=] PASSED
tests/test_rules_postgres.py::test_create_rule_round_trips_operator_on_postgres[==] PASSED
tests/test_rules_postgres.py::test_ruleoperator_enum_labels_are_wordform      PASSED
```

Confirmed against pre-PR code (branch stashed): the same four tests fail with `InvalidTextRepresentation` on the create paths and an `AssertionError` on the enum-labels test. The SQLite-only harness cannot reproduce either failure, which is exactly the blind spot this test closes.

## Acceptance Checklist

- [x] New migration `018_migrate_ruleoperator_to_wordform.py` lands on develop.
- [x] `alembic upgrade head` succeeds against a clean Postgres; `alembic downgrade -1` reverses cleanly (verified locally against `brain3_migration_check`).
- [x] On Postgres, `create_rule` with `operator: ">="` succeeds and `GET /api/rules/{id}` returns `"operator": ">="`.
- [x] Model's `operator` column updated to `native_enum=True`.
- [x] At least one Postgres-backed test asserts end-to-end round-trip of operator values.
- [x] Existing SQLite tests (`tests/test_rules.py`, `tests/test_rules_seed.py`) continue to pass unchanged.

Closes #170