### PR TITLE
[2A-Enh-02]: Rename introduced_at column to accountable_since across habit model, schemas, router, service, and tests

### DIFF
--- a/alembic/versions/020_rename_introduced_at_to_accountable_since.py
+++ b/alembic/versions/020_rename_introduced_at_to_accountable_since.py
@@ -1,0 +1,51 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Rename habits.introduced_at to habits.accountable_since.
+
+Revision ID: 20a1b2c3d4e5
+Revises: 19a1b2c3d4e5
+Create Date: 2026-04-18
+
+Pure column rename per D2 / [A-1] v2 Amendment 02. The field stores the
+date a habit entered the accountable phase of the graduated scaffolding
+loop — auto-populated on tracking→accountable transition and never
+thereafter. The pre-rename name ``introduced_at`` read as "first
+practiced," which did not match the semantic and would confuse
+AI-unmediated users in the long-term Companion App.
+
+``ALTER TABLE ... RENAME COLUMN`` on PostgreSQL preserves row data and
+any indexes bound to the column. No data migration, no constraint
+rebuild.
+"""
+
+from typing import Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20a1b2c3d4e5"
+down_revision: Union[str, None] = "19a1b2c3d4e5"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.alter_column("habits", "introduced_at", new_column_name="accountable_since")
+
+
+def downgrade() -> None:
+    op.alter_column("habits", "accountable_since", new_column_name="introduced_at")

--- a/app/models.py
+++ b/app/models.py
@@ -580,7 +580,11 @@ class Habit(Base):
         nullable=False,
         server_default="tracking",
     )
-    introduced_at: Mapped[date | None] = mapped_column(Date)
+    accountable_since: Mapped[date | None] = mapped_column(Date)
+    """Date the habit entered the accountable phase of the graduated
+    scaffolding loop. Auto-populated on tracking→accountable transition
+    (see ``app/routers/habits.py``) and never thereafter. Used as the
+    graduation threshold anchor and the stacking stability anchor."""
     graduation_window: Mapped[int | None] = mapped_column(Integer)
     graduation_target: Mapped[float | None] = mapped_column(
         Numeric(precision=3, scale=2),

--- a/app/routers/graduation.py
+++ b/app/routers/graduation.py
@@ -79,8 +79,8 @@ class GraduationStatusResponse(BaseModel):
     notification_frequency: str
     friction_score: int | None
     re_scaffold_count: int
-    introduced_at: str | None
-    days_since_introduction: int
+    accountable_since: str | None
+    days_accountable: int
     graduation_params: dict
     current_metrics: dict
     progress_summary: str
@@ -313,13 +313,13 @@ def graduation_status_endpoint(
             window, target, threshold, habit.re_scaffold_count,
         )
 
-    # Days since introduction
+    # Days accountable (days since tracking → accountable transition)
     from datetime import UTC, datetime
     now = datetime.now(tz=UTC)
-    if habit.introduced_at is not None:
-        days_since_introduction = (now.date() - habit.introduced_at).days
+    if habit.accountable_since is not None:
+        days_accountable = (now.date() - habit.accountable_since).days
     else:
-        days_since_introduction = 0
+        days_accountable = 0
 
     # Current metrics — only if accountable
     current_rate = 0.0
@@ -342,7 +342,7 @@ def graduation_status_endpoint(
     else:
         rate_pct = int(current_rate * 100)
         target_pct = int(target * 100)
-        remaining_days = max(0, threshold - days_since_introduction)
+        remaining_days = max(0, threshold - days_accountable)
         if remaining_days > 0:
             progress_summary = (
                 f"{rate_pct}% of the way to graduation target ({target_pct}%). "
@@ -379,8 +379,10 @@ def graduation_status_endpoint(
         "notification_frequency": habit.notification_frequency,
         "friction_score": habit.friction_score,
         "re_scaffold_count": habit.re_scaffold_count,
-        "introduced_at": str(habit.introduced_at) if habit.introduced_at else None,
-        "days_since_introduction": days_since_introduction,
+        "accountable_since": (
+            str(habit.accountable_since) if habit.accountable_since else None
+        ),
+        "days_accountable": days_accountable,
         "graduation_params": {
             "window_days": window,
             "target_rate": target,

--- a/app/routers/habits.py
+++ b/app/routers/habits.py
@@ -47,10 +47,13 @@ def create_habit(payload: HabitCreate, db: Session = Depends(get_db)) -> Habit:
 
     fields = payload.model_dump()
 
-    # [2G-Gap-01] Auto-populate introduced_at when creating an accountable
+    # [2G-Gap-01] Auto-populate accountable_since when creating an accountable
     # habit without an explicit date. Graduation needs a start anchor.
-    if fields.get("scaffolding_status") == "accountable" and fields.get("introduced_at") is None:
-        fields["introduced_at"] = date.today()
+    if (
+        fields.get("scaffolding_status") == "accountable"
+        and fields.get("accountable_since") is None
+    ):
+        fields["accountable_since"] = date.today()
 
     habit = Habit(**fields)
     db.add(habit)
@@ -130,15 +133,15 @@ def update_habit(
     ):
         updates["last_frequency_changed_at"] = datetime.now(tz=UTC)
 
-    # [2G-Gap-01] Auto-populate introduced_at on transition to accountable.
-    # Graduation evaluation reads introduced_at to compute days_since_introduction;
+    # [2G-Gap-01] Auto-populate accountable_since on transition to accountable.
+    # Graduation evaluation reads accountable_since to compute days_accountable;
     # without an anchor date it cannot produce a correct result.
     if (
         updates.get("scaffolding_status") == "accountable"
-        and "introduced_at" not in updates
-        and habit.introduced_at is None
+        and "accountable_since" not in updates
+        and habit.accountable_since is None
     ):
-        updates["introduced_at"] = date.today()
+        updates["accountable_since"] = date.today()
 
     for field, value in updates.items():
         setattr(habit, field, value)

--- a/app/schemas/habits.py
+++ b/app/schemas/habits.py
@@ -42,7 +42,7 @@ class HabitCreate(BaseModel):
     frequency: HabitFrequency | None = None
     notification_frequency: NotificationFrequency = "none"
     scaffolding_status: ScaffoldingStatus = "tracking"
-    introduced_at: date | None = None
+    accountable_since: date | None = None
     graduation_window: int | None = None
     graduation_target: float | None = None
     graduation_threshold: int | None = None
@@ -83,7 +83,7 @@ class HabitUpdate(BaseModel):
     frequency: HabitFrequency | None = None
     notification_frequency: NotificationFrequency | None = None
     scaffolding_status: ScaffoldingStatus | None = None
-    introduced_at: date | None = None
+    accountable_since: date | None = None
     graduation_window: int | None = None
     graduation_target: float | None = None
     graduation_threshold: int | None = None
@@ -120,7 +120,7 @@ class HabitResponse(BaseModel):
     frequency: HabitFrequency | None = None
     notification_frequency: NotificationFrequency
     scaffolding_status: ScaffoldingStatus
-    introduced_at: date | None = None
+    accountable_since: date | None = None
     graduation_window: int | None = None
     graduation_target: float | None = None
     graduation_threshold: int | None = None

--- a/app/services/graduation.py
+++ b/app/services/graduation.py
@@ -41,7 +41,7 @@ class GraduationResult(BaseModel):
     already_done_count: int
     window_days: int
     target_rate: float
-    days_since_introduction: int
+    days_accountable: int
     threshold_days: int
     meets_rate: bool
     meets_threshold: bool
@@ -96,7 +96,7 @@ def evaluate_graduation(
             already_done_count=0,
             window_days=0,
             target_rate=0.0,
-            days_since_introduction=0,
+            days_accountable=0,
             threshold_days=0,
             meets_rate=False,
             meets_threshold=False,
@@ -119,13 +119,13 @@ def evaluate_graduation(
 
     now = datetime.now(tz=UTC)
 
-    # Compute days since introduction
-    if habit.introduced_at is not None:
-        days_since_introduction = (now.date() - habit.introduced_at).days
+    # Compute days accountable
+    if habit.accountable_since is not None:
+        days_accountable = (now.date() - habit.accountable_since).days
     else:
-        days_since_introduction = 0
+        days_accountable = 0
 
-    meets_threshold = days_since_introduction >= threshold
+    meets_threshold = days_accountable >= threshold
 
     # Query notification responses in the rolling window
     window_start = now - timedelta(days=window)
@@ -153,7 +153,7 @@ def evaluate_graduation(
             already_done_count=0,
             window_days=window,
             target_rate=target,
-            days_since_introduction=days_since_introduction,
+            days_accountable=days_accountable,
             threshold_days=threshold,
             meets_rate=False,
             meets_threshold=meets_threshold,
@@ -171,7 +171,7 @@ def evaluate_graduation(
         blocking_reasons.append(f"Rate {current_rate:.0%} below target {target:.0%}")
     if not meets_threshold:
         blocking_reasons.append(
-            f"{days_since_introduction} days since introduction, need {threshold}"
+            f"{days_accountable} days accountable, need {threshold}"
         )
 
     eligible = meets_rate and meets_threshold
@@ -184,7 +184,7 @@ def evaluate_graduation(
         already_done_count=already_done_count,
         window_days=window,
         target_rate=target,
-        days_since_introduction=days_since_introduction,
+        days_accountable=days_accountable,
         threshold_days=threshold,
         meets_rate=meets_rate,
         meets_threshold=meets_threshold,
@@ -928,8 +928,8 @@ def _assess_habit_stability(
 
     # Stable if accountable for 14+ days with no missed completions in last 7
     now = datetime.now(tz=UTC)
-    if habit.introduced_at is not None:
-        days_accountable = (now.date() - habit.introduced_at).days
+    if habit.accountable_since is not None:
+        days_accountable = (now.date() - habit.accountable_since).days
         if days_accountable >= STABILITY_MIN_ACCOUNTABLE_DAYS:
             window_start = now.date() - timedelta(
                 days=STABILITY_NO_MISS_WINDOW_DAYS,
@@ -960,8 +960,8 @@ def _assess_habit_stability(
 
     # Not stable — blocking
     detail_parts = [f"{rate:.0%} already-done rate"]
-    if habit.introduced_at is not None:
-        days = (now.date() - habit.introduced_at).days
+    if habit.accountable_since is not None:
+        days = (now.date() - habit.accountable_since).days
         detail_parts.append(f"{days} days accountable")
     return HabitStabilityInfo(
         habit_id=habit.id,
@@ -1030,12 +1030,12 @@ def get_stacking_recommendation(
 
     if ready:
         # Priority 1: Paused habits with scaffolding_status='tracking',
-        # ordered by introduced_at (oldest first)
+        # ordered by accountable_since (oldest first)
         paused_tracking = [h for h in paused_habits if h.scaffolding_status == "tracking"]
         paused_tracking.sort(
             key=lambda h: (
                 h.position if h.position is not None else float("inf"),
-                h.introduced_at or datetime.min.date(),
+                h.accountable_since or datetime.min.date(),
             ),
         )
 

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -75,7 +75,7 @@ def _create_habit(db, **overrides) -> Habit:
         "frequency": "daily",
         "notification_frequency": "daily",
         "scaffolding_status": "accountable",
-        "introduced_at": date.today() - timedelta(days=60),
+        "accountable_since": date.today() - timedelta(days=60),
     }
     defaults.update(constructor_overrides)
     habit = Habit(**defaults)
@@ -279,7 +279,7 @@ class TestReScaffoldTightening:
 class TestEvaluateGraduation:
     def test_eligible_habit(self, db):
         """Habit that meets both rate and threshold is eligible."""
-        habit = _create_habit(db, introduced_at=date.today() - timedelta(days=60))
+        habit = _create_habit(db, accountable_since=date.today() - timedelta(days=60))
         # 10 notifications, 9 "Already done" = 90% rate
         for i in range(9):
             _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
@@ -298,7 +298,7 @@ class TestEvaluateGraduation:
 
     def test_ineligible_rate_too_low(self, db):
         """Habit with rate below target is not eligible."""
-        habit = _create_habit(db, introduced_at=date.today() - timedelta(days=60))
+        habit = _create_habit(db, accountable_since=date.today() - timedelta(days=60))
         # 10 notifications, 5 "Already done" = 50%
         for i in range(5):
             _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
@@ -314,7 +314,7 @@ class TestEvaluateGraduation:
 
     def test_ineligible_not_enough_time(self, db):
         """Habit introduced recently (below threshold) is not eligible."""
-        habit = _create_habit(db, introduced_at=date.today() - timedelta(days=10))
+        habit = _create_habit(db, accountable_since=date.today() - timedelta(days=10))
         for i in range(10):
             _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
 
@@ -323,11 +323,11 @@ class TestEvaluateGraduation:
         assert result.eligible is False
         assert result.meets_rate is True
         assert result.meets_threshold is False
-        assert any("days since introduction" in r for r in result.blocking_reasons)
+        assert any("days accountable" in r for r in result.blocking_reasons)
 
     def test_ineligible_no_notification_data(self, db):
         """Habit with no notifications in window is not eligible."""
-        habit = _create_habit(db, introduced_at=date.today() - timedelta(days=60))
+        habit = _create_habit(db, accountable_since=date.today() - timedelta(days=60))
 
         result = evaluate_graduation(db, habit.id)
 
@@ -357,7 +357,7 @@ class TestEvaluateGraduation:
         """Habit with re_scaffold_count > 0 has tightened criteria."""
         habit = _create_habit(
             db,
-            introduced_at=date.today() - timedelta(days=60),
+            accountable_since=date.today() - timedelta(days=60),
             re_scaffold_count=1,
             friction_score=1,
             graduation_window=None,
@@ -381,7 +381,7 @@ class TestEvaluateGraduation:
         """Same data that passes without re-scaffold fails with re_scaffold_count=1."""
         habit = _create_habit(
             db,
-            introduced_at=date.today() - timedelta(days=60),
+            accountable_since=date.today() - timedelta(days=60),
             re_scaffold_count=1,
             friction_score=1,
             graduation_window=None,
@@ -403,7 +403,7 @@ class TestEvaluateGraduation:
 
     def test_expired_notifications_counted(self, db):
         """Expired (unanswered) notifications are included in total count."""
-        habit = _create_habit(db, introduced_at=date.today() - timedelta(days=60))
+        habit = _create_habit(db, accountable_since=date.today() - timedelta(days=60))
         for i in range(8):
             _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
         # 2 expired notifications (no response)
@@ -418,7 +418,7 @@ class TestEvaluateGraduation:
 
     def test_pending_notifications_excluded(self, db):
         """Pending/delivered notifications are NOT included in evaluation."""
-        habit = _create_habit(db, introduced_at=date.today() - timedelta(days=60))
+        habit = _create_habit(db, accountable_since=date.today() - timedelta(days=60))
         for i in range(10):
             _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
         # These should be excluded
@@ -433,7 +433,7 @@ class TestEvaluateGraduation:
         """Notifications older than the window are not counted."""
         habit = _create_habit(
             db,
-            introduced_at=date.today() - timedelta(days=120),
+            accountable_since=date.today() - timedelta(days=120),
             friction_score=1,  # 30-day window
             graduation_window=None,
             graduation_target=None,
@@ -457,15 +457,15 @@ class TestEvaluateGraduation:
         with pytest.raises(ValueError, match="not found"):
             evaluate_graduation(db, uuid.uuid4())
 
-    def test_habit_with_no_introduced_at(self, db):
-        """Habit with no introduced_at gets 0 days_since_introduction."""
-        habit = _create_habit(db, introduced_at=None)
+    def test_habit_with_no_accountable_since(self, db):
+        """Habit with no accountable_since gets 0 days_accountable."""
+        habit = _create_habit(db, accountable_since=None)
         for i in range(10):
             _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
 
         result = evaluate_graduation(db, habit.id)
 
-        assert result.days_since_introduction == 0
+        assert result.days_accountable == 0
         assert result.meets_threshold is False
 
 
@@ -555,7 +555,7 @@ class TestGraduateHabit:
     def _eligible_habit(self, db, **overrides) -> Habit:
         """Create a habit that meets graduation criteria."""
         defaults = {
-            "introduced_at": date.today() - timedelta(days=60),
+            "accountable_since": date.today() - timedelta(days=60),
             "scaffolding_status": "accountable",
             "notification_frequency": "daily",
             "status": "active",
@@ -571,7 +571,7 @@ class TestGraduateHabit:
     def _ineligible_habit(self, db, **overrides) -> Habit:
         """Create a habit that does NOT meet graduation criteria (low rate)."""
         defaults = {
-            "introduced_at": date.today() - timedelta(days=60),
+            "accountable_since": date.today() - timedelta(days=60),
             "scaffolding_status": "accountable",
             "notification_frequency": "daily",
             "status": "active",
@@ -1302,7 +1302,7 @@ class TestEvaluateGraduatedHabitSlip:
             "scaffolding_status": "graduated",
             "notification_frequency": "graduated",
             "status": "active",
-            "introduced_at": date.today() - timedelta(days=90),
+            "accountable_since": date.today() - timedelta(days=90),
             "routine_id": routine_id,
         }
         defaults.update(overrides)
@@ -1608,7 +1608,7 @@ class TestEvaluateAllGraduatedHabits:
             scaffolding_status="graduated",
             notification_frequency="graduated",
             status="active",
-            introduced_at=date.today() - timedelta(days=90),
+            accountable_since=date.today() - timedelta(days=90),
         )
         for i in range(5):
             _create_completion(db, good.id, days_ago=i + 1)
@@ -1619,7 +1619,7 @@ class TestEvaluateAllGraduatedHabits:
             scaffolding_status="graduated",
             notification_frequency="graduated",
             status="active",
-            introduced_at=date.today() - timedelta(days=90),
+            accountable_since=date.today() - timedelta(days=90),
             title="Slipping Habit",
         )
 
@@ -1673,7 +1673,7 @@ class TestEvaluateAllGraduatedHabits:
                 scaffolding_status="graduated",
                 notification_frequency="graduated",
                 status="active",
-                introduced_at=date.today() - timedelta(days=90),
+                accountable_since=date.today() - timedelta(days=90),
                 title=f"Slipping {i}",
             )
 
@@ -1694,7 +1694,7 @@ class TestReScaffoldHabit:
             "scaffolding_status": "graduated",
             "notification_frequency": "graduated",
             "status": "active",
-            "introduced_at": date.today() - timedelta(days=90),
+            "accountable_since": date.today() - timedelta(days=90),
             "friction_score": 1,
             "graduation_window": None,
             "graduation_target": None,
@@ -1910,7 +1910,7 @@ class TestGetStackingRecommendation:
             scaffolding_status="accountable",
             title="Stable Habit",
             notification_frequency="daily",
-            introduced_at=date.today() - timedelta(days=30),
+            accountable_since=date.today() - timedelta(days=30),
         )
         # Create 10 notifications: 7 "Already done" = 70% rate
         for i in range(7):
@@ -1945,7 +1945,7 @@ class TestGetStackingRecommendation:
             scaffolding_status="accountable",
             title="Weekly Habit",
             notification_frequency="weekly",
-            introduced_at=date.today() - timedelta(days=30),
+            accountable_since=date.today() - timedelta(days=30),
         )
 
         result = get_stacking_recommendation(db, routine.id)
@@ -1964,7 +1964,7 @@ class TestGetStackingRecommendation:
             scaffolding_status="accountable",
             title="Consistent Habit",
             notification_frequency="daily",
-            introduced_at=date.today() - timedelta(days=20),
+            accountable_since=date.today() - timedelta(days=20),
         )
         # No notifications (rate would be 0), but 7 completions in last 7 days
         for i in range(7):
@@ -1986,7 +1986,7 @@ class TestGetStackingRecommendation:
             scaffolding_status="accountable",
             title="Struggling Habit",
             notification_frequency="daily",
-            introduced_at=date.today() - timedelta(days=10),
+            accountable_since=date.today() - timedelta(days=10),
         )
         # 10 notifications: 3 "Already done" = 30% rate (below 60%)
         for i in range(3):
@@ -2021,7 +2021,7 @@ class TestGetStackingRecommendation:
             scaffolding_status="tracking",
             status="paused",
             title="Paused Tracking",
-            introduced_at=date.today() - timedelta(days=30),
+            accountable_since=date.today() - timedelta(days=30),
         )
 
         result = get_stacking_recommendation(db, routine.id)
@@ -2031,8 +2031,8 @@ class TestGetStackingRecommendation:
         assert result.suggested_next.habit_name == "Paused Tracking"
         assert result.suggested_next.source == "paused"
 
-    def test_paused_ordered_by_introduced_at(self, db):
-        """Multiple paused habits: oldest introduced_at is suggested first."""
+    def test_paused_ordered_by_accountable_since(self, db):
+        """Multiple paused habits: oldest accountable_since is suggested first."""
         routine = _create_routine(db)
 
         _create_habit(
@@ -2041,7 +2041,7 @@ class TestGetStackingRecommendation:
             scaffolding_status="tracking",
             status="paused",
             title="Newer Paused",
-            introduced_at=date.today() - timedelta(days=5),
+            accountable_since=date.today() - timedelta(days=5),
         )
         _create_habit(
             db,
@@ -2049,7 +2049,7 @@ class TestGetStackingRecommendation:
             scaffolding_status="tracking",
             status="paused",
             title="Older Paused",
-            introduced_at=date.today() - timedelta(days=30),
+            accountable_since=date.today() - timedelta(days=30),
         )
 
         result = get_stacking_recommendation(db, routine.id)
@@ -2156,7 +2156,7 @@ class TestGetStackingRecommendation:
             scaffolding_status="accountable",
             title="Needs Work",
             notification_frequency="daily",
-            introduced_at=date.today() - timedelta(days=5),
+            accountable_since=date.today() - timedelta(days=5),
         )
         for i in range(6):
             _create_notification(db, blocking.id, "Done now", "responded", days_ago=i + 1)
@@ -2182,7 +2182,7 @@ class TestGraduatedAtTimestamp:
         defaults = {
             "scaffolding_status": "accountable",
             "notification_frequency": "daily",
-            "introduced_at": date.today() - timedelta(days=60),
+            "accountable_since": date.today() - timedelta(days=60),
             "friction_score": 1,
         }
         defaults.update(overrides)
@@ -2216,7 +2216,7 @@ class TestGraduatedAtTimestamp:
             db,
             scaffolding_status="accountable",
             notification_frequency="daily",
-            introduced_at=date.today() - timedelta(days=5),
+            accountable_since=date.today() - timedelta(days=5),
         )
 
         graduate_habit(db, habit.id, force=True)
@@ -2254,7 +2254,7 @@ class TestGraduatedAtTimestamp:
             db,
             scaffolding_status="graduated",
             notification_frequency="graduated",
-            introduced_at=date.today() - timedelta(days=90),
+            accountable_since=date.today() - timedelta(days=90),
         )
         # Set graduated_at to 20 days ago
         grad_time = datetime.now(tz=UTC) - timedelta(days=20)
@@ -2275,7 +2275,7 @@ class TestGraduatedAtTimestamp:
             db,
             scaffolding_status="graduated",
             notification_frequency="graduated",
-            introduced_at=date.today() - timedelta(days=90),
+            accountable_since=date.today() - timedelta(days=90),
         )
         # Graduate 15 days ago
         grad_time = datetime.now(tz=UTC) - timedelta(days=15)
@@ -2301,7 +2301,7 @@ class TestGraduatedAtTimestamp:
             db,
             scaffolding_status="graduated",
             notification_frequency="graduated",
-            introduced_at=date.today() - timedelta(days=90),
+            accountable_since=date.today() - timedelta(days=90),
         )
         # graduated_at is None by default (no migration backfill)
         assert habit.graduated_at is None
@@ -2429,8 +2429,8 @@ class TestHabitPositionField:
         assert result.suggested_next is not None
         assert result.suggested_next.habit_name == "Has Position"
 
-    def test_paused_ordered_by_position_then_introduced_at(self, db):
-        """Paused tracking habits sorted by position first, then introduced_at."""
+    def test_paused_ordered_by_position_then_accountable_since(self, db):
+        """Paused tracking habits sorted by position first, then accountable_since."""
         routine = _create_routine(db)
 
         _create_habit(
@@ -2440,7 +2440,7 @@ class TestHabitPositionField:
             status="paused",
             title="Paused Pos 3",
             position=3,
-            introduced_at=date.today() - timedelta(days=60),
+            accountable_since=date.today() - timedelta(days=60),
         )
         _create_habit(
             db,
@@ -2449,7 +2449,7 @@ class TestHabitPositionField:
             status="paused",
             title="Paused Pos 1",
             position=1,
-            introduced_at=date.today() - timedelta(days=5),
+            accountable_since=date.today() - timedelta(days=5),
         )
 
         result = get_stacking_recommendation(db, routine.id)
@@ -2458,8 +2458,8 @@ class TestHabitPositionField:
         assert result.suggested_next.habit_name == "Paused Pos 1"
         assert result.suggested_next.source == "paused"
 
-    def test_paused_null_position_falls_back_to_introduced_at(self, db):
-        """Paused habits with null position fall back to introduced_at ordering."""
+    def test_paused_null_position_falls_back_to_accountable_since(self, db):
+        """Paused habits with null position fall back to accountable_since ordering."""
         routine = _create_routine(db)
 
         _create_habit(
@@ -2468,7 +2468,7 @@ class TestHabitPositionField:
             scaffolding_status="tracking",
             status="paused",
             title="Newer Paused",
-            introduced_at=date.today() - timedelta(days=5),
+            accountable_since=date.today() - timedelta(days=5),
         )
         _create_habit(
             db,
@@ -2476,7 +2476,7 @@ class TestHabitPositionField:
             scaffolding_status="tracking",
             status="paused",
             title="Older Paused",
-            introduced_at=date.today() - timedelta(days=30),
+            accountable_since=date.today() - timedelta(days=30),
         )
 
         result = get_stacking_recommendation(db, routine.id)
@@ -2543,7 +2543,7 @@ class TestGraduationOverrideDefaultsD1:
                 "frequency": "daily",
                 "friction_score": 3,
                 "scaffolding_status": "accountable",
-                "introduced_at": date.today().isoformat(),
+                "accountable_since": date.today().isoformat(),
             },
         )
         habit_id = resp.json()["id"]
@@ -2564,7 +2564,7 @@ class TestGraduationOverrideDefaultsD1:
                 "frequency": "daily",
                 "friction_score": 4,
                 "scaffolding_status": "accountable",
-                "introduced_at": date.today().isoformat(),
+                "accountable_since": date.today().isoformat(),
             },
         )
         habit_id = resp.json()["id"]
@@ -2584,7 +2584,7 @@ class TestGraduationOverrideDefaultsD1:
                 "frequency": "daily",
                 "friction_score": 5,
                 "scaffolding_status": "accountable",
-                "introduced_at": date.today().isoformat(),
+                "accountable_since": date.today().isoformat(),
             },
         )
         habit_id = resp.json()["id"]
@@ -2604,7 +2604,7 @@ class TestGraduationOverrideDefaultsD1:
                 "frequency": "daily",
                 "friction_score": 1,
                 "scaffolding_status": "accountable",
-                "introduced_at": date.today().isoformat(),
+                "accountable_since": date.today().isoformat(),
             },
         )
         habit_id = resp.json()["id"]
@@ -2625,7 +2625,7 @@ class TestGraduationOverrideDefaultsD1:
                 "friction_score": 5,  # would resolve to 60 without override
                 "graduation_window": 50,
                 "scaffolding_status": "accountable",
-                "introduced_at": date.today().isoformat(),
+                "accountable_since": date.today().isoformat(),
             },
         )
         habit_id = resp.json()["id"]
@@ -2654,7 +2654,7 @@ class TestGraduationOverrideDefaultsD1:
                 "friction_score": 5,
                 "scaffolding_status": "graduated",
                 "notification_frequency": "graduated",
-                "introduced_at": date.today().isoformat(),
+                "accountable_since": date.today().isoformat(),
             },
         )
         habit_id = resp.json()["id"]
@@ -2685,7 +2685,7 @@ class TestGraduationOverrideDefaultsD1:
                 "frequency": "daily",
                 "friction_score": 3,
                 "scaffolding_status": "accountable",
-                "introduced_at": date.today().isoformat(),
+                "accountable_since": date.today().isoformat(),
             },
         )
         habit_id = resp.json()["id"]
@@ -2704,7 +2704,7 @@ class TestGraduationOverrideDefaultsD1:
                 "friction_score": 3,
                 "graduation_window": 50,  # single column override is enough
                 "scaffolding_status": "accountable",
-                "introduced_at": date.today().isoformat(),
+                "accountable_since": date.today().isoformat(),
             },
         )
         habit_id = resp.json()["id"]

--- a/tests/test_graduation_endpoints.py
+++ b/tests/test_graduation_endpoints.py
@@ -39,7 +39,7 @@ def _create_habit(db, **overrides) -> Habit:
         "frequency": "daily",
         "notification_frequency": "daily",
         "scaffolding_status": "accountable",
-        "introduced_at": date.today() - timedelta(days=60),
+        "accountable_since": date.today() - timedelta(days=60),
     }
     defaults.update(constructor_overrides)
     habit = Habit(**defaults)
@@ -106,7 +106,7 @@ def _create_completion(db, habit_id, days_ago=0):
 def _eligible_habit(db, **overrides) -> Habit:
     """Create a habit that meets graduation criteria."""
     defaults = {
-        "introduced_at": date.today() - timedelta(days=60),
+        "accountable_since": date.today() - timedelta(days=60),
         "scaffolding_status": "accountable",
         "notification_frequency": "daily",
         "status": "active",

--- a/tests/test_habits.py
+++ b/tests/test_habits.py
@@ -86,7 +86,7 @@ class TestCreateHabit:
                 "description": "10 min mindfulness",
                 "notification_frequency": "daily",
                 "scaffolding_status": "accountable",
-                "introduced_at": "2026-04-01",
+                "accountable_since": "2026-04-01",
                 "graduation_window": 60,
                 "graduation_target": 0.9,
                 "graduation_threshold": 45,
@@ -97,7 +97,7 @@ class TestCreateHabit:
         assert body["description"] == "10 min mindfulness"
         assert body["notification_frequency"] == "daily"
         assert body["scaffolding_status"] == "accountable"
-        assert body["introduced_at"] == "2026-04-01"
+        assert body["accountable_since"] == "2026-04-01"
         assert body["graduation_window"] == 60
         assert body["graduation_target"] == 0.9
         assert body["graduation_threshold"] == 45
@@ -381,14 +381,14 @@ class TestUpdateHabit:
 
 
 # ---------------------------------------------------------------------------
-# [2G-Gap-01] Auto-populate introduced_at on transition to accountable
+# [2G-Gap-01] Auto-populate accountable_since on transition to accountable
 # ---------------------------------------------------------------------------
 
 
 class TestIntroducedAtAutoPopulate:
 
-    def test_create_accountable_without_introduced_at_sets_today(self, client):
-        """POST with scaffolding_status=accountable and no introduced_at → today."""
+    def test_create_accountable_without_accountable_since_sets_today(self, client):
+        """POST with scaffolding_status=accountable and no accountable_since → today."""
         resp = client.post(
             "/api/habits",
             json={
@@ -398,24 +398,24 @@ class TestIntroducedAtAutoPopulate:
             },
         )
         assert resp.status_code == 201
-        assert resp.json()["introduced_at"] == date.today().isoformat()
+        assert resp.json()["accountable_since"] == date.today().isoformat()
 
-    def test_create_accountable_with_explicit_introduced_at_respected(self, client):
-        """POST with explicit introduced_at is never overwritten."""
+    def test_create_accountable_with_explicit_accountable_since_respected(self, client):
+        """POST with explicit accountable_since is never overwritten."""
         resp = client.post(
             "/api/habits",
             json={
                 "title": "Meditate",
                 "frequency": "daily",
                 "scaffolding_status": "accountable",
-                "introduced_at": "2026-01-15",
+                "accountable_since": "2026-01-15",
             },
         )
         assert resp.status_code == 201
-        assert resp.json()["introduced_at"] == "2026-01-15"
+        assert resp.json()["accountable_since"] == "2026-01-15"
 
-    def test_create_tracking_leaves_introduced_at_null(self, client):
-        """POST with scaffolding_status=tracking does not auto-set introduced_at."""
+    def test_create_tracking_leaves_accountable_since_null(self, client):
+        """POST with scaffolding_status=tracking does not auto-set accountable_since."""
         resp = client.post(
             "/api/habits",
             json={
@@ -425,12 +425,12 @@ class TestIntroducedAtAutoPopulate:
             },
         )
         assert resp.status_code == 201
-        assert resp.json()["introduced_at"] is None
+        assert resp.json()["accountable_since"] is None
 
     def test_patch_transition_to_accountable_sets_today(self, client):
         """PATCH transition tracking → accountable with no prior value → today."""
         habit = make_habit(client, scaffolding_status="tracking")
-        assert habit["introduced_at"] is None
+        assert habit["accountable_since"] is None
 
         resp = client.patch(
             f"/api/habits/{habit['id']}",
@@ -439,51 +439,51 @@ class TestIntroducedAtAutoPopulate:
         assert resp.status_code == 200
         body = resp.json()
         assert body["scaffolding_status"] == "accountable"
-        assert body["introduced_at"] == date.today().isoformat()
+        assert body["accountable_since"] == date.today().isoformat()
 
-    def test_patch_transition_with_explicit_introduced_at_respected(self, client):
-        """PATCH transition with explicit introduced_at uses the provided value."""
+    def test_patch_transition_with_explicit_accountable_since_respected(self, client):
+        """PATCH transition with explicit accountable_since uses the provided value."""
         habit = make_habit(client, scaffolding_status="tracking")
         resp = client.patch(
             f"/api/habits/{habit['id']}",
             json={
                 "scaffolding_status": "accountable",
-                "introduced_at": "2026-03-01",
+                "accountable_since": "2026-03-01",
             },
         )
         assert resp.status_code == 200
-        assert resp.json()["introduced_at"] == "2026-03-01"
+        assert resp.json()["accountable_since"] == "2026-03-01"
 
-    def test_patch_unchanged_scaffolding_does_not_touch_introduced_at(self, client):
-        """PATCH that doesn't change scaffolding_status never modifies introduced_at."""
+    def test_patch_unchanged_scaffolding_does_not_touch_accountable_since(self, client):
+        """PATCH that doesn't change scaffolding_status never modifies accountable_since."""
         habit = make_habit(client, scaffolding_status="tracking")
         resp = client.patch(
             f"/api/habits/{habit['id']}",
             json={"title": "Rename only"},
         )
         assert resp.status_code == 200
