### PR TITLE
[2G-Bug-01]: Standardize evaluate-* endpoints to 200+blocking_reasons pattern

### DIFF
--- a/app/routers/graduation.py
+++ b/app/routers/graduation.py
@@ -117,22 +117,7 @@ def evaluate_graduation_endpoint(
     habit_id: UUID, db: Session = Depends(get_db),
 ) -> GraduationResult:
     """Dry-run graduation evaluation. Returns eligibility metrics without changing state."""
-    habit = _get_habit_or_404(db, habit_id)
-
-    if habit.status != "active":
-        raise HTTPException(
-            status_code=422,
-            detail=f"Habit status is '{habit.status}', must be 'active'",
-        )
-    if habit.scaffolding_status != "accountable":
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                f"Habit scaffolding_status is '{habit.scaffolding_status}', "
-                "must be 'accountable'"
-            ),
-        )
-
+    _get_habit_or_404(db, habit_id)
     return evaluate_graduation(db, habit_id)
 
 
@@ -250,14 +235,7 @@ def evaluate_slip_endpoint(
     habit_id: UUID, db: Session = Depends(get_db),
 ) -> SlipDetectionResult:
     """Check if a graduated habit shows signs of regression. Read-only."""
-    habit = _get_habit_or_404(db, habit_id)
-
-    if habit.scaffolding_status != "graduated":
-        raise HTTPException(
-            status_code=422,
-            detail=f"Habit scaffolding_status is '{habit.scaffolding_status}', must be 'graduated'",
-        )
-
+    _get_habit_or_404(db, habit_id)
     return evaluate_graduated_habit_slip(db, habit_id)
 
 

