### PR TITLE
[2A-Bug-01]: Wrap GET /api/habits/ list response in items+count envelope

### DIFF
--- a/app/routers/habits.py
+++ b/app/routers/habits.py
@@ -29,6 +29,7 @@ from app.schemas.habits import (
     HabitCompleteResponse,
     HabitCreate,
     HabitDetailResponse,
+    HabitListResponse,
     HabitResponse,
     HabitUpdate,
 )
@@ -62,13 +63,13 @@ def create_habit(payload: HabitCreate, db: Session = Depends(get_db)) -> Habit:
     return habit
 
 
-@router.get("/", response_model=list[HabitResponse])
+@router.get("/", response_model=HabitListResponse)
 def list_habits(
     routine_id: UUID | None = Query(None),
     habit_status: str | None = Query(None, alias="status"),
     scaffolding_status: str | None = Query(None),
     db: Session = Depends(get_db),
-) -> list[Habit]:
+) -> HabitListResponse:
     """List habits with composable filters."""
     query = db.query(Habit)
 
@@ -79,7 +80,11 @@ def list_habits(
     if scaffolding_status is not None:
         query = query.filter(Habit.scaffolding_status == scaffolding_status)
 
-    return query.order_by(Habit.created_at).all()
+    results = query.order_by(Habit.created_at).all()
+    return HabitListResponse(
+        items=[HabitResponse.model_validate(h) for h in results],
+        count=len(results),
+    )
 
 
 @router.get("/{habit_id}", response_model=HabitDetailResponse)

--- a/app/schemas/habits.py
+++ b/app/schemas/habits.py
@@ -142,6 +142,13 @@ class HabitDetailResponse(HabitResponse):
     routine: RoutineResponse | None = None
 
 
+class HabitListResponse(BaseModel):
+    """Envelope for GET /api/habits/ — wraps the item list with a count."""
+
+    items: list[HabitResponse]
+    count: int
+
+
 # ---------------------------------------------------------------------------
 # Habit Completion — POST /api/habits/{id}/complete
 # ---------------------------------------------------------------------------

--- a/tests/test_habits.py
+++ b/tests/test_habits.py
@@ -175,13 +175,24 @@ class TestListHabits:
     def test_list_habits_empty(self, client):
         resp = client.get("/api/habits")
         assert resp.status_code == 200
-        assert resp.json() == []
+        assert resp.json() == {"items": [], "count": 0}
+
+    def test_list_habits_single(self, client):
+        make_habit(client, title="Only")
+        resp = client.get("/api/habits")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["title"] == "Only"
 
     def test_list_habits(self, client):
         make_habit(client, title="A")
         make_habit(client, title="B")
         resp = client.get("/api/habits")
-        assert len(resp.json()) == 2
+        data = resp.json()
+        assert data["count"] == 2
+        assert len(data["items"]) == 2
 
     def test_filter_by_routine_id(self, client):
         domain = make_domain(client)
@@ -189,25 +200,26 @@ class TestListHabits:
         make_habit(client, title="Linked", routine_id=routine["id"])
         make_habit(client, title="Standalone")
         resp = client.get(f"/api/habits?routine_id={routine['id']}")
-        habits = resp.json()
-        assert len(habits) == 1
-        assert habits[0]["title"] == "Linked"
+        data = resp.json()
+        assert data["count"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["title"] == "Linked"
 
     def test_filter_by_status(self, client):
         make_habit(client, title="Active", status="active")
         make_habit(client, title="Paused", status="paused")
         resp = client.get("/api/habits?status=paused")
-        habits = resp.json()
-        assert len(habits) == 1
-        assert habits[0]["title"] == "Paused"
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["items"][0]["title"] == "Paused"
 
     def test_filter_by_scaffolding_status(self, client):
         make_habit(client, title="Tracking", scaffolding_status="tracking")
         make_habit(client, title="Accountable", scaffolding_status="accountable")
         resp = client.get("/api/habits?scaffolding_status=accountable")
-        habits = resp.json()
-        assert len(habits) == 1
-        assert habits[0]["title"] == "Accountable"
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["items"][0]["title"] == "Accountable"
 
     def test_filter_combined(self, client):
         domain = make_domain(client)
@@ -230,15 +242,15 @@ class TestListHabits:
             f"/api/habits?routine_id={routine['id']}"
             "&status=active&scaffolding_status=accountable"
         )
-        habits = resp.json()
-        assert len(habits) == 1
-        assert habits[0]["title"] == "Match"
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["items"][0]["title"] == "Match"
 
     def test_list_ordered_by_created_at(self, client):
         make_habit(client, title="First")
         make_habit(client, title="Second")
         resp = client.get("/api/habits")
-        titles = [h["title"] for h in resp.json()]
+        titles = [h["title"] for h in resp.json()["items"]]
         assert titles == ["First", "Second"]
 
 


### PR DESCRIPTION
## Verification

- `pytest -v` — ✅ Pass (1280 passed, 0 failed)
- `ruff check .` — ✅ Pass (All checks passed)
- Migration applied locally on brain3-dev: ✅ Not applicable (no schema migration in this change)
- Postgres-backed test confirmed: ✅ Not applicable (no DB-layer change; existing SQLite in-memory suite covers the envelope)

Ran locally against develop HEAD at `6d36e48` immediately before opening this PR.

## Summary

`GET /api/habits/` now returns the `HabitListResponse {items, count}` envelope instead of a bare JSON array. This closes the FastMCP serialisation defect where a list response was split into one `TextContent` block per element, producing concatenated JSON to consumers reading the unstructured-content channel.

Implements `[A-5]` v2 Amendment 04. Template change for the Wave 2 envelope cluster — four more tickets (#175, #176, #177, #178) mirror this pattern.

## Changes

- `app/schemas/habits.py` — added `HabitListResponse(BaseModel)` with `items: list[HabitResponse]` and `count: int` fields. Imports unchanged (already imports `BaseModel`).
- `app/routers/habits.py` — imported `HabitListResponse`; changed `list_habits`'s `response_model` from `list[HabitResponse]` to `HabitListResponse`; materialised the ordered query to `results`, then returned `HabitListResponse(items=[HabitResponse.model_validate(h) for h in results], count=len(results))`. Handler logic and filter semantics are unchanged.
- `tests/test_habits.py` — updated every `TestListHabits` case to assert the envelope shape (`data["items"]`, `data["count"]`). Added `test_list_habits_single` so 0-, 1-, and N-element coverage is explicit per the Packet 1 §2.9 pattern cited in the filing.

## How to Verify

1. `git fetch origin && git checkout feature/2A-Enh-01-env-habits-list-envelope && git pull`
2. `ruff check .` — expect `All checks passed!`
3. `pytest -v tests/test_habits.py` — expect 56 passed, including the new `test_list_habits_single`
4. `pytest -v` — full suite, expect 1280 passed
5. Boot the API locally (`uvicorn app.main:app --reload`) and hit `GET http://localhost:8000/api/habits/` — confirm the response is `{"items": [...], "count": N}` and the OpenAPI schema at `/docs` shows `HabitListResponse` as the response model

## Deviations

None.

`[A-5]` v2 lists additional acceptance criteria for `effective_graduation_params` (Amendment 05). Those are explicitly deferred to the sequenced Wave 2 ticket #181 per the Wave 2 brief and are not addressed here.

## Test Results

```
$ pytest -v
============================ 1280 passed in 18.06s ============================

$ ruff check .
All checks passed!
```

`TestListHabits` summary (8 cases — one new):

```
tests/test_habits.py::TestListHabits::test_list_habits_empty PASSED
tests/test_habits.py::TestListHabits::test_list_habits_single PASSED
tests/test_habits.py::TestListHabits::test_list_habits PASSED
tests/test_habits.py::TestListHabits::test_filter_by_routine_id PASSED
tests/test_habits.py::TestListHabits::test_filter_by_status PASSED
tests/test_habits.py::TestListHabits::test_filter_by_scaffolding_status PASSED
tests/test_habits.py::TestListHabits::test_filter_combined PASSED
tests/test_habits.py::TestListHabits::test_list_ordered_by_created_at PASSED
```

## Acceptance Checklist

Acceptance criteria from issue #174:

- [x] `HabitListResponse {items, count}` Pydantic class added to `app/schemas/habits.py`
- [x] `list_habits` returns `HabitListResponse(items=results, count=len(results))`
- [x] Route decorator uses `response_model=HabitListResponse` (was `list[HabitResponse]`)
- [x] List-endpoint tests assert envelope shape (`data["items"]`, `data["count"]`) rather than bare-array structure
- [x] 0-, 1-, and N-element cases covered per Packet 1 §2.9 pattern
- [x] All existing filter tests updated to envelope shape
- [x] Full `pytest -v` and `ruff check .` pass

Closes #174