-        assert resp.json()["introduced_at"] is None
+        assert resp.json()["accountable_since"] is None
 
     def test_patch_already_accountable_with_value_not_overwritten(self, client):
-        """PATCH on a habit already accountable with introduced_at set never mutates it."""
+        """PATCH on a habit already accountable with accountable_since set never mutates it."""
         resp = client.post(
             "/api/habits",
             json={
                 "title": "Meditate",
                 "frequency": "daily",
                 "scaffolding_status": "accountable",
-                "introduced_at": "2026-02-20",
+                "accountable_since": "2026-02-20",
             },
         )
         assert resp.status_code == 201
         habit = resp.json()
 
-        # PATCH something unrelated — introduced_at must survive untouched.
+        # PATCH something unrelated — accountable_since must survive untouched.
         resp = client.patch(
             f"/api/habits/{habit['id']}", json={"title": "Meditate (renamed)"},
         )
         assert resp.status_code == 200
-        assert resp.json()["introduced_at"] == "2026-02-20"
+        assert resp.json()["accountable_since"] == "2026-02-20"
 
         # Re-sending scaffolding_status=accountable on a habit already at that
         # value + with a date set must also leave the date unchanged.
@@ -492,7 +492,7 @@ class TestIntroducedAtAutoPopulate:
             json={"scaffolding_status": "accountable"},
         )
         assert resp.status_code == 200
