### PR TITLE
[2A-Enh-01]: Add effective_graduation_params to HabitDetailResponse

### DIFF
--- a/app/schemas/habits.py
+++ b/app/schemas/habits.py
@@ -22,7 +22,7 @@ from datetime import date, datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
 
 HabitStatus = Literal["active", "paused", "graduated", "abandoned"]
 HabitFrequency = Literal["daily", "weekdays", "weekends", "weekly", "custom"]
@@ -107,6 +107,19 @@ class HabitUpdate(BaseModel):
         return v
 
 
+class EffectiveGraduationParams(BaseModel):
+    """Resolved graduation parameters surfaced on habit responses (Amendment 05).
+
+    Composite of `resolve_graduation_params` + `apply_re_scaffold_tightening`.
+    Read-only: computed at serialization time, not stored and not settable.
+    """
+
+    window_days: int
+    target_rate: float
+    threshold_days: int
+    source: Literal["override", "friction_default"]
+
+
 class HabitResponse(BaseModel):
     """Habit returned from API — includes id and timestamps."""
 
@@ -134,6 +147,34 @@ class HabitResponse(BaseModel):
     last_completed: date | None = None
     created_at: datetime
     updated_at: datetime
+
+    @computed_field
+    @property
+    def effective_graduation_params(self) -> EffectiveGraduationParams:
+        """Resolved graduation params — overrides or friction defaults, plus tightening."""
+        # Local imports keep schemas → services dependency one-way at module
+        # load time; resolve_graduation_params uses TYPE_CHECKING for Habit so
+        # duck-typing this Pydantic model is safe — it reads the same four
+        # attrs (friction_score + three override columns).
+        from app.services.graduation import apply_re_scaffold_tightening
+        from app.services.graduation_defaults import resolve_graduation_params
+
+        window, target, threshold = resolve_graduation_params(self)
+        if self.re_scaffold_count > 0:
+            window, target, threshold = apply_re_scaffold_tightening(
+                window, target, threshold, self.re_scaffold_count,
+            )
+        has_override = (
+            self.graduation_window is not None
+            or self.graduation_target is not None
+            or self.graduation_threshold is not None
+        )
+        return EffectiveGraduationParams(
+            window_days=window,
+            target_rate=target,
+            threshold_days=threshold,
+            source="override" if has_override else "friction_default",
+        )
 
 
 class HabitDetailResponse(HabitResponse):

--- a/tests/test_habits.py
+++ b/tests/test_habits.py
@@ -286,6 +286,206 @@ class TestGetHabit:
 
 
 # ---------------------------------------------------------------------------
