### PR TITLE
[2G-Test-01]: Add endpoint-level activity-log assertions for Stream G transitions

### DIFF
--- a/tests/test_graduation_endpoints.py
+++ b/tests/test_graduation_endpoints.py
@@ -564,3 +564,91 @@ class TestEvaluateAllSlipsEndpoint:
         assert data["evaluated_count"] == 2
         assert len(data["attention_needed"]) == 1
         assert data["attention_needed"][0]["habit_id"] == str(bad.id)
+
+
+# ===========================================================================
+# 10. Activity-log side effects — endpoint-layer coverage
+#
+# Service-layer tests in test_graduation.py already assert the activity-log
+# writes for each Stream G transition. These tests close the endpoint-to-
+# retrieval Layer Coverage blind spot (issue #180): drive the transition
+# through its HTTP endpoint, then query GET /api/activity?habit_id={id}
+# and assert the expected entry is returned.
+# ===========================================================================
+
+
+class TestActivityLogEndpointCoverage:
+
+    def test_graduate_evaluated_writes_activity_log(self, client, db):
+        """Evaluated graduation via endpoint is retrievable at GET /api/activity."""
+        habit = _eligible_habit(db)
+        resp = client.post(f"/api/habits/{habit.id}/graduate")
+        assert resp.status_code == 200
+
+        log_resp = client.get(f"/api/activity?habit_id={habit.id}")
+        assert log_resp.status_code == 200
+        entries = log_resp.json()
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["action_type"] == "completed"
+        assert entry["habit_id"] == str(habit.id)
+        assert entry["notes"].startswith(f"Habit graduated: {habit.title}")
+        assert "(forced)" not in entry["notes"]
+
+    def test_graduate_forced_writes_activity_log(self, client, db):
+        """Forced graduation via endpoint is retrievable with '(forced)' label."""
+        habit = _create_habit(db)  # No notifications — not eligible
+        resp = client.post(
+            f"/api/habits/{habit.id}/graduate", json={"force": True},
+        )
+        assert resp.status_code == 200
+
+        log_resp = client.get(f"/api/activity?habit_id={habit.id}")
+        assert log_resp.status_code == 200
+        entries = log_resp.json()
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["action_type"] == "completed"
+        assert entry["habit_id"] == str(habit.id)
+        assert entry["notes"].startswith(f"Habit graduated (forced): {habit.title}")
+
+    def test_step_down_frequency_writes_activity_log(self, client, db):
+        """Step-down via endpoint is retrievable at GET /api/activity."""
+        habit = _create_habit(db, notification_frequency="daily")
+        for i in range(10):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+
+        resp = client.post(f"/api/habits/{habit.id}/step-down-frequency")
+        assert resp.status_code == 200
+
+        log_resp = client.get(f"/api/activity?habit_id={habit.id}")
+        assert log_resp.status_code == 200
+        entries = log_resp.json()
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["action_type"] == "completed"
+        assert entry["habit_id"] == str(habit.id)
+        assert entry["notes"].startswith(
+            f"Notification frequency stepped down: {habit.title}",
+        )
+        assert "daily → every_other_day" in entry["notes"]
+
+    def test_re_scaffold_writes_activity_log(self, client, db):
+        """Re-scaffold via endpoint is retrievable with action_type=reflected."""
+        habit = _create_habit(
+            db, scaffolding_status="graduated", notification_frequency="graduated",
+            friction_score=1, graduation_window=None, graduation_target=None,
+            graduation_threshold=None,
+        )
+        resp = client.post(f"/api/habits/{habit.id}/re-scaffold")
+        assert resp.status_code == 200
+
+        log_resp = client.get(f"/api/activity?habit_id={habit.id}")
+        assert log_resp.status_code == 200
+        entries = log_resp.json()
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["action_type"] == "reflected"
+        assert entry["habit_id"] == str(habit.id)
+        assert entry["notes"].startswith(f"Habit re-scaffolded: {habit.title}")
+        assert "re-scaffold #1" in entry["notes"]


### PR DESCRIPTION
## Verification

