### PR TITLE
[2F-Spec-01] Add Layer Coverage field to finding-report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/finding-report.md
+++ b/.github/ISSUE_TEMPLATE/finding-report.md
@@ -1,0 +1,73 @@
+---
+name: Finding Report
+about: QA, Security, or Documentation finding during hardening
+labels: ''
+assignees: ''
+---
+
+## Finding
+
+**Type:**
+<!-- Choose one: Bug | Deviation | Gap | Cosmetic | Vulnerability | Misconfiguration | Risk | Hardening | Contract Mismatch | Documentation Gap | Recommendation -->
+
+**Severity:**
+<!-- Choose one: Blocker | Major | Minor | Cosmetic -->
+
+**Filed by:**
+<!-- Agent name and designation (e.g., Quincy Assurance · QA-01) -->
+
+**Area:**
+<!-- Where in the system this finding applies.
+QA examples: Router | Schema | Filter | Cascade | Test Coverage | Edge Case
+Security examples: Input Validation | Secrets | Docker | CORS | Auth Readiness | Dependencies | Backup | Logging | Scripts
+API Doc examples: Router | Schema | OpenAPI | Filter | Report | Tool Definition | Client | Configuration -->
+
+**Ticket context:**
+<!-- Which ticket introduced or should have covered this (e.g., TICKET-05) -->
+
+---
+
+## Description
+<!-- Clear, specific description of the finding. One finding per issue. -->
+
+## Location
+<!-- File path and line number(s) where the issue exists. -->
+
+## Steps to Reproduce
+<!-- For bugs and deviations. Remove this section if not applicable. -->
+
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- What should happen according to the spec, design document, or convention. -->
+
+## Actual Behavior
+<!-- What actually happens. Include response body, error message, or output if relevant. -->
+
+## Suggested Fix
+<!-- Optional. Your analysis and recommendation. Do not implement — file only. -->
+
+## Layer Coverage
+<!-- Required for Type: Contract Mismatch. Optional for other types; remove the section if not applicable.
+List every layer that could carry state for this finding, what you checked, and what you found.
+Status column values: Checked + consistent | Checked + inconsistent | Not applicable | Not checked (blind spot).
+Any "Not checked" row must name its mitigation — a proxy test, manual probe, or follow-up issue.
+For enum / schema / typed-column findings, the standing layer list lives in BRAIN artifact
+18e6da34-03e1-4e3d-bc87-3c788f88d688 (Enum / Schema Change Checklist). -->
+
+| Layer | Status | Evidence / Notes |
+|-------|--------|------------------|
+|       |        |                  |
+
+---
+
+### Severity Reference
+
+| Severity | Meaning |
+|----------|---------|
+| **Blocker** | Release cannot proceed. Core functionality broken, data integrity at risk, or documentation cannot be written. |
+| **Major** | Significant gap but workaround exists. Should be addressed before release if possible. |
+| **Minor** | Small functional issue, low user impact. Log for next cycle. |
+| **Cosmetic** | No functional impact. Style, convention, or aesthetic issue. |


### PR DESCRIPTION
## Summary

Piece C of the three-part [2F-Spec-01] breakdown — the only piece that actually belongs in this repo. Adds a Layer Coverage section to the finding-report issue template so filers of Contract Mismatch findings must explicitly enumerate which layers they checked during investigation, which they didn't, and how they mitigated the blind spots. Closes the upstream cause of the ST-04 → ST-08 half-fix pattern where layer inconsistency hid under a single-layer report.

Pieces A (Enum / Schema Change Checklist spec template) and B (Layer Coverage Gate investigation protocol) landed in BRAIN rather than the repo; see the cross-reference block below.

## Changes

- **`.github/ISSUE_TEMPLATE/finding-report.md`** (net-new file) — finding-report template at the GitHub-standard path with a Layer Coverage section between Suggested Fix and the Severity Reference separator. The section instructs filers on when it applies (required for Contract Mismatch; optional elsewhere), what the status values mean, and points at the BRAIN checklist as the standing layer list for enum / schema / typed-column findings.

## Scope Clarification

Issue #171 specified `.github/ISSUE_TEMPLATE/finding-report.md` as an existing path, but no finding-report template was actually tracked on develop — the repo had only `.github/pull_request_template.md`. During implementation we confirmed the mismatch with L and landed the template net-new at the GitHub-standard path so it renders as a selectable template on issue filing. Whether to relocate this to an `ISSUE_TEMPLATE.md`-at-root convention instead is a separate question deferred as a future consideration — not in scope here.

Because the file is net-new rather than an edit, the diff reads as a 73-line addition rather than an insertion into an existing template.

## How to Verify

1. Open https://github.com/WilliM233/brain3/issues/new/choose after merge — "Finding Report" should appear as a selectable template.
2. Select the template and confirm the Layer Coverage section renders between Suggested Fix and Severity Reference, with the status-value guidance and BRAIN artifact reference visible in the comment body.
3. Verify the table skeleton renders as a valid markdown table (three columns, one empty row).

## Deviations

None relative to Piece C as scoped in the brief. The broader scope-narrowing of #171 (Pieces A and B relocated to BRAIN) is recorded in BRAIN activity `68383570-3faa-4487-b4a9-0747ae515dbc` and cross-referenced below.

## Test Results

Template-only PR — no code, no tests, no lint-relevant changes. Rendering verification is manual via the "New issue" flow above.

## BRAIN Cross-Reference

Original #171 filing covered three pieces. This PR implements Piece C only.

Pieces A and B landed in BRAIN as the appropriate entity types:
- Piece A (Enum / Schema Change Checklist spec template) → BRAIN artifact 18e6da34-03e1-4e3d-bc87-3c788f88d688
- Piece B (Layer Coverage Gate investigation protocol) → BRAIN protocol db6e4239-ef0c-44e0-86ea-f7b469366024
- Binding directive → BRAIN directive d508a3bb-e654-461b-a768-c6843b47718e (Stellan agent-scoped)

See BRAIN activity 68383570 for the full process decision and rationale for the split.

## Acceptance Checklist

- [x] `.github/ISSUE_TEMPLATE/finding-report.md` includes a Layer Coverage section.
- [x] Section comments point at BRAIN artifact 18e6da34 as the standing layer list source.
- [x] PR body includes the BRAIN cross-reference block above.
- [x] No test or code changes required — template-only.
- [x] `git status` clean after merge (the only artefact is the one new tracked file).

Closes #171