### PR TITLE
[2F-Bug-03]: Wrap POST /api/rules/evaluate response in summary+results envelope

### DIFF
--- a/app/routers/rules.py
+++ b/app/routers/rules.py
@@ -17,6 +17,7 @@
 """CRUD and evaluation endpoints for Rules."""
 
 from dataclasses import asdict
+from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -29,6 +30,8 @@ from app.schemas.rule import (
     RuleCreate,
     RuleEntityType,
     RuleEvaluationResultResponse,
+    RuleEvaluationRunResponse,
+    RuleEvaluationSummary,
     RuleListResponse,
     RuleRead,
     RuleUpdate,
@@ -92,13 +95,47 @@ def list_rules(
 # POST — evaluate all rules
 # ---------------------------------------------------------------------------
 
-@router.post("/evaluate", response_model=list[RuleEvaluationResultResponse])
+@router.post("/evaluate", response_model=RuleEvaluationRunResponse)
 def evaluate_all_rules(
     db: Session = Depends(get_db),
-) -> list[dict]:
-    """Evaluate all enabled rules and create notifications for matches."""
+) -> RuleEvaluationRunResponse:
+    """Evaluate all enabled rules and create notifications for matches.
+
+    Returns a run envelope with a per-reason summary alongside the per-rule
+    results. The service-layer `evaluate_rules` function still returns a bare
+    list — summary aggregation lives in the handler so the scheduler import
+    path (Stream C) is unaffected.
+    """
+    evaluated_at = datetime.now(tz=UTC)
     results = evaluate_rules(db)
-    return [asdict(r) for r in results]
+
+    counts = {
+        "fired": 0,
+        "cooldown": 0,
+        "condition_not_met": 0,
+        "no_matching_entities": 0,
+        "error": 0,
+    }
+    notifications_created = 0
+    for r in results:
+        if r.reason in counts:
+            counts[r.reason] += 1
+        notifications_created += r.notifications_created
+
+    summary = RuleEvaluationSummary(
+        total_rules_evaluated=len(results),
+        fired=counts["fired"],
+        cooldown=counts["cooldown"],
+        condition_not_met=counts["condition_not_met"],
+        no_matching_entities=counts["no_matching_entities"],
+        error=counts["error"],
+        total_notifications_created=notifications_created,
+        evaluated_at=evaluated_at,
+    )
+    return RuleEvaluationRunResponse(
+        summary=summary,
+        results=[RuleEvaluationResultResponse(**asdict(r)) for r in results],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/app/schemas/rule.py
+++ b/app/schemas/rule.py
@@ -191,3 +191,29 @@ class RuleEvaluationResultResponse(BaseModel):
     reason: str
     notifications_created: int
     entities_evaluated: int
+
+
+class RuleEvaluationSummary(BaseModel):
+    """Run-level totals for an evaluation cycle.
+
+    Per-reason counts mirror the `reason` enum from the service-layer
+    `RuleEvaluationResult`, so consumers can join a result back to its bucket
+    without re-deriving the schema. `total_rules_evaluated` is the sum of all
+    per-reason buckets and equals `len(results)`.
+    """
+
+    total_rules_evaluated: int
+    fired: int
+    cooldown: int
+    condition_not_met: int
+    no_matching_entities: int
+    error: int
+    total_notifications_created: int
+    evaluated_at: datetime
+
+
+class RuleEvaluationRunResponse(BaseModel):
+    """Envelope for POST /api/rules/evaluate — wraps results with a summary."""
+
+    summary: RuleEvaluationSummary
+    results: list[RuleEvaluationResultResponse]

--- a/tests/test_rule_evaluation.py
+++ b/tests/test_rule_evaluation.py
@@ -789,9 +789,9 @@ class TestNotificationProperties:
 
 
 class TestEvaluateAllEndpoint:
-    """POST /api/rules/evaluate"""
+    """POST /api/rules/evaluate — envelope shape and summary aggregation."""
 
-    def test_evaluate_all_returns_results(self, client, db):
+    def test_evaluate_all_returns_envelope_with_results(self, client, db):
         _make_habit_orm(db, current_streak=0, best_streak=10)
         _make_rule(
             db,
@@ -803,15 +803,25 @@ class TestEvaluateAllEndpoint:
         resp = client.post(f"{RULES_URL}/evaluate")
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["fired"] is True
-        assert data[0]["reason"] == "fired"
-        assert data[0]["notifications_created"] == 1
+        assert set(data.keys()) == {"summary", "results"}
+        assert len(data["results"]) == 1
+        assert data["results"][0]["fired"] is True
+        assert data["results"][0]["reason"] == "fired"
+        assert data["results"][0]["notifications_created"] == 1
 
     def test_evaluate_all_empty_when_no_rules(self, client):
         resp = client.post(f"{RULES_URL}/evaluate")
         assert resp.status_code == 200
-        assert resp.json() == []
+        data = resp.json()
+        assert data["results"] == []
+        summary = data["summary"]
+        assert summary["total_rules_evaluated"] == 0
+        assert summary["fired"] == 0
+        assert summary["cooldown"] == 0
+        assert summary["condition_not_met"] == 0
+        assert summary["no_matching_entities"] == 0
+        assert summary["error"] == 0
+        assert summary["total_notifications_created"] == 0
 
     def test_evaluate_all_skips_disabled_rules(self, client, db):
         _make_habit_orm(db, current_streak=0, best_streak=10)
@@ -819,7 +829,158 @@ class TestEvaluateAllEndpoint:
 
         resp = client.post(f"{RULES_URL}/evaluate")
         assert resp.status_code == 200
-        assert resp.json() == []
+        data = resp.json()
+        assert data["results"] == []
+        assert data["summary"]["total_rules_evaluated"] == 0
+
+
+class TestEvaluateAllEnvelopeSummary:
+    """Summary fields cover the per-reason breakdown and the sum invariant."""
+
+    _REASON_KEYS = ("fired", "cooldown", "condition_not_met",
+                    "no_matching_entities", "error")
+
+    def test_summary_fields_present_and_typed(self, client):
+        resp = client.post(f"{RULES_URL}/evaluate")
+        summary = resp.json()["summary"]
+        for key in (
+            "total_rules_evaluated",
+            *self._REASON_KEYS,
+            "total_notifications_created",
+            "evaluated_at",
+        ):
+            assert key in summary, f"missing summary key: {key}"
+        for key in ("total_rules_evaluated", *self._REASON_KEYS,
+                    "total_notifications_created"):
+            assert isinstance(summary[key], int)
+        # evaluated_at parses as ISO 8601
+        datetime.fromisoformat(summary["evaluated_at"].replace("Z", "+00:00"))
+
+    def test_summary_counts_match_per_reason_results(self, client, db):
+        # fired
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        _make_rule(
+            db,
+            name="Fires",
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            notification_type="pattern_observation",
+        )
+        # cooldown — last_triggered recent, cooldown still active
+        _make_rule(
+            db,
+            name="In cooldown",
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            cooldown_hours=24,
+            last_triggered_at=datetime.now(tz=UTC) - timedelta(hours=1),
+            notification_type="pattern_observation",
+        )
+        # condition_not_met — habit exists but no skips
+        _make_habit_orm(db, title="Quiet habit")
+        _make_rule(
+            db,
+            name="Won't meet",
+            metric=RuleMetric.consecutive_skips,
+            threshold=99,
+        )
+        # no_matching_entities — task rule, no tasks
+        _make_rule(
+            db,
+            name="No tasks",
+            entity_type=RuleEntityType.task,
+            metric=RuleMetric.days_untouched,
+            threshold=14,
+            notification_type="stale_work_nudge",
+        )
+
+        resp = client.post(f"{RULES_URL}/evaluate")
+        data = resp.json()
+        summary = data["summary"]
+        results = data["results"]
+
+        # Counts derived from results match summary
+        for key in self._REASON_KEYS:
+            assert summary[key] == sum(1 for r in results if r["reason"] == key), (
+                f"summary[{key}] != count of results with reason={key}"
+            )
+
+    def test_summary_sum_invariant(self, client, db):
+        """sum of per-reason buckets == total_rules_evaluated == len(results)."""
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            notification_type="pattern_observation",
+        )
+        _make_rule(
+            db,
+            entity_type=RuleEntityType.task,
+            metric=RuleMetric.days_untouched,
+            threshold=14,
+            notification_type="stale_work_nudge",
+        )
+
+        resp = client.post(f"{RULES_URL}/evaluate")
+        data = resp.json()
+        summary = data["summary"]
+
+        bucket_total = sum(summary[k] for k in self._REASON_KEYS)
+        assert bucket_total == summary["total_rules_evaluated"]
+        assert bucket_total == len(data["results"])
+
+    def test_summary_total_notifications_created_matches_results_sum(
+        self, client, db,
+    ):
+        # Two habits, both will fire on the same global rule
+        _make_habit_orm(db, title="A", current_streak=0, best_streak=10)
+        _make_habit_orm(db, title="B", current_streak=0, best_streak=10)
+        _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            notification_type="pattern_observation",
+        )
+
+        resp = client.post(f"{RULES_URL}/evaluate")
+        data = resp.json()
+        per_result = sum(r["notifications_created"] for r in data["results"])
+        assert data["summary"]["total_notifications_created"] == per_result
+        assert per_result == 2  # one notification per matching habit
+
+    def test_summary_evaluated_at_set_to_handler_call_time(self, client):
+        before = datetime.now(tz=UTC)
+        resp = client.post(f"{RULES_URL}/evaluate")
+        after = datetime.now(tz=UTC)
+        evaluated_at = datetime.fromisoformat(
+            resp.json()["summary"]["evaluated_at"].replace("Z", "+00:00"),
+        )
+        assert before <= evaluated_at <= after
+
+
+class TestEvaluateSingleEndpointShape:
+    """Single-rule endpoint stays bare — not wrapped in the run envelope."""
+
+    def test_single_rule_response_is_bare_result_not_envelope(self, client, db):
+        _make_habit_orm(db, current_streak=0, best_streak=10)
+        rule = _make_rule(
+            db,
+            metric=RuleMetric.streak_length,
+            threshold=7,
+            notification_type="pattern_observation",
+        )
+
+        resp = client.post(f"{RULES_URL}/{rule.id}/evaluate")
+        assert resp.status_code == 200
+        data = resp.json()
+        # Bare RuleEvaluationResult shape — no summary/results wrapper
+        assert "summary" not in data
+        assert "results" not in data
+        assert set(data.keys()) >= {
+            "rule_id", "rule_name", "fired", "reason",
+            "notifications_created", "entities_evaluated",
+        }
 
 
 class TestEvaluateSingleEndpoint:


### PR DESCRIPTION
## Verification

- `ruff check .` — ✅ Pass (All checks passed!)
- `pytest -v` — ✅ Pass (1289 passed in 20.03s)
- Migration applied locally on brain3-dev: N/A (no schema change)
- Postgres-backed test confirmed: ✅ Yes (`tests/test_rules_postgres.py` runs in the suite above)
- Other project-specific checks: ✅ Pass (`tests/test_rule_evaluation.py`: 43 passed, including 6 new envelope/summary tests)

Ran locally against develop HEAD at `c3d495e` immediately before opening this PR.

## Summary

`POST /api/rules/evaluate` now returns a `RuleEvaluationRunResponse {summary, results}` envelope instead of a bare `list[RuleEvaluationResultResponse]`. The bare-list shape was producing concatenated-JSON output through FastMCP's `_convert_to_content` because each list element became its own `TextContent` block (Round 3 Finding #1), and consumers had no run-level totals (Finding #15). One envelope closes both findings.

The summary mirrors the `reason` enum from the service-layer `RuleEvaluationResult` so a consumer can join a result back to its bucket without re-deriving the schema. The five per-reason buckets sum to `total_rules_evaluated` and to `len(results)` — invariant asserted in tests.

## Changes

- `app/schemas/rule.py` — added `RuleEvaluationSummary` (8 fields: `total_rules_evaluated`, `fired`, `cooldown`, `condition_not_met`, `no_matching_entities`, `error`, `total_notifications_created`, `evaluated_at`) and `RuleEvaluationRunResponse {summary, results}`.
- `app/routers/rules.py` — `evaluate_all_rules` now declares `response_model=RuleEvaluationRunResponse`. Captures `evaluated_at` at the start of the handler (before the service call), iterates the result list once to bucket per-reason counts and sum `notifications_created`, returns the envelope.
- `app/services/rule_evaluation.py` — **unchanged.** Per Packet 1 §5: the service-layer `evaluate_rules(db, rule_id, respect_cooldown) -> list[RuleEvaluationResult]` signature is load-bearing for Stream C's scheduler, which imports it directly. Summary aggregation deliberately lives in the handler, not the service.
- `tests/test_rule_evaluation.py` — migrated `TestEvaluateAllEndpoint` to envelope shape; added `TestEvaluateAllEnvelopeSummary` (5 tests covering field presence/typing, per-reason count agreement with results, the sum invariant, `total_notifications_created` agreement, and `evaluated_at` falling between handler entry and exit); added `TestEvaluateSingleEndpointShape` confirming the single-rule endpoint stays bare (no envelope wrapper).

## How to Verify

1. `git checkout feature/2F-Bug-03-rules-evaluate-envelope`
2. `pytest -v tests/test_rule_evaluation.py` — all 43 pass.
3. `pytest -v` — full suite, 1289 pass.
4. `ruff check .` — all checks pass.
5. With brain3-dev running, `curl -X POST http://localhost:8000/api/rules/evaluate` returns `{\"summary\": {...}, \"results\": [...]}`. With ≥2 enabled rules, the response parses as a single JSON object — no concatenation.
6. `curl -X POST http://localhost:8000/api/rules/{rule_id}/evaluate` continues to return a bare `RuleEvaluationResult` — confirms both shapes coexist.

## Deviations

Implements per issue #178, **not** per `[2F-03]` v2 Amendment 21 where they diverge. Spec reconciliation filed as a separate observation for Stellan.

The three divergences:

1. **Summary schema.** Issue specifies an 8-field per-reason breakdown matching the `reason` enum (`total_rules_evaluated`, `fired`, `cooldown`, `condition_not_met`, `no_matching_entities`, `error`, `total_notifications_created`, `evaluated_at`). Spec amendment specifies a 5-field collapsed schema (`evaluated_count`, `fired_count`, `skipped_count`, `notifications_created`, `run_at`). Implemented per issue.
2. **Service-layer signature.** Issue is explicit (Suggested Fix #6): `evaluate_rules(db: Session) -> list[RuleEvaluationResult]` does NOT change — Stream C's scheduler imports the function directly and is unaffected. Spec amendment changes the signature to return `RuleEvaluationRunResponse`. Implemented per issue; service signature unchanged.
3. **Aggregation location.** Issue places summary computation in the handler. Spec amendment places it in the service. Implemented per issue; aggregation lives in `evaluate_all_rules`.

**Authority trail:** Packet 1 §5 (BRAIN artifact `024434af-e8dd-4df0-a11d-c5aff177b9e3`) is the design source for both the 8-field per-reason breakdown and the scheduler-compatibility guarantee on the service signature. The Packet 1.5 filing instructed the amendment author to specify summary fields per Packet 1 §5; the spec text drifted from that instruction. Confirmed and authorized in BRAIN activity `c43ea33e-ba00-4e5e-8cf7-df3fee967a17` — proceed per the issue, file a separate spec-reconciliation observation for Stellan.

## Test Results

```
pytest -v
============================ 1289 passed in 20.03s ============================
```

```
pytest -v tests/test_rule_evaluation.py
============================= 43 passed in 0.53s ==============================
```

```
ruff check .
All checks passed!
```

## Acceptance Checklist

Per spec Amendment 21 + issue Suggested Fix (issue takes precedence where they diverge — see Deviations):

- [x] `POST /api/rules/evaluate` returns `RuleEvaluationRunResponse {summary, results}` (not a bare array).
- [x] Summary populated with: `total_rules_evaluated`, per-reason counts (`fired`, `cooldown`, `condition_not_met`, `no_matching_entities`, `error`), `total_notifications_created`, `evaluated_at`.
- [x] `summary.evaluated_at` is set at handler entry, in UTC.
- [x] `sum(per-reason buckets) == summary.total_rules_evaluated == len(results)` — asserted by `test_summary_sum_invariant`.
- [x] `summary.total_notifications_created == sum(r.notifications_created for r in results)` — asserted.
- [x] Single-rule endpoint `POST /api/rules/{rule_id}/evaluate` continues to return a bare `RuleEvaluationResult` — asserted by `test_single_rule_response_is_bare_result_not_envelope`.
- [x] Service-layer `evaluate_rules` signature unchanged (Stream C scheduler-compatible, per Packet 1 §5).
- [x] Closes Finding #1 (malformed concatenated JSON for N≥2 rules) — single envelope object replaces the bare list.
- [x] Closes Finding #15 (no run-level summary) — `summary` block exposes per-reason counts plus totals.

Closes #178