+# [2A-Enh-01] effective_graduation_params composite field
+# ---------------------------------------------------------------------------
+
+
+class TestEffectiveGraduationParams:
+    """Amendment 05: composite graduation params on habit read responses.
+
+    Source labels `"override"` / `"friction_default"` come from spec
+    Amendment 05. Pre-existing `graduation_status_endpoint` uses its own
+    legacy `"per_habit"` label; that divergence is tracked under D8-X and
+    deliberately not touched here.
+    """
+
+    def test_get_habit_friction_default_source(self, client):
+        """No overrides, friction_score=3 → friction-tier defaults, source=friction_default."""
+        habit = make_habit(client, friction_score=3)
+        resp = client.get(f"/api/habits/{habit['id']}")
+        assert resp.status_code == 200
+        params = resp.json()["effective_graduation_params"]
+        assert params == {
+            "window_days": 45,
+            "target_rate": 0.85,
+            "threshold_days": 45,
+            "source": "friction_default",
+        }
+
+    def test_get_habit_friction_default_with_null_friction(self, client):
+        """No overrides, no friction_score → middle-tier defaults."""
+        habit = make_habit(client)
+        resp = client.get(f"/api/habits/{habit['id']}")
+        params = resp.json()["effective_graduation_params"]
+        assert params["source"] == "friction_default"
+        assert params["window_days"] == 45
+        assert params["target_rate"] == 0.85
+        assert params["threshold_days"] == 45
+
+    def test_get_habit_override_source_single_column(self, client):
+        """Any single override column non-NULL → source=override."""
+        habit = make_habit(client, friction_score=1, graduation_window=90)
+        resp = client.get(f"/api/habits/{habit['id']}")
+        params = resp.json()["effective_graduation_params"]
+        assert params["source"] == "override"
+        assert params["window_days"] == 90  # override
+        assert params["target_rate"] == 0.85  # friction-1 default
+        assert params["threshold_days"] == 30  # friction-1 default
+
+    def test_get_habit_override_source_all_three_columns(self, client):
+        """All three overrides set → source=override, values come from overrides."""
+        habit = make_habit(
+            client,
+            friction_score=1,
+            graduation_window=100,
+            graduation_target=0.70,
+            graduation_threshold=100,
+        )
+        resp = client.get(f"/api/habits/{habit['id']}")
+        params = resp.json()["effective_graduation_params"]
+        assert params == {
+            "window_days": 100,
+            "target_rate": 0.70,
+            "threshold_days": 100,
+            "source": "override",
+        }
+
+    def test_get_habit_applies_re_scaffold_tightening_friction_default(self, db, client):
+        """re_scaffold_count>0 tightens values — source stays friction_default."""
+        import uuid
+
+        from app.models import Habit
+
+        habit = Habit(
+            id=uuid.uuid4(),
+            title="Tightened habit",
+            frequency="daily",
+            status="active",
+            scaffolding_status="tracking",
+            friction_score=1,  # baseline defaults: (30, 0.85, 30)
+            re_scaffold_count=2,
+        )
+        db.add(habit)
+        db.commit()
+
+        resp = client.get(f"/api/habits/{habit.id}")
+        params = resp.json()["effective_graduation_params"]
+        # Double re-scaffold from (30, 0.85, 30): (37, 0.90, 37) → (46, 0.95, 46)
+        assert params == {
+            "window_days": 46,
+            "target_rate": 0.95,
+            "threshold_days": 46,
+            "source": "friction_default",
+        }
+
+    def test_get_habit_re_scaffold_tightens_overrides(self, db, client):
+        """Tightening applies to override baseline; source stays override."""
+        import uuid
+
+        from app.models import Habit
+
+        habit = Habit(
+            id=uuid.uuid4(),
+            title="Tightened override",
+            frequency="daily",
+            status="active",
+            scaffolding_status="tracking",
+            graduation_window=60,
+            graduation_target=0.70,
+            graduation_threshold=60,
+            re_scaffold_count=1,
+        )
+        db.add(habit)
+        db.commit()
+
+        resp = client.get(f"/api/habits/{habit.id}")
+        params = resp.json()["effective_graduation_params"]
+        # Single re-scaffold from (60, 0.70, 60): (75, 0.75, 75)
+        assert params["window_days"] == 75
+        assert params["target_rate"] == 0.75
+        assert params["threshold_days"] == 75
+        assert params["source"] == "override"
+
+    def test_list_habits_items_include_effective_graduation_params(self, client):
+        """Each item in GET /api/habits includes effective_graduation_params."""
+        make_habit(client, title="H1", friction_score=1)
+        make_habit(
+            client,
+            title="H2",
+            friction_score=5,
+            graduation_window=100,
+        )
+        resp = client.get("/api/habits")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 2
+        for item in body["items"]:
+            assert "effective_graduation_params" in item
+            assert set(item["effective_graduation_params"].keys()) == {
+                "window_days",
+                "target_rate",
+                "threshold_days",
+                "source",
+            }
+        sources = {
+            item["title"]: item["effective_graduation_params"]["source"]
+            for item in body["items"]
+        }
+        assert sources["H1"] == "friction_default"
+        assert sources["H2"] == "override"
+
+    def test_effective_graduation_params_ignored_in_post_body(self, client):
+        """Request-body effective_graduation_params is ignored; response reflects computed value."""
+        resp = client.post(
+            "/api/habits",
+            json={
+                "title": "Ignored field",
+                "frequency": "daily",
+                "friction_score": 1,
+                "effective_graduation_params": {
+                    "window_days": 999,
+                    "target_rate": 0.01,
+                    "threshold_days": 999,
+                    "source": "override",
+                },
+            },
+        )
+        assert resp.status_code == 201
+        params = resp.json()["effective_graduation_params"]
+        # Computed from friction_score=1 with no overrides — NOT echoed
+        assert params == {
+            "window_days": 30,
+            "target_rate": 0.85,
+            "threshold_days": 30,
+            "source": "friction_default",
+        }
+
+    def test_effective_graduation_params_ignored_in_patch_body(self, client):
+        """PATCH body cannot set effective_graduation_params — it stays computed."""
+        habit = make_habit(client, friction_score=3)
+        resp = client.patch(
+            f"/api/habits/{habit['id']}",
+            json={
+                "effective_graduation_params": {
+                    "window_days": 1,
+                    "target_rate": 0.01,
+                    "threshold_days": 1,
+                    "source": "override",
+                },
+            },
+        )
+        assert resp.status_code == 200
+        params = resp.json()["effective_graduation_params"]
+        # friction_score=3 defaults still apply
+        assert params == {
+            "window_days": 45,
+            "target_rate": 0.85,
+            "threshold_days": 45,
+            "source": "friction_default",
+        }
+
+
+# ---------------------------------------------------------------------------
 # PATCH /api/habits/{id}
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Verification

- `ruff check .` — ✅ Pass (All checks passed!)
- `pytest -v` — ✅ Pass (1308 passed, 4 skipped)
- Migration applied locally on brain3-dev: N/A (no schema change — reads existing columns only)
- Postgres-backed test confirmed: N/A (pure Pydantic serialization; no Postgres-specific behavior)