- `ruff check .` — ✅ Pass (All checks passed!)
- `pytest -v` — ✅ Pass (1266 passed, 4 skipped)

Ran locally against develop HEAD `91a74fd` immediately before opening this PR.

## Summary

Closes a Layer Coverage blind spot in Stream G endpoint tests. Service-layer tests in `tests/test_graduation.py` already assert activity-log writes for graduate / step-down-frequency / re-scaffold, but `tests/test_graduation_endpoints.py` contained zero assertions that the write is retrievable through the endpoint path the spec advertises (`GET /api/activity?habit_id={id}`). This PR adds four endpoint-layer integration cases that drive each transition through its HTTP endpoint and then query `GET /api/activity?habit_id={id}` to confirm the expected entry is returned.

Test-only — no production code changes.

## Changes

- `tests/test_graduation_endpoints.py` — added `TestActivityLogEndpointCoverage` class with four cases:
  - `test_graduate_evaluated_writes_activity_log` — `POST /api/habits/{id}/graduate` → asserts `completed` entry with notes starting `Habit graduated: {title}` and no `(forced)` label.
  - `test_graduate_forced_writes_activity_log` — `POST /api/habits/{id}/graduate` with `force=True` → asserts `completed` entry with notes starting `Habit graduated (forced): {title}`.
  - `test_step_down_frequency_writes_activity_log` — `POST /api/habits/{id}/step-down-frequency` → asserts `completed` entry with notes starting `Notification frequency stepped down: {title}` and containing `daily → every_other_day`.
  - `test_re_scaffold_writes_activity_log` — `POST /api/habits/{id}/re-scaffold` → asserts `reflected` entry (distinct `action_type` for this transition) with notes starting `Habit re-scaffolded: {title}` and containing `re-scaffold #1`.

Each test uses the existing file-local helpers (`_eligible_habit`, `_create_habit`, `_create_notification`) and the shared `client` / `db` fixtures from `tests/conftest.py`.

## How to Verify

1. Check out `feature/2G-Test-01-activity-log-endpoint-coverage`.
2. Run the full suite: `pytest -v` → expect 1266 passed, 4 skipped.
3. Run just the new class: `pytest tests/test_graduation_endpoints.py::TestActivityLogEndpointCoverage -v` → expect 4 passed.
4. Run `ruff check .` → expect clean.
5. Confirm no production code changed: `git diff develop -- app/ alembic/` → expect empty.

## Deviations

None.

## Test Results

```
$ pytest -v
...
====================== 1266 passed, 4 skipped in 20.24s =======================

$ ruff check .
All checks passed!

$ pytest tests/test_graduation_endpoints.py::TestActivityLogEndpointCoverage -v
tests/test_graduation_endpoints.py::TestActivityLogEndpointCoverage::test_graduate_evaluated_writes_activity_log PASSED [ 25%]
tests/test_graduation_endpoints.py::TestActivityLogEndpointCoverage::test_graduate_forced_writes_activity_log PASSED [ 50%]
tests/test_graduation_endpoints.py::TestActivityLogEndpointCoverage::test_step_down_frequency_writes_activity_log PASSED [ 75%]
tests/test_graduation_endpoints.py::TestActivityLogEndpointCoverage::test_re_scaffold_writes_activity_log PASSED [100%]
============================== 4 passed in 0.17s ==============================
```

## Acceptance Checklist

- [x] Endpoint test case exists asserting activity-log entry created via `POST /api/habits/{id}/graduate` (covers both forced and evaluated paths — two separate test methods).
- [x] Endpoint test case exists asserting activity-log entry created via `POST /api/habits/{id}/step-down-frequency`.
- [x] Endpoint test case exists asserting activity-log entry created via `POST /api/habits/{id}/re-scaffold`.
- [x] Each test drives the transition through the endpoint and then queries `GET /api/activity?habit_id={id}` to assert the write (not a direct service-layer call).
- [x] Tests pass on develop without any code changes to graduation endpoints or services (verified against `91a74fd`; issue was filed against `fd7dc2f` — no Stream G changes between the two).

Closes #180