### PR TITLE
[2A-Bug-03]: Remove scalar defaults on graduation override columns to restore friction-aware resolver

### DIFF
--- a/alembic/versions/019_drop_graduation_override_defaults.py
+++ b/alembic/versions/019_drop_graduation_override_defaults.py
@@ -1,0 +1,77 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Drop scalar server_defaults on habit graduation override columns; backfill to NULL.
+
+Revision ID: 19a1b2c3d4e5
+Revises: 18a1b2c3d4e5
+Create Date: 2026-04-18
+
+The three override columns (``graduation_window``, ``graduation_target``,
+``graduation_threshold``) were created by migration 007 with scalar
+server_defaults (30 / 0.85 / 30). Those defaults made override detection
+impossible: every habit shipped with the default value regardless of
+intent, so the ``resolve_graduation_params`` resolver in ``[2G-01]``
+could never distinguish "user override to 30" from "inherit 30 from
+friction-tier default." The friction-aware path was unreachable.
+
+Per D1 (BRAIN decision) and ``[A-1]`` v2 Amendment 01, this migration:
+1. Backfills existing rows so all three columns are NULL.
+2. Drops the server_default on each column.
+
+NULL is now the only default. ``resolve_graduation_params`` fires its
+friction-tier fallback for un-overridden habits.
+
+The blanket backfill is safe per BRAIN + L confirmation: no legitimate
+user overrides exist in prod — every row's values came from the scalar
+defaults, so nulling them preserves no user intent.
+"""
+
+from typing import Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "19a1b2c3d4e5"
+down_revision: Union[str, None] = "18a1b2c3d4e5"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    # Backfill: every existing row gets NULL in all three override columns.
+    # Safe per D1 blast-radius analysis (issue #182).
+    op.execute(
+        "UPDATE habits SET "
+        "graduation_window = NULL, "
+        "graduation_target = NULL, "
+        "graduation_threshold = NULL"
+    )
+
+    # Drop the scalar server_defaults so future INSERTs leave columns NULL
+    # unless the caller supplies an explicit override.
+    op.alter_column("habits", "graduation_window", server_default=None)
+    op.alter_column("habits", "graduation_target", server_default=None)
+    op.alter_column("habits", "graduation_threshold", server_default=None)
+
+
+def downgrade() -> None:
+    # Restore the scalar server_defaults. Row values are not restored —
+    # the pre-upgrade values were the same defaults, so the result is
+    # equivalent for habits created before migration 019.
+    op.alter_column("habits", "graduation_window", server_default="30")
+    op.alter_column("habits", "graduation_target", server_default="0.85")
+    op.alter_column("habits", "graduation_threshold", server_default="30")

--- a/app/models.py
+++ b/app/models.py
@@ -581,12 +581,11 @@ class Habit(Base):
         server_default="tracking",
     )
     introduced_at: Mapped[date | None] = mapped_column(Date)
-    graduation_window: Mapped[int | None] = mapped_column(Integer, default=30)
+    graduation_window: Mapped[int | None] = mapped_column(Integer)
     graduation_target: Mapped[float | None] = mapped_column(
         Numeric(precision=3, scale=2),
-        default=0.85,
     )
-    graduation_threshold: Mapped[int | None] = mapped_column(Integer, default=30)
+    graduation_threshold: Mapped[int | None] = mapped_column(Integer)
     friction_score: Mapped[int | None] = mapped_column(Integer)
     position: Mapped[int | None] = mapped_column(Integer)
     re_scaffold_count: Mapped[int] = mapped_column(

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -2507,3 +2507,208 @@ class TestHabitPositionField:
 
         assert result.suggested_next is not None
         assert result.suggested_next.habit_name == "First Created"
+
+
+# ===========================================================================
+# [2A-Bug-03] D1 regression — scalar defaults removed on graduation override
+# columns; NULL-means-inherit; friction-aware resolver fires end-to-end.
+#
+# Also covers Packet 5 Finding #8 Observation 1 absorption: a never-overridden
+# accountable habit must return graduation_params.source == "friction_default"
+# from GET /api/habits/{id}/graduation-status. Pre-D1 the scalar defaults made
+# the friction_default branch unreachable — every habit was labeled per_habit.
+# ===========================================================================
+
+
+class TestGraduationOverrideDefaultsD1:
+
+    def test_post_habit_without_overrides_creates_null_columns(self, client):
+        """New habit with no override payload has NULL in all three columns."""
+        resp = client.post(
+            "/api/habits",
+            json={"title": "Friction 3", "frequency": "daily", "friction_score": 3},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["graduation_window"] is None
+        assert body["graduation_target"] is None
+        assert body["graduation_threshold"] is None
+
+    def test_friction_3_habit_resolves_to_friction_3_defaults(self, client):
+        """Friction-3 habit without overrides resolves to (45, 0.85, 45)."""
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Friction 3",
+                "frequency": "daily",
+                "friction_score": 3,
+                "scaffolding_status": "accountable",
+                "introduced_at": date.today().isoformat(),
+            },
+        )
+        habit_id = resp.json()["id"]
+
+        status = client.get(f"/api/habits/{habit_id}/graduation-status")
+        assert status.status_code == 200
+        params = status.json()["graduation_params"]
+        assert params["window_days"] == 45
+        assert params["target_rate"] == 0.85
+        assert params["threshold_days"] == 45
+
+    def test_friction_4_habit_resolves_to_friction_4_defaults(self, client):
+        """Friction-4 habit without overrides resolves to (60, 0.80, 60)."""
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Friction 4",
+                "frequency": "daily",
+                "friction_score": 4,
+                "scaffolding_status": "accountable",
+                "introduced_at": date.today().isoformat(),
+            },
+        )
+        habit_id = resp.json()["id"]
+
+        status = client.get(f"/api/habits/{habit_id}/graduation-status")
+        params = status.json()["graduation_params"]
+        assert params["window_days"] == 60
+        assert params["target_rate"] == 0.80
+        assert params["threshold_days"] == 60
+
+    def test_friction_5_habit_resolves_to_friction_5_defaults(self, client):
+        """Friction-5 habit without overrides resolves to (60, 0.80, 60)."""
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Friction 5",
+                "frequency": "daily",
+                "friction_score": 5,
+                "scaffolding_status": "accountable",
+                "introduced_at": date.today().isoformat(),
+            },
+        )
+        habit_id = resp.json()["id"]
+
+        status = client.get(f"/api/habits/{habit_id}/graduation-status")
+        params = status.json()["graduation_params"]
+        assert params["window_days"] == 60
+        assert params["target_rate"] == 0.80
+        assert params["threshold_days"] == 60
+
+    def test_friction_1_habit_resolves_to_friction_1_defaults(self, client):
+        """Friction-1 habit without overrides resolves to (30, 0.85, 30)."""
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Friction 1",
+                "frequency": "daily",
+                "friction_score": 1,
+                "scaffolding_status": "accountable",
+                "introduced_at": date.today().isoformat(),
+            },
+        )
+        habit_id = resp.json()["id"]
+
+        status = client.get(f"/api/habits/{habit_id}/graduation-status")
+        params = status.json()["graduation_params"]
+        assert params["window_days"] == 30
+        assert params["target_rate"] == 0.85
+        assert params["threshold_days"] == 30
+
+    def test_user_override_via_post_is_preserved(self, client, db):
+        """POST with explicit graduation_window=50 stores 50 and resolver returns 50."""
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Override",
+                "frequency": "daily",
+                "friction_score": 5,  # would resolve to 60 without override
+                "graduation_window": 50,
+                "scaffolding_status": "accountable",
+                "introduced_at": date.today().isoformat(),
+            },
+        )
+        habit_id = resp.json()["id"]
+        assert resp.json()["graduation_window"] == 50
+
+        # Column is the override value, not the friction default.
+        habit = db.query(Habit).filter(Habit.id == uuid.UUID(habit_id)).one()
+        assert habit.graduation_window == 50
+
+        # Other columns remain NULL (unset by caller).
+        assert habit.graduation_target is None
+        assert habit.graduation_threshold is None
+
+        window, target, threshold = resolve_graduation_params(habit)
+        assert window == 50
+        assert target == 0.80  # friction-5 default for unset target
+        assert threshold == 60  # friction-5 default for unset threshold
+
+    def test_re_scaffold_compounds_against_friction_5_baseline(self, client, db):
+        """Friction-5 habit re-scaffolded once evaluates at 75/0.85/75, not 37/0.90/37."""
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Friction 5",
+                "frequency": "daily",
+                "friction_score": 5,
+                "scaffolding_status": "graduated",
+                "notification_frequency": "graduated",
+                "introduced_at": date.today().isoformat(),
+            },
+        )
+        habit_id = resp.json()["id"]
+
+        re_scaffold = client.post(f"/api/habits/{habit_id}/re-scaffold")
+        assert re_scaffold.status_code == 200
+
+        status = client.get(f"/api/habits/{habit_id}/graduation-status")
+        params = status.json()["graduation_params"]
+        # 25% tightening on friction-5 baseline: int(60*1.25)=75, min(0.80+0.05, 0.95)≈0.85
+        assert params["window_days"] == 75
+        assert params["target_rate"] == pytest.approx(0.85)
+        assert params["threshold_days"] == 75
+
+    def test_graduation_status_source_is_friction_default_when_no_overrides(self, client):
+        """Never-overridden habit labels graduation_params.source = 'friction_default'.
+
+        Absorbs Packet 5 Finding #8 Observation 1. Pre-D1 the scalar defaults
+        on the override columns made the any-is-not-None check always True, so
+        the friction_default branch at routers/graduation.py:305-309 was
+        unreachable. Post-D1 the columns are NULL by default and the branch
+        fires correctly.
+        """
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Un-overridden",
+                "frequency": "daily",
+                "friction_score": 3,
+                "scaffolding_status": "accountable",
+                "introduced_at": date.today().isoformat(),
+            },
+        )
+        habit_id = resp.json()["id"]
+
+        status = client.get(f"/api/habits/{habit_id}/graduation-status")
+        assert status.status_code == 200
+        assert status.json()["graduation_params"]["source"] == "friction_default"
+
+    def test_graduation_status_source_is_per_habit_when_any_override(self, client):
+        """Explicitly-overridden habit labels graduation_params.source = 'per_habit'."""
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Overridden",
+                "frequency": "daily",
+                "friction_score": 3,
+                "graduation_window": 50,  # single column override is enough
+                "scaffolding_status": "accountable",
+                "introduced_at": date.today().isoformat(),
+            },
+        )
+        habit_id = resp.json()["id"]
+
+        status = client.get(f"/api/habits/{habit_id}/graduation-status")
+        assert status.status_code == 200
+        assert status.json()["graduation_params"]["source"] == "per_habit"


### PR DESCRIPTION
## Verification

- `ruff check .` — ✅ Pass (All checks passed!)
- `pytest -v` — ✅ Pass (1275 passed, 4 skipped)
- Migration applied locally on brain3-dev: ✅ Yes (`alembic upgrade head` → pre-existing row with `(30, 0.85, 30)` backfilled to `(NULL, NULL, NULL)`; `information_schema.columns.column_default` confirmed NULL on all three columns; new INSERT without override yields NULL columns)
- Migration round-trip on brain3-dev: ✅ Yes (`alembic downgrade 18a1b2c3d4e5` restored `column_default` values `30 / 0.85 / 30`, then `alembic upgrade head` re-applied cleanly)
- Postgres-backed test confirmed: ✅ Yes (migration applied on Postgres 16.13 via `docker-compose.dev.yml`; see above)

Ran locally against develop HEAD `47aace9` immediately before opening this PR.

## Summary

Removes the scalar defaults (`30 / 0.85 / 30`) on the per-habit graduation override columns at both the SQLAlchemy model level and the 007-migration `server_default` level, and backfills any pre-existing rows to `NULL` via new migration 019. With the defaults gone, `resolve_graduation_params` can finally distinguish "user override" from "inherit from friction tier" — the friction-aware path is reachable for the first time. Re-scaffold tightening now compounds against the correct baseline, and the `graduation_params.source` signal from `GET /api/habits/{id}/graduation-status` correctly reports `friction_default` vs `per_habit` (see §Finding #8 Obs 1 absorption below).

## Changes

- `app/models.py:584-589` — drop `default=30` / `default=0.85` / `default=30` from the three `mapped_column` calls. Columns remain `Integer` / `Numeric(3,2)` / `Integer`, nullable.
- `alembic/versions/019_drop_graduation_override_defaults.py` — new migration. `upgrade()` runs a blanket `UPDATE habits SET graduation_window = NULL, graduation_target = NULL, graduation_threshold = NULL` (safe per BRAIN + L confirmation — no legitimate user overrides at `(30, 0.85, 30)` exist in prod), then drops the three `server_default`s via `op.alter_column(..., server_default=None)`. `downgrade()` restores the `server_default`s to their pre-019 string values. Row-level restoration on downgrade is intentionally not attempted — pre-019 values were themselves the scalar defaults, so the downgraded state is equivalent for any habit created before 019.
- `tests/test_graduation.py` — new `TestGraduationOverrideDefaultsD1` class with 9 cases covering:
  - NULL columns on POST without overrides
  - Friction-1 / 3 / 4 / 5 resolver output via `GET /api/habits/{id}/graduation-status`
  - User override via POST is preserved end-to-end (column value + resolver return)
  - Re-scaffold compounds against friction-5 baseline → `(75, 0.85, 75)`, not pre-D1 `(37, 0.90, 37)`
  - `graduation_params.source == "friction_default"` for never-overridden habits
  - `graduation_params.source == "per_habit"` as soon as any single column is overridden

## How to Verify

1. Check out `feature/2A-Bug-03-schema-defaults-backfill`.
2. Start brain3-dev: `docker-compose -f docker-compose.dev.yml up -d`.
3. Apply the migration: `POSTGRES_HOST=localhost POSTGRES_DB=brain3_dev alembic upgrade head` — expect a single `Running upgrade 18a1b2c3d4e5 -> 19a1b2c3d4e5` line and no errors.
4. Inspect schema: `docker exec brain3-postgres-1 psql -U brain3 -d brain3_dev -c "SELECT column_name, column_default FROM information_schema.columns WHERE table_name = 'habits' AND column_name IN ('graduation_window','graduation_target','graduation_threshold');"` — expect all three `column_default` values to be blank/NULL.
5. (Optional) Round-trip: `alembic downgrade 18a1b2c3d4e5` then `alembic upgrade head` — expect the `column_default` values to return to `30 / 0.85 / 30` on downgrade and disappear again on re-upgrade.
6. Run tests: `pytest -v` → expect 1275 passed, 4 skipped.
7. Focused run: `pytest tests/test_graduation.py::TestGraduationOverrideDefaultsD1 -v` → expect 9 passed.
8. Lint: `ruff check .` → expect clean.

## Deviations

None.

## Finding #8 Observation 1 absorption

This PR also resolves Packet 5 Finding #8 Observation 1 (the `"per_habit"` mislabel for never-overridden habits). Per the Packet 5 investigation report `ce36fb84-226e-4411-a19c-9bd4fbc26dd4` §4, the mislabel is a downstream symptom of the scalar defaults this PR removes. The source-determination logic at `app/routers/graduation.py:305-309` is **unchanged** by this PR, but its runtime output becomes correct once the `Habit` override columns default to NULL.

Verification steps added per the Packet 5.5 filing report `3ea61c7a-9ce3-4183-b4d7-af8491ad8f2f` §4 recommendation:
- `test_graduation_status_source_is_friction_default_when_no_overrides` — asserts a never-overridden accountable habit returns `graduation_params.source == "friction_default"`.
- `test_graduation_status_source_is_per_habit_when_any_override` — asserts an explicitly-overridden habit returns `graduation_params.source == "per_habit"`.

Finding #8 Observations 2 & 3 (re-scaffold tightening residual, `graduation_params.source` semantic) are held for BRAIN decision D8-X post-merge per the Wave 1 brief — **not addressed by this PR**.

## Test Results

```
$ ruff check .
All checks passed!

$ pytest -v
...
====================== 1275 passed, 4 skipped in 20.12s =======================

$ pytest tests/test_graduation.py::TestGraduationOverrideDefaultsD1 -v
tests/test_graduation.py::TestGraduationOverrideDefaultsD1::test_post_habit_without_overrides_creates_null_columns PASSED [ 11%]
tests/test_graduation.py::TestGraduationOverrideDefaultsD1::test_friction_3_habit_resolves_to_friction_3_defaults PASSED [ 22%]
tests/test_graduation.py::TestGraduationOverrideDefaultsD1::test_friction_4_habit_resolves_to_friction_4_defaults PASSED [ 33%]
tests/test_graduation.py::TestGraduationOverrideDefaultsD1::test_friction_5_habit_resolves_to_friction_5_defaults PASSED [ 44%]
tests/test_graduation.py::TestGraduationOverrideDefaultsD1::test_friction_1_habit_resolves_to_friction_1_defaults PASSED [ 55%]
tests/test_graduation.py::TestGraduationOverrideDefaultsD1::test_user_override_via_post_is_preserved PASSED [ 66%]
tests/test_graduation.py::TestGraduationOverrideDefaultsD1::test_re_scaffold_compounds_against_friction_5_baseline PASSED [ 77%]
tests/test_graduation.py::TestGraduationOverrideDefaultsD1::test_graduation_status_source_is_friction_default_when_no_overrides PASSED [ 88%]
tests/test_graduation.py::TestGraduationOverrideDefaultsD1::test_graduation_status_source_is_per_habit_when_any_override PASSED [100%]
============================== 9 passed in 0.28s ==============================
```

## Acceptance Checklist

- [x] `graduation_window`, `graduation_target`, `graduation_threshold` columns have no scalar defaults at the ORM or migration level (removed from `app/models.py:584-589`; dropped by migration 019).
- [x] Existing habits in the `habits` table have NULL values in all three columns after the migration runs (verified on brain3-dev: pre-existing `(30, 0.85, 30)` row → `(NULL, NULL, NULL)` post-upgrade).
- [x] `resolve_graduation_params` correctly returns friction-aware defaults for habits without user-set overrides — friction 3 → `(45, 0.85, 45)`; friction 4 → `(60, 0.80, 60)`; friction 5 → `(60, 0.80, 60)` (covered by the four per-friction endpoint tests).
- [x] User-set overrides are preserved: POST `HabitCreate` with `graduation_window=50` results in column value `50`, and resolver returns `50` regardless of `friction_score` (`test_user_override_via_post_is_preserved`).
- [x] `apply_re_scaffold_tightening` compounds against the resolver's friction-aware baseline: friction-5 habit re-scaffolded once evaluates at `75/0.85/75`, not `37/0.90/37` (`test_re_scaffold_compounds_against_friction_5_baseline`).
- [x] Existing tests continue to pass (1275 passed, 4 skipped unchanged — fixture usage of explicit `None` for override columns is unchanged and no longer relies on the two-phase force-null hack).
- [x] Integration test coverage added per scope above.

Closes #182
