### PR TITLE
[2A-Bug-02]: Wrap GET /api/routines/ list response in items+count envelope

### DIFF
--- a/app/routers/routines.py
+++ b/app/routers/routines.py
@@ -29,6 +29,7 @@ from app.schemas.routines import (
     RoutineCompleteResponse,
     RoutineCreate,
     RoutineDetailResponse,
+    RoutineListResponse,
     RoutineResponse,
     RoutineScheduleCreate,
     RoutineScheduleResponse,
@@ -63,14 +64,14 @@ def create_routine(payload: RoutineCreate, db: Session = Depends(get_db)) -> Rou
     return routine
 
 
-@router.get("/", response_model=list[RoutineResponse])
+@router.get("/", response_model=RoutineListResponse)
 def list_routines(
     domain_id: UUID | None = Query(None),
     routine_status: str | None = Query(None, alias="status"),
     frequency: str | None = Query(None),
     streak_broken: bool | None = Query(None),
     db: Session = Depends(get_db),
-) -> list[Routine]:
+) -> RoutineListResponse:
     """List routines with optional filters."""
     query = db.query(Routine)
 
@@ -83,7 +84,11 @@ def list_routines(
     if streak_broken is True:
         query = query.filter(Routine.current_streak == 0, Routine.status == "active")
 
-    return query.order_by(Routine.created_at).all()
+    results = query.order_by(Routine.created_at).all()
+    return RoutineListResponse(
+        items=[RoutineResponse.model_validate(r) for r in results],
+        count=len(results),
+    )
 
 
 @router.get("/{routine_id}", response_model=RoutineDetailResponse)

--- a/app/schemas/routines.py
+++ b/app/schemas/routines.py
@@ -98,6 +98,13 @@ class RoutineDetailResponse(RoutineResponse):
     schedules: list["RoutineScheduleResponse"] = []
 
 
+class RoutineListResponse(BaseModel):
+    """Envelope for GET /api/routines/ — wraps the item list with a count."""
+
+    items: list[RoutineResponse]
+    count: int
+
+
 # ---------------------------------------------------------------------------
 # RoutineSchedule schemas
 # ---------------------------------------------------------------------------

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -135,14 +135,26 @@ class TestListRoutines:
     def test_list_routines_empty(self, client):
         resp = client.get("/api/routines")
         assert resp.status_code == 200
-        assert resp.json() == []
+        assert resp.json() == {"items": [], "count": 0}
+
+    def test_list_routines_single(self, client):
+        domain = make_domain(client)
+        make_routine(client, domain["id"], title="Only")
+        resp = client.get("/api/routines")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["title"] == "Only"
 
     def test_list_routines(self, client):
         domain = make_domain(client)
         make_routine(client, domain["id"], title="A")
         make_routine(client, domain["id"], title="B")
         resp = client.get("/api/routines")
-        assert len(resp.json()) == 2
+        data = resp.json()
+        assert data["count"] == 2
+        assert len(data["items"]) == 2
 
     def test_filter_by_domain_id(self, client):
         d1 = make_domain(client, name="D1")
@@ -150,27 +162,27 @@ class TestListRoutines:
         make_routine(client, d1["id"], title="R1")
         make_routine(client, d2["id"], title="R2")
         resp = client.get(f"/api/routines?domain_id={d1['id']}")
-        routines = resp.json()
-        assert len(routines) == 1
-        assert routines[0]["title"] == "R1"
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["items"][0]["title"] == "R1"
 
     def test_filter_by_status(self, client):
         domain = make_domain(client)
         make_routine(client, domain["id"], title="Active", status="active")
         make_routine(client, domain["id"], title="Paused", status="paused")
         resp = client.get("/api/routines?status=paused")
-        routines = resp.json()
-        assert len(routines) == 1
-        assert routines[0]["title"] == "Paused"
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["items"][0]["title"] == "Paused"
 
     def test_filter_by_frequency(self, client):
         domain = make_domain(client)
         make_routine(client, domain["id"], title="Daily", frequency="daily")
         make_routine(client, domain["id"], title="Weekly", frequency="weekly")
         resp = client.get("/api/routines?frequency=weekly")
-        routines = resp.json()
-        assert len(routines) == 1
-        assert routines[0]["title"] == "Weekly"
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["items"][0]["title"] == "Weekly"
 
     def test_filter_streak_broken(self, client):
         domain = make_domain(client)
@@ -182,9 +194,9 @@ class TestListRoutines:
         client.post(f"/api/routines/{r_ok['id']}/complete")
 
         resp = client.get("/api/routines?streak_broken=true")
-        routines = resp.json()
-        assert len(routines) == 1
-        assert routines[0]["title"] == "Broken"
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["items"][0]["title"] == "Broken"
         # Paused routine should NOT appear even though streak is 0
 
 


### PR DESCRIPTION
## Verification

- `pytest -v` — ✅ Pass (1281 passed, 0 failed)
- `ruff check .` — ✅ Pass (All checks passed)
- Migration applied locally on brain3-dev: ✅ Not applicable (no schema migration)
- Postgres-backed test confirmed: ✅ Not applicable (no DB-layer change; existing SQLite in-memory suite covers the envelope)

Ran locally against develop HEAD at `b47d828` immediately before opening this PR.

## Summary

`GET /api/routines/` now returns the `RoutineListResponse {items, count}` envelope instead of a bare JSON array. Closes the FastMCP serialisation defect where a list response was split into one `TextContent` block per element, producing concatenated JSON to consumers reading the unstructured-content channel.

Implements the envelope clause in the retroactive routines spec (BRAIN artifact `faffad13-d0dc-4c72-a7c7-b9ae1f2032db`). Mirrors the pattern landed for habits in #190.

## Changes

- `app/schemas/routines.py` — added `RoutineListResponse(BaseModel)` with `items: list[RoutineResponse]` and `count: int`. Imports unchanged (already imports `BaseModel`).
- `app/routers/routines.py` — imported `RoutineListResponse`; changed `list_routines`'s `response_model` from `list[RoutineResponse]` to `RoutineListResponse`; materialised the ordered query to `results`, then returned `RoutineListResponse(items=[RoutineResponse.model_validate(r) for r in results], count=len(results))`. Handler logic, filter semantics, and completion/schedule endpoints are unchanged.
- `tests/test_routines.py` — updated every `TestListRoutines` case to assert the envelope shape (`data["items"]`, `data["count"]`). Added `test_list_routines_single` so 0-, 1-, and N-element coverage is explicit per the Packet 1 §2.9 pattern cited in the filing.

## How to Verify

1. `git fetch origin && git checkout feature/Routines-env-list-envelope && git pull`
2. `ruff check .` — expect `All checks passed!`
3. `pytest -v tests/test_routines.py` — expect 66 passed, including the new `test_list_routines_single`
4. `pytest -v` — full suite, expect 1281 passed
5. Boot the API locally (`uvicorn app.main:app --reload`) and hit `GET http://localhost:8000/api/routines/` — confirm the response is `{"items": [...], "count": N}` and `/docs` shows `RoutineListResponse` as the response model

## Deviations

None.

## Test Results

```
$ pytest -v
============================ 1281 passed in 17.73s ============================

$ ruff check .
All checks passed!
```

`TestListRoutines` summary (7 cases — one new):

```
tests/test_routines.py::TestListRoutines::test_list_routines_empty PASSED
tests/test_routines.py::TestListRoutines::test_list_routines_single PASSED
tests/test_routines.py::TestListRoutines::test_list_routines PASSED
tests/test_routines.py::TestListRoutines::test_filter_by_domain_id PASSED
tests/test_routines.py::TestListRoutines::test_filter_by_status PASSED
tests/test_routines.py::TestListRoutines::test_filter_by_frequency PASSED
tests/test_routines.py::TestListRoutines::test_filter_streak_broken PASSED
```

## Acceptance Checklist

From the retroactive routines spec (`faffad13`):

- [x] `GET /api/routines` returns `RoutineListResponse` envelope, not a bare array
- [x] `RoutineListResponse` schema registered with the API's OpenAPI spec
- [ ] `list_routines` MCP tool returns the envelope unchanged — **out of scope here; lives in brain3-mcp#62 (Wave 3)**
- [x] Phase 1 regression tests updated to assert envelope shape

From issue #175 suggested fix:

- [x] `RoutineListResponse {items, count}` added to `app/schemas/routines.py`
- [x] `list_routines` returns the envelope
- [x] `response_model=RoutineListResponse` (was `list[RoutineResponse]`)
- [x] List-endpoint tests updated; 0/1/N coverage explicit
- [x] Full `pytest -v` and `ruff check .` pass

Closes #175