### PR TITLE
[2F-Enh-01-env]: Wrap GET /api/rules/ list response in items+count envelope

### DIFF
--- a/app/routers/rules.py
+++ b/app/routers/rules.py
@@ -29,6 +29,7 @@ from app.schemas.rule import (
     RuleCreate,
     RuleEntityType,
     RuleEvaluationResultResponse,
+    RuleListResponse,
     RuleRead,
     RuleUpdate,
 )
@@ -57,7 +58,7 @@ def create_rule(
 # GET list — with composable filters
 # ---------------------------------------------------------------------------
 
-@router.get("/", response_model=list[RuleRead])
+@router.get("/", response_model=RuleListResponse)
 def list_rules(
     entity_type: RuleEntityType | None = Query(None),
     enabled: bool | None = Query(None),
@@ -65,7 +66,7 @@ def list_rules(
     entity_id: UUID | None = Query(None),
     is_default: bool | None = Query(None),
     db: Session = Depends(get_db),
-) -> list[Rule]:
+) -> RuleListResponse:
     """List rules with composable filters (AND logic)."""
     query = db.query(Rule)
 
@@ -80,7 +81,11 @@ def list_rules(
     if is_default is not None:
         query = query.filter(Rule.is_default == is_default)
 
-    return query.order_by(Rule.created_at.desc()).all()
+    results = query.order_by(Rule.created_at.desc()).all()
+    return RuleListResponse(
+        items=[RuleRead.model_validate(r) for r in results],
+        count=len(results),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/app/schemas/rule.py
+++ b/app/schemas/rule.py
@@ -175,6 +175,13 @@ class RuleRead(BaseModel):
     updated_at: datetime
 
 
+class RuleListResponse(BaseModel):
+    """Envelope for GET /api/rules/ — wraps the item list with a count."""
+
+    items: list[RuleRead]
+    count: int
+
+
 class RuleEvaluationResultResponse(BaseModel):
     """API response model for a rule evaluation result."""
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -560,7 +560,17 @@ class TestListRulesEndpoint:
     def test_list_empty(self, client):
         resp = client.get(RULES_URL)
         assert resp.status_code == 200
-        assert resp.json() == []
+        assert resp.json() == {"items": [], "count": 0}
+
+    def test_list_single(self, client):
+        """Single-element list returns envelope with count=1."""
+        client.post(RULES_URL, json=_rule_payload(name="Only"))
+        resp = client.get(RULES_URL)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["name"] == "Only"
 
     def test_list_returns_created_rules(self, client):
         client.post(RULES_URL, json=_rule_payload(name="Rule A"))
@@ -568,7 +578,8 @@ class TestListRulesEndpoint:
         resp = client.get(RULES_URL)
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 2
+        assert data["count"] == 2
+        assert len(data["items"]) == 2
 
     def test_list_ordered_by_created_at_desc(self, client, db):
         """Newest rule appears first in the list."""
@@ -607,7 +618,9 @@ class TestListRulesEndpoint:
         db.commit()
 
         resp = client.get(RULES_URL)
-        names = [r["name"] for r in resp.json()]
+        data = resp.json()
+        assert data["count"] == 2
+        names = [r["name"] for r in data["items"]]
         assert names == ["Second", "First"]
 
     def test_filter_by_entity_type(self, client):
@@ -621,16 +634,16 @@ class TestListRulesEndpoint:
         ))
         resp = client.get(RULES_URL, params={"entity_type": "task"})
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["name"] == "Task rule"
+        assert data["count"] == 1
+        assert data["items"][0]["name"] == "Task rule"
 
     def test_filter_by_enabled(self, client):
         client.post(RULES_URL, json=_rule_payload(name="Active", enabled=True))
         client.post(RULES_URL, json=_rule_payload(name="Disabled", enabled=False))
         resp = client.get(RULES_URL, params={"enabled": "false"})
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["name"] == "Disabled"
+        assert data["count"] == 1
+        assert data["items"][0]["name"] == "Disabled"
 
     def test_filter_by_notification_type(self, client):
         client.post(RULES_URL, json=_rule_payload(
@@ -644,8 +657,8 @@ class TestListRulesEndpoint:
             "notification_type": "stale_work_nudge",
         })
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["name"] == "Stale"
+        assert data["count"] == 1
+        assert data["items"][0]["name"] == "Stale"
 
     def test_filter_by_entity_id(self, client):
         eid = str(uuid.uuid4())
@@ -653,8 +666,8 @@ class TestListRulesEndpoint:
         client.post(RULES_URL, json=_rule_payload(name="Global"))
         resp = client.get(RULES_URL, params={"entity_id": eid})
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["name"] == "Scoped"
+        assert data["count"] == 1
+        assert data["items"][0]["name"] == "Scoped"
 
     def test_filter_combined(self, client):
         """Multiple filters compose with AND logic."""
@@ -672,8 +685,8 @@ class TestListRulesEndpoint:
             "entity_type": "habit", "enabled": "true",
         })
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["name"] == "Match"
+        assert data["count"] == 1
+        assert data["items"][0]["name"] == "Match"
 
 
 # ---------------------------------------------------------------------------
@@ -830,7 +843,9 @@ class TestRuleLifecycle:
         # List
         resp = client.get(RULES_URL)
         assert resp.status_code == 200
