### PR TITLE
[2G-Bug-02]: Credit habit_completions rows toward evaluate_graduation "Already done" rate on expired nudges

### DIFF
--- a/app/services/graduation.py
+++ b/app/services/graduation.py
@@ -180,7 +180,32 @@ def evaluate_graduation(
             blocking_reasons=["No notification data in evaluation window"],
         )
 
-    already_done_count = sum(1 for n in notifications if n.response == "Already done")
+    # D5 hybrid credit (Amendment 12): an expired nudge with no response can be
+    # credited by a same-date HabitCompletion row. Reflects that multiple
+    # low-friction completion paths (direct complete, routine cascade,
+    # reconciliation) all represent "I did it" from the user's perspective.
+    # Explicit responses — positive or negative — always win over completion
+    # rows: "Already done" still counts on its own, and an explicit non-"Already
+    # done" response (e.g., "Skip today") is never overridden.
+    completion_dates = {
+        c.completed_at
+        for c in db.query(HabitCompletion)
+        .filter(
+            HabitCompletion.habit_id == habit_id,
+            HabitCompletion.completed_at >= window_start.date(),
+            HabitCompletion.completed_at <= now.date(),
+        )
+        .all()
+    }
+
+    already_done_count = 0
+    for n in notifications:
+        if n.response == "Already done":
+            already_done_count += 1
+        elif n.status == "expired" and n.response is None:
+            if n.scheduled_at.date() in completion_dates:
+                already_done_count += 1
+
     current_rate = already_done_count / total_notifications
 
     meets_rate = current_rate >= target

--- a/tests/test_graduation.py
+++ b/tests/test_graduation.py
@@ -483,6 +483,126 @@ class TestEvaluateGraduation:
 
 
 # ===========================================================================
+# D5 hybrid credit — [2G-Bug-02]
+# ===========================================================================
+
+
+class TestEvaluateGraduationHybridCredit:
+    """Expired nudges credited by same-date HabitCompletion rows.
+
+    See `[2G-01]` Amendment 12 / brain3#184. Multiple low-friction completion
+    paths (direct complete, routine cascade, reconciliation) all count toward
+    graduation — explicit responses still win over completion rows.
+    """
+
+    def test_routine_cascade_completion_credited_toward_graduation(self, db):
+        """Expired nudges with same-date routine_cascade completions credit the rate."""
+        habit = _create_habit(db, accountable_since=date.today() - timedelta(days=60))
+        # 10 expired (unresponded) nudges, each with a matching routine_cascade
+        # completion on the same date.
+        for i in range(10):
+            days_ago = i + 1
+            _create_notification(db, habit.id, None, "expired", days_ago=days_ago)
+            db.add(
+                HabitCompletion(
+                    id=uuid.uuid4(),
+                    habit_id=habit.id,
+                    completed_at=date.today() - timedelta(days=days_ago),
+                    source="routine_cascade",
+                ),
+            )
+        db.commit()
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.total_notifications == 10
+        assert result.already_done_count == 10
+        assert result.current_rate == 1.0
+        assert result.meets_rate is True
+        assert result.eligible is True
+
+    def test_individual_completion_credited_toward_graduation(self, db):
+        """Expired nudges with same-date individual completions credit the rate."""
+        habit = _create_habit(db, accountable_since=date.today() - timedelta(days=60))
+        # 10 expired (unresponded) nudges; first 9 have matching individual
+        # completions, last 1 does not → 90% hybrid-credited rate.
+        for i in range(10):
+            days_ago = i + 1
+            _create_notification(db, habit.id, None, "expired", days_ago=days_ago)
+            if i < 9:
+                _create_completion(db, habit.id, days_ago=days_ago)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.total_notifications == 10
+        assert result.already_done_count == 9
+        assert result.current_rate == 0.9
+        assert result.eligible is True
+
+    def test_no_credit_when_no_completion_row(self, db):
+        """Regression guard: expired nudges without a matching completion do NOT get credit."""
+        habit = _create_habit(db, accountable_since=date.today() - timedelta(days=60))
+        # 10 expired nudges, zero completions anywhere.
+        for i in range(10):
+            _create_notification(db, habit.id, None, "expired", days_ago=i + 1)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.total_notifications == 10
+        assert result.already_done_count == 0
+        assert result.current_rate == 0.0
+        assert result.eligible is False
+        assert any("below target" in r for r in result.blocking_reasons)
+
+    def test_no_credit_when_date_mismatch(self, db):
+        """Completion rows credit only same-date expired nudges."""
+        habit = _create_habit(db, accountable_since=date.today() - timedelta(days=60))
+        # 5 expired nudges on days 1-5. Completions exist, but on days 10-14.
+        # Date mismatch → no credit.
+        for i in range(5):
+            _create_notification(db, habit.id, None, "expired", days_ago=i + 1)
+        for i in range(5):
+            _create_completion(db, habit.id, days_ago=i + 10)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.total_notifications == 5
+        assert result.already_done_count == 0
+        assert result.current_rate == 0.0
+
+    def test_response_already_done_still_counts_without_completion_row(self, db):
+        """Back-compat: explicit 'Already done' responses count regardless of completion rows."""
+        habit = _create_habit(db, accountable_since=date.today() - timedelta(days=60))
+        # 10 nudges, all explicit "Already done" responses. No completion rows.
+        for i in range(10):
+            _create_notification(db, habit.id, "Already done", "responded", days_ago=i + 1)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.total_notifications == 10
+        assert result.already_done_count == 10
+        assert result.current_rate == 1.0
+        assert result.eligible is True
+
+    def test_explicit_negative_response_not_overridden_by_completion(self, db):
+        """Explicit non-'Already done' responses win — completion row does NOT override."""
+        habit = _create_habit(db, accountable_since=date.today() - timedelta(days=60))
+        # 10 notifications all responded "Skip today". Completions exist on
+        # every same day. Per spec Acceptance Criterion #4, explicit negative
+        # responses are never overridden.
+        for i in range(10):
+            days_ago = i + 1
+            _create_notification(db, habit.id, "Skip today", "responded", days_ago=days_ago)
+            _create_completion(db, habit.id, days_ago=days_ago)
+
+        result = evaluate_graduation(db, habit.id)
+
+        assert result.total_notifications == 10
+        assert result.already_done_count == 0
+        assert result.current_rate == 0.0
+
+
+# ===========================================================================
 # Schema validation — friction_score on create/update
 # ===========================================================================
 