Ran locally against develop HEAD at `bd3ed64` immediately before opening this PR.

**#182 merge gate confirmed:** visible on develop as commit `b87f089` (`fix(habits): remove scalar defaults on graduation override columns (#182)`) — the NULL-backfilled schema this PR depends on to distinguish overrides from defaults is present.

## Summary

`HabitResponse` (and by inheritance `HabitDetailResponse` and every item in `HabitListResponse`) now carries an `effective_graduation_params` composite with the post-resolver, post-tightening graduation knobs: `{window_days, target_rate, threshold_days, source}`. Consumers of `GET /api/habits/{id}` no longer need a second call to `/graduation-status` just to see what graduation parameters actually apply to a habit.

Implementation uses a Pydantic `computed_field` on `HabitResponse`, so all routes that return habit data pick it up automatically — no router changes. The field delegates to the same `resolve_graduation_params` + `apply_re_scaffold_tightening` used by `graduation_status_endpoint`, so the two disclosures stay in lock-step on values. It's read-only: POST/PATCH bodies that include the field are silently ignored (standard Pydantic behavior on unknown fields).

`source` is `"override"` if any of `graduation_window` / `graduation_target` / `graduation_threshold` is non-NULL, and `"friction_default"` otherwise — per spec Amendment 05.

## Changes

- `app/schemas/habits.py` — added `EffectiveGraduationParams` model (literal `source: "override" | "friction_default"`). Added a `computed_field` `effective_graduation_params` on `HabitResponse` that calls `resolve_graduation_params(self)` + tightening. Local imports inside the method keep the schemas → services edge lazy.
- `tests/test_habits.py` — new `TestEffectiveGraduationParams` class with 9 cases: friction-default source (with and without friction_score), override source (single-column and all-three-columns), tightening on friction-default baseline, tightening on override baseline, list-endpoint inclusion, POST-body ignore, PATCH-body ignore.

## How to Verify

1. `git checkout feature/2A-Enh-01-effective-graduation-params`
2. `ruff check .` — passes clean
3. `pytest -v tests/test_habits.py` — 65 habit tests pass, including the 9 new cases
4. `pytest -v` — full suite: 1308 passed, 4 skipped
5. Hit `GET /api/habits/{id}` on any habit — response includes `effective_graduation_params` with the four keys; `source` reflects override presence; `window_days` / `target_rate` / `threshold_days` reflect tightening when `re_scaffold_count > 0`.

## Deviations

**Source-label divergence (flagged, intentional):** Spec Amendment 05 specifies `source: Literal["override", "friction_default"]` for this new field, which is what I implemented. The pre-existing `graduation_status_endpoint` (`app/routers/graduation.py:283`) emits `"per_habit"` in its analogous `graduation_params.source` slot. The Wave 2 brief flags D8-X as held — "`graduation_params.source` semantic — still held" — and explicitly tells me not to address it in Wave 2, so I left the legacy endpoint untouched. That leaves the two endpoints diverging on label values in the short term; canonicalisation lands when D8-X unblocks.

Otherwise none — implementation follows spec Amendment 05 and issue #181 acceptance criteria.

## Test Results

\`\`\`
$ ruff check .
All checks passed!

$ pytest -v
====================== 1308 passed, 4 skipped in 22.80s =======================
\`\`\`

New tests in `TestEffectiveGraduationParams`:
- `test_get_habit_friction_default_source`
- `test_get_habit_friction_default_with_null_friction`
- `test_get_habit_override_source_single_column`
- `test_get_habit_override_source_all_three_columns`
- `test_get_habit_applies_re_scaffold_tightening_friction_default`
- `test_get_habit_re_scaffold_tightens_overrides`
- `test_list_habits_items_include_effective_graduation_params`
- `test_effective_graduation_params_ignored_in_post_body`
- `test_effective_graduation_params_ignored_in_patch_body`

## Acceptance Checklist

- [x] `GET /api/habits/{id}` response includes `effective_graduation_params` (AC #1)
- [x] Shape matches `graduation_status_endpoint`'s `graduation_params` block: `{window_days, target_rate, threshold_days, source}` (AC #2)
- [x] Values reflect resolver + tightening; post-re-scaffold tests assert tightened values on both friction-default and override baselines (AC #3)
- [x] Existing `graduation_window` / `graduation_target` / `graduation_threshold` bare fields unchanged (AC #4)
- [x] Endpoint tests cover pre-re-scaffold and post-re-scaffold habits (AC #5)
- [x] `[Amendment 05]` Also surfaced on list-endpoint items (`GET /api/habits` → `items[*]`)
- [x] `[Amendment 05]` `source = "override"` when any override column is non-NULL
- [x] `[Amendment 05]` `source = "friction_default"` when all three override columns are NULL
- [x] `[Amendment 05]` Field is read-only; POST/PATCH ignore it in request body

Closes #181