--- a/app/services/graduation.py
+++ b/app/services/graduation.py
@@ -86,6 +86,25 @@ def evaluate_graduation(
     if habit is None:
         raise ValueError(f"Habit {habit_id} not found")
 
+    # Gate: habit must be active
+    if habit.status != "active":
+        return GraduationResult(
+            eligible=False,
+            habit_id=habit_id,
+            current_rate=0.0,
+            total_notifications=0,
+            already_done_count=0,
+            window_days=0,
+            target_rate=0.0,
+            days_accountable=0,
+            threshold_days=0,
+            meets_rate=False,
+            meets_threshold=False,
+            blocking_reasons=[
+                f"Habit status must be 'active' to evaluate graduation (current: {habit.status})"
+            ],
+        )
+
     # Gate: only accountable habits can be evaluated
     if habit.scaffolding_status != "accountable":
         return GraduationResult(
@@ -101,7 +120,8 @@ def evaluate_graduation(
             meets_rate=False,
             meets_threshold=False,
             blocking_reasons=[
-                "Habit scaffolding_status must be 'accountable' to evaluate graduation"
+                "Habit scaffolding_status must be 'accountable' to evaluate "
+                f"graduation (current: {habit.scaffolding_status})"
             ],
         )
 

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -344,6 +344,19 @@ class TestEvaluateGraduation:
         assert result.eligible is False
         assert any("accountable" in r for r in result.blocking_reasons)
 
+    def test_paused_habit_returns_blocking_reason(self, db):
+        """Habit with status != 'active' returns eligible=False with status blocking_reason."""
+        habit = _create_habit(
+            db, status="paused", scaffolding_status="accountable",
+        )
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.eligible is False
+        assert any(
+            "status must be 'active'" in r for r in result.blocking_reasons
+        )
+
     def test_wrong_scaffolding_status_graduated(self, db):
         """Already graduated habits cannot be re-evaluated."""
         habit = _create_habit(db, scaffolding_status="graduated")

--- a/tests/test_graduation_endpoints.py
+++ b/tests/test_graduation_endpoints.py
@@ -143,25 +143,35 @@ class TestEvaluateGraduationEndpoint:
         assert resp.status_code == 404
 
     def test_wrong_scaffolding_status(self, client, db):
-        """Habit with scaffolding_status != accountable returns 422."""
+        """Habit with scaffolding_status != accountable returns 200 with blocking_reasons."""
         habit = _create_habit(db, scaffolding_status="tracking")
         resp = client.post(f"/api/habits/{habit.id}/evaluate-graduation")
-        assert resp.status_code == 422
-        assert "accountable" in resp.json()["detail"]
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["eligible"] is False
+        assert data["habit_id"] == str(habit.id)
+        assert any("accountable" in reason for reason in data["blocking_reasons"])
 
     def test_graduated_habit_rejected(self, client, db):
-        """Already graduated habit returns 422."""
+        """Already graduated habit returns 200 with blocking_reasons."""
         habit = _create_habit(db, scaffolding_status="graduated",
                               notification_frequency="graduated")
         resp = client.post(f"/api/habits/{habit.id}/evaluate-graduation")
-        assert resp.status_code == 422
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["eligible"] is False
+        assert any("accountable" in reason for reason in data["blocking_reasons"])
 
     def test_paused_habit_rejected(self, client, db):
-        """Paused habit returns 422 (wrong status)."""
+        """Paused habit returns 200 with status blocking_reason."""
         habit = _create_habit(db, status="paused", scaffolding_status="accountable")
         resp = client.post(f"/api/habits/{habit.id}/evaluate-graduation")
-        assert resp.status_code == 422
-        assert "active" in resp.json()["detail"]
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["eligible"] is False
+        assert any(
+            "status must be 'active'" in reason for reason in data["blocking_reasons"]
+        )
 
 
 # ===========================================================================
@@ -334,12 +344,15 @@ class TestEvaluateSlipEndpoint:
         assert data["slip_detected"] is True
         assert data["recommendation"] == "re_scaffold"
 
-    def test_not_graduated_422(self, client, db):
-        """Non-graduated habit returns 422."""
+    def test_not_graduated(self, client, db):
+        """Non-graduated habit returns 200 with slip_detected=False and message."""
         habit = _create_habit(db, scaffolding_status="accountable")
         resp = client.post(f"/api/habits/{habit.id}/evaluate-slip")
-        assert resp.status_code == 422
-        assert "graduated" in resp.json()["detail"]
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["slip_detected"] is False
+        assert "not graduated" in data["message"]
+        assert data["recommendation"] == "no_action"
 
     def test_not_found(self, client):
         """Nonexistent habit returns 404."""


### PR DESCRIPTION
## Verification

- `ruff check .` — ✅ Pass (All checks passed!)
- `pytest -v` — ✅ Pass (1286 passed, 4 skipped)
- `pytest tests/test_graduation_endpoints.py tests/test_graduation.py -v` — ✅ Pass (196 passed)

Ran locally against develop HEAD at `3b2491a` immediately before opening this PR.

## Summary

Fixes brain3#179. Standardizes the two evaluate-* endpoints that were raising `422` for habit-state preconditions so they match the canonical `200+blocking_reasons` pattern established by `evaluate_frequency_step_down` and `graduation_status`. `422` is now reserved for FastAPI/Pydantic request-shape validation errors only. Closes spec [2G-06] v2 Amendment 18 for endpoints 1 (evaluate-graduation) and 5 (evaluate-slip).

## Changes

- `app/routers/graduation.py` — `evaluate_graduation_endpoint` and `evaluate_slip_endpoint` reduced to `_get_habit_or_404(...)` + `return <service_call>`. Router-level 422 guards deleted (status + scaffolding_status for graduation; scaffolding_status for slip).
- `app/services/graduation.py` — Added `habit.status != "active"` precondition to `evaluate_graduation`, returning `GraduationResult(eligible=False, blocking_reasons=[...])` so the status precondition from spec AC #1 survives the router-layer strip. The existing `scaffolding_status != "accountable"` gate is unchanged; reworded the blocking_reason to include the current status value for symmetry. `evaluate_graduated_habit_slip` required no changes — its existing `scaffolding_status != "graduated"` gate already returns `200` with `slip_detected=False` and a populated `message`.
- `tests/test_graduation_endpoints.py` — `test_wrong_scaffolding_status`, `test_graduated_habit_rejected`, `test_paused_habit_rejected` now assert `200` + `eligible=False` + `blocking_reasons`. `test_not_graduated_422` renamed to `test_not_graduated` and asserts `200` + `slip_detected=False` + populated `message`.
- `tests/test_graduation.py` — Added `test_paused_habit_returns_blocking_reason` covering the new service-level `habit.status` precondition.

## How to Verify

1. `git checkout feature/2G-Bug-01-evaluate-graduation-standardization`
2. `pytest tests/test_graduation_endpoints.py tests/test_graduation.py -v` — all green
3. Spot-check: POST `/api/habits/{id}/evaluate-graduation` against a paused habit returns `200` with `eligible=false` and `blocking_reasons` containing `"status must be 'active'"`; against a tracking/graduated habit returns `200` with `blocking_reasons` citing scaffolding_status.
4. Spot-check: POST `/api/habits/{id}/evaluate-slip` against a non-graduated habit returns `200` with `slip_detected=false` and `message` indicating the habit is not graduated.

## Deviations

One deviation from the issue's literal Suggested Fix, taken with PO approval before implementation:

Issue #179 Suggested Fix says "Service-layer precondition handling is already correct — no service changes required" and prescribes reducing the router to `_get_habit_or_404(...) + return <service_call>`. In practice the service only gated on `scaffolding_status`, not on `habit.status`. Following the issue literally would have dropped the `habit.status != "active"` precondition entirely, contradicting spec [2G-06] v2 Amendment 18 AC #1 which lists both preconditions as required 200+blocking_reasons cases. Spec is canonical; the issue text was incomplete. Added the `habit.status` check to `evaluate_graduation` in the service so both preconditions are honoured while keeping the router thin as intended. Flagged for Regina's release ceremony / audit trail.

## Test Results

`pytest -v` — 1286 passed, 4 skipped.
`ruff check .` — All checks passed.

## Acceptance Checklist

- [x] `POST /api/habits/{id}/evaluate-graduation` returns `200` with `GraduationResult.eligible=False` and populated `blocking_reasons` when `habit.status != "active"`
- [x] `POST /api/habits/{id}/evaluate-graduation` returns `200` with `GraduationResult.eligible=False` and populated `blocking_reasons` when `habit.scaffolding_status != "accountable"`
- [x] `POST /api/habits/{id}/evaluate-slip` returns `200` with `SlipDetectionResult.slip_detected=False` and populated `message` when `habit.scaffolding_status != "graduated"`
- [x] `422` responses on these endpoints are reserved for FastAPI/Pydantic request-shape validation errors only
- [x] Endpoint tests assert `200+blocking_reasons` / `200+message` for each precondition that previously returned `422`
- [x] `evaluate_frequency_endpoint` and `graduation_status_endpoint` behaviour unchanged

Closes #179