-        assert resp.json()["introduced_at"] == "2026-02-20"
+        assert resp.json()["accountable_since"] == "2026-02-20"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Verification

- `ruff check .` — ✅ Pass (All checks passed!)
- `pytest -v` — ✅ Pass (1279 passed, 4 skipped)
- Migration applied locally on brain3-dev: ✅ Yes (Postgres 16.13 via `docker-compose.dev.yml`; seeded a pre-020 row with `introduced_at = 2026-04-01`, ran `alembic upgrade head`, confirmed the row surfaces as `accountable_since = 2026-04-01` — data preserved, column renamed, old column absent from `information_schema.columns`)
- Migration round-trip on brain3-dev: ✅ Yes (`alembic downgrade 19a1b2c3d4e5` restored the column to `introduced_at` with `2026-04-01` still present; re-upgrade re-applied cleanly)
- Postgres-backed test confirmed: ✅ Yes (see migration evidence above)
- Grep verification (`grep -rn introduced_at` outside `alembic/versions/`): ✅ Zero hits

Ran locally against develop HEAD `912ea5c` immediately before opening this PR.

### Grep result (verbatim)

```
$ grep -rn "introduced_at" --include="*.py" --exclude-dir=alembic --exclude-dir=__pycache__ --exclude-dir=.claude
(no output — zero hits)

$ grep -rn "introduced_at" alembic/versions/
alembic/versions/007_create_habits_table.py:58:        sa.Column("introduced_at", sa.Date(), nullable=True),
alembic/versions/010_migrate_routines_to_container_model.py:42:            introduced_at, graduation_window, graduation_target,
alembic/versions/020_rename_introduced_at_to_accountable_since.py:17:"""Rename habits.introduced_at to habits.accountable_since.
alembic/versions/020_rename_introduced_at_to_accountable_since.py:26:thereafter. The pre-rename name ``introduced_at`` read as "first
alembic/versions/020_rename_introduced_at_to_accountable_since.py:47:    op.alter_column("habits", "introduced_at", new_column_name="accountable_since")
alembic/versions/020_rename_introduced_at_to_accountable_since.py:51:    op.alter_column("habits", "accountable_since", new_column_name="introduced_at")
```