### PR DESCRIPTION
## Verification

- `ruff check .` — ✅ Pass (All checks passed!)
- `pytest -v` — ✅ Pass (1292 passed, 4 skipped)
- Migration applied locally on brain3-dev: N/A (no schema change)
- Postgres-backed test confirmed: N/A (pure ORM logic; no Postgres-specific behavior)

Ran locally against develop HEAD at `90d6989` immediately before opening this PR.

## Summary

`evaluate_graduation` now credits a same-date `habit_completions` row when an expired nudge has no response. The result: a user who completes a habit through any path (direct complete, routine cascade, reconciliation) gets credit toward graduation — not only when they explicitly tap "Already done" on a nudge. This is the ADHD quality lens in action: multiple low-friction completion paths work better than a single path, and all of them feel like "I did it" to the user.

Explicit responses still win. An explicit `"Already done"` counts on its own (back-compat preserved). An explicit non-`"Already done"` response (e.g., `"Skip today"`) is never overridden by a completion row — a user saying "no" to a nudge means no, even if reconciliation later recorded a completion.

## Changes

- `app/services/graduation.py` — `evaluate_graduation` now queries `habit_completions` over the evaluation window and builds a set of completion dates. The `already_done_count` derivation iterates notifications: `"Already done"` responses count as before; expired notifications with `response IS NULL` count if a same-date completion exists; all other explicit responses are untouched. `GraduationResult` shape unchanged.
- `tests/test_graduation.py` — new `TestEvaluateGraduationHybridCredit` class covers the five acceptance tests from the issue (routine-cascade credit, individual credit, no-credit-without-row, no-credit-on-date-mismatch, explicit-"Already done" back-compat) plus an explicit-negative-override guard.

## How to Verify

1. `git checkout feature/2G-Bug-02-evaluate-graduation-hybrid-credit`
2. `ruff check .` — passes clean
3. `pytest -v tests/test_graduation.py` — all 160 graduation tests pass, including the 6 new hybrid-credit tests
4. `pytest -v` — full suite: 1292 passed, 4 skipped

## Deviations

None. Implementation matches the GitHub issue acceptance criteria and `[2G-01]` v2 Amendment 12.

Per Wave 2 brief guidance (D7, Wave 3 #186): the hybrid-credit logic here is deliberately inline. Duplication with the companion step-down fix (#185) is expected and retained — the shared `read_completion_history` helper refactor lands in Wave 3 as #186.

## Test Results

\`\`\`
$ ruff check .
All checks passed!

$ pytest -v
====================== 1292 passed, 4 skipped in 21.73s =======================
\`\`\`

New tests in `TestEvaluateGraduationHybridCredit`:
- `test_routine_cascade_completion_credited_toward_graduation`
- `test_individual_completion_credited_toward_graduation`
- `test_no_credit_when_no_completion_row`
- `test_no_credit_when_date_mismatch`
- `test_response_already_done_still_counts_without_completion_row`
- `test_explicit_negative_response_not_overridden_by_completion`

All existing graduation tests continue to pass (AC #6).

## Acceptance Checklist

- [x] `evaluate_graduation` reads both `notification_queue.response='Already done'` and `habit_completions` rows dated to expired-nudge dates
- [x] Expired notification with `response IS NULL` + matching same-date `HabitCompletion` → counted toward `already_done_count`
- [x] Explicit `"Already done"` continues to count regardless of completion-row presence (back-compat)
- [x] Non-`"Already done"` responses (e.g., `"Skip today"`) are NOT overridden by a completion row
- [x] `GraduationResult` response shape unchanged; only `already_done_count` / derived `current_rate` differ
- [x] All existing graduation tests continue to pass
- [x] New integration tests added (see above)

Closes #184