-        assert len(resp.json()) == 1
+        data = resp.json()
+        assert data["count"] == 1
+        assert len(data["items"]) == 1
 
         # Update
         resp = client.patch(
@@ -847,4 +862,4 @@ class TestRuleLifecycle:
 
         # Confirm gone
         resp = client.get(RULES_URL)
-        assert resp.json() == []
+        assert resp.json() == {"items": [], "count": 0}

--- a/tests/test_rules_seed.py
+++ b/tests/test_rules_seed.py
@@ -339,8 +339,8 @@ class TestIsDefaultFilter:
         resp = client.get(RULES_URL, params={"is_default": "true"})
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 4
-        assert all(r["is_default"] is True for r in data)
+        assert data["count"] == 4
+        assert all(r["is_default"] is True for r in data["items"])
 
     def test_filter_is_default_false(self, client, seeded_rules):
         """Filtering by is_default=false returns only user-created rules."""
@@ -357,9 +357,9 @@ class TestIsDefaultFilter:
         resp = client.get(RULES_URL, params={"is_default": "false"})
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["name"] == "User custom"
-        assert data[0]["is_default"] is False
+        assert data["count"] == 1
+        assert data["items"][0]["name"] == "User custom"
+        assert data["items"][0]["is_default"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -391,7 +391,7 @@ class TestSeedCreationViaAPI:
         """GET /api/rules?enabled=true returns all 4 default rules."""
         resp = client.get(RULES_URL, params={"enabled": "true"})
         assert resp.status_code == 200
-        assert len(resp.json()) == 4
+        assert resp.json()["count"] == 4
 
 
 # ---------------------------------------------------------------------------
@@ -433,10 +433,10 @@ class TestSeedIdempotency:
 
         # Verify 4 rules
         resp = client.get(RULES_URL)
-        assert len(resp.json()) == 4
+        assert resp.json()["count"] == 4
 
         # Second pass — skip existing (simulates seed script behavior)
-        existing = {r["name"] for r in client.get(RULES_URL).json()}
+        existing = {r["name"] for r in client.get(RULES_URL).json()["items"]}
         created_count = 0
         for rule_data in seed_rules:
             if rule_data["name"] not in existing:
@@ -448,7 +448,7 @@ class TestSeedIdempotency:
 
         # Still exactly 4 rules
         resp = client.get(RULES_URL)
-        assert len(resp.json()) == 4
+        assert resp.json()["count"] == 4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Verification

- `ruff check .` — ✅ Pass (All checks passed!)
- `pytest -v` — ✅ Pass (1283 passed in 17.86s)
- Migration applied locally on brain3-dev: N/A (no schema change)
- Postgres-backed test confirmed: ✅ Yes (`tests/test_rules_postgres.py` runs in the suite above)
- Other project-specific checks: ✅ Pass (rules + seed suites: 117 passed, including new envelope-shape coverage)

Ran locally against develop HEAD at `5bdbb6c` immediately before opening this PR.

## Summary

Wraps `GET /api/rules/` in a `RuleListResponse {items, count}` envelope instead of returning a bare `list[RuleRead]`. This is the fourth Wave 2 envelope ticket — same pattern shipped for habits (#174), routines (#175), and notifications (#176). The bare-list shape was producing concatenated-JSON output through FastMCP's `_convert_to_content` because each list element became its own `TextContent` block; the envelope yields a single block.

`count` reflects the total matching the filters (no pagination in v1, so it equals `len(items)`).

## Changes

- `app/schemas/rule.py` — added `RuleListResponse(BaseModel)` with `items: list[RuleRead]` and `count: int`.
- `app/routers/rules.py` — `list_rules` now declares `response_model=RuleListResponse`, returns `RuleListResponse(items=[...], count=N)`. The query, filters, and ordering are unchanged.
- `tests/test_rules.py` — empty/single/multi-element list assertions updated for the envelope shape; new `test_list_single` added; sort-order test asserts on `data["items"]`; full-lifecycle test updated for both the populated-list and empty-list checks.
- `tests/test_rules_seed.py` — `is_default` filter assertions and the seed-idempotency check migrated to envelope shape.

## How to Verify

1. `git checkout feature/2F-Enh-01-env-rules-list-envelope`
2. `pytest -v tests/test_rules.py tests/test_rules_seed.py` — all 117 pass.
3. `pytest -v` — full suite, 1283 pass.
4. `ruff check .` — all checks pass.
5. With brain3-dev running, `curl http://localhost:8000/api/rules/` returns `{\"items\": [...], \"count\": N}` whether N is 0, 1, or many.

## Deviations

None.

## Test Results

```
pytest -v
============================ 1283 passed in 17.86s ============================
```

```
ruff check .
All checks passed!
```

## Acceptance Checklist

- [x] AC6 (Amendment 20): \`GET /api/rules\` returns \`RuleListResponse {items, count}\` envelope, not a bare array. \`count\` equals \`len(items)\` in v1 (no pagination).
- [x] Test Requirements / Amendment 20: Envelope shape — \`GET /api/rules\` returns \`{items: [...], count: N}\` object, not a bare array; \`count\` matches \`len(items)\` for all filter combinations (covered across 0-, 1-, and N-element cases plus every existing filter test).

Closes #177