The surviving hits are exactly the three expected migration files — 007 (original create, historical), 010 (historical data migration), and 020 (this PR's rename migration, which necessarily references both names). Per the issue's brief note, the app source tree returns zero hits.

## Summary

Pure D2 rename — `habits.introduced_at` → `habits.accountable_since` (with the derived API/variable name `days_since_introduction` → `days_accountable`) across model, schemas, routers, service layer, and tests. No behavior change: the field is still auto-populated on `tracking → accountable` transition and never thereafter, and the graduation threshold still measures elapsed days since that transition. The rename closes the semantic gap flagged in Packet 3 Finding #10: the old name read as "first practiced," while the value is set on accountability transition — confusing for the long-term AI-unmediated Companion App.

Widest blast radius in Wave 1 — touches every Stream G service function that reads the habit's accountability anchor, both graduation response schemas, the `[2G-Gap-01]` auto-populate test class, and ~50 test call sites across three test modules. brain3-mcp companion update is Wave 3 per the brief.

## Changes

**Migration (new):**
- `alembic/versions/020_rename_introduced_at_to_accountable_since.py` — `ALTER TABLE habits RENAME COLUMN introduced_at TO accountable_since`. Postgres preserves row data and any indexes bound to the column; no data migration needed. Reversible via the symmetric rename in `downgrade()`.

**Production code (6 files):**
- `app/models.py:583` — ORM attribute renamed. Added a docstring explaining the semantic (per AC #3): auto-populated on tracking→accountable transition, used as the graduation threshold anchor and stacking stability anchor.
- `app/schemas/habits.py` — renamed on `HabitCreate` (line 45), `HabitUpdate` (line 86), and `HabitResponse` (line 123). `HabitDetailResponse` extends `HabitResponse` and picks the rename up automatically.
- `app/routers/habits.py` — the two `[2G-Gap-01]` auto-populate blocks (POST create at `:50-53`, PATCH update at `:133-141`) use the new field name. Inline comments updated to the new semantic ("reads accountable_since to compute days_accountable").
- `app/routers/graduation.py` — `GraduationStatusResponse.introduced_at` / `days_since_introduction` renamed to `accountable_since` / `days_accountable` ([2G-06] Amendment 19). Response body keys in the `graduation-status` endpoint updated to match.
- `app/services/graduation.py` — `GraduationResult.days_since_introduction` → `days_accountable` ([2G-01] Amendment 11). All `habit.introduced_at` reads in `evaluate_graduation`, `_assess_habit_stability`, and `get_stacking_recommendation` renamed. Updated the blocking-reason string from `"{n} days since introduction, need {t}"` → `"{n} days accountable, need {t}"` for consistency with the new vocabulary.

**Tests (3 files, ~50 call sites):**
- `tests/test_habits.py` — `[2G-Gap-01]` auto-populate test class (6 cases) renamed throughout plus the `test_create_with_optional_fields` case.
- `tests/test_graduation.py` — `_create_habit` helper fixture, resolver tests, evaluate/stacking/slip/re-scaffold coverage, and the `TestGraduationOverrideDefaultsD1` cases added in PR #188. The assertion in `test_ineligible_not_enough_time` was updated from `"days since introduction"` to `"days accountable"` to match the renamed blocking-reason string.
- `tests/test_graduation_endpoints.py` — `_create_habit` and `_eligible_habit` defaults.

Test method names that literally reference the field (e.g., `test_paused_ordered_by_introduced_at`) were renamed too — otherwise the test inventory would drift from the documented behavior.

## How to Verify

1. Check out `feature/2A-Enh-02-accountable-since-rename`.
2. Start brain3-dev: `docker-compose -f docker-compose.dev.yml up -d`.
3. (Optional — requires pre-existing `introduced_at` row) seed data: `docker exec brain3-postgres-1 psql -U brain3 -d brain3_dev -c "INSERT INTO habits (id, title, status, notification_frequency, scaffolding_status, introduced_at) VALUES ('33333333-...', 'Test', 'active', 'none', 'accountable', '2026-04-01');"` — then verify the row survives the rename in step 4.
4. Apply migration: `POSTGRES_HOST=localhost POSTGRES_DB=brain3_dev alembic upgrade head` — expect a single `Running upgrade 19a1b2c3d4e5 -> 20a1b2c3d4e5` line.
5. Inspect schema: `docker exec brain3-postgres-1 psql -U brain3 -d brain3_dev -c "SELECT column_name FROM information_schema.columns WHERE table_name = 'habits' AND column_name IN ('introduced_at', 'accountable_since');"` — expect only `accountable_since`.
6. (Optional round-trip) `alembic downgrade 19a1b2c3d4e5` → column returns to `introduced_at`, data preserved. Re-upgrade to clean up.
7. Run tests: `pytest -v` → expect 1279 passed, 4 skipped.
8. Lint: `ruff check .` → expect clean.
9. Grep: `grep -rn "introduced_at" --include="*.py" --exclude-dir=alembic` → expect no output.

## Deviations

None.

## Test Results

```
$ ruff check .
All checks passed!

$ pytest -v
...
============================ 1279 passed in 17.33s ============================

$ POSTGRES_HOST=localhost POSTGRES_DB=brain3_dev alembic upgrade head
INFO  [alembic.runtime.migration] Running upgrade 19a1b2c3d4e5 -> 20a1b2c3d4e5, Rename habits.introduced_at to habits.accountable_since.

$ docker exec brain3-postgres-1 psql -U brain3 -d brain3_dev \
    -c "SELECT id, accountable_since FROM habits WHERE id = '33333333-3333-3333-3333-333333333333';"
                  id                  | accountable_since
--------------------------------------+-------------------
 33333333-3333-3333-3333-333333333333 | 2026-04-01
(1 row)
```

## Acceptance Checklist

- [x] DB column renamed from `introduced_at` to `accountable_since` via non-data-destructive migration (verified: row with `2026-04-01` survives upgrade and downgrade).
- [x] SQLAlchemy model, Pydantic schemas (`HabitCreate`, `HabitUpdate`, `HabitResponse`, `HabitDetailResponse`), router auto-population blocks, service readers, and `graduation-status` endpoint all use the new name.
- [x] Docstring added to `Habit.accountable_since` explaining its semantic (see `app/models.py:583-587`).
- [x] All tests pass with the renamed field; test assertions check `accountable_since` everywhere the old `introduced_at` appeared.
- [x] API responses expose `accountable_since` (not `introduced_at`) in `HabitResponse`, `HabitDetailResponse`, and `graduation-status` response bodies.

Closes #183
