### PR TITLE
[2C-03] Make notification response endpoint idempotent on (notification_id, response) tuple

### DIFF
--- a/app/routers/notification.py
+++ b/app/routers/notification.py
@@ -174,7 +174,21 @@ def respond_to_notification(
     payload: NotificationRespondRequest,
     db: Session = Depends(get_db),
 ) -> NotificationQueue:
-    """Record a user response to a delivered notification."""
+    """Record a user response to a delivered notification.
+
+    Idempotent on the (notification_id, response, response_note) tuple: a
+    repeat call with the same ``response`` and ``response_note`` as the
+    already-recorded values returns 200 with the existing notification
+    unchanged (no DB write, ``responded_at`` not bumped). A repeat call
+    with a different ``response`` or ``response_note`` is a legitimate
+    conflict and returns 409.
+
+    Idempotent retry contract: clients (e.g. the Stream C canned-response
+    queue) treat a 200 response as "your write was applied — you can
+    clear it from the queue" regardless of whether it was the original
+    write or a retry. The server does not distinguish first-vs-retry in
+    the status code.
+    """
     notification = (
         db.query(NotificationQueue)
         .filter(NotificationQueue.id == notification_id)
@@ -190,6 +204,12 @@ def respond_to_notification(
             detail="Notification has not been delivered yet",
         )
     if notification.status == "responded":
+        if (
+            notification.response == payload.response
+            and notification.response_note == payload.response_note
+        ):
+            # Idempotent retry — return existing row, no write, no status change.
+            return notification
         raise HTTPException(
             status_code=409,
             detail="Notification has already been responded to",

--- a/tests/test_notification_respond.py
+++ b/tests/test_notification_respond.py
@@ -266,19 +266,22 @@ class TestRespondErrors:
         assert resp.status_code == 409
         assert "not been delivered" in resp.json()["detail"]
 
-    def test_409_already_responded(self, client):
-        """Responding to an already-responded notification returns 409."""
-        n = make_notification(client, canned_responses=["Done"])
+    def test_409_already_responded_with_different_response(self, client):
+        """Responding to an already-responded notification with a *different*
+        response returns 409. Idempotent retries on the same response are
+        covered in TestRespondIdempotency.
+        """
+        n = make_notification(client, canned_responses=["Done", "Skip"])
         deliver(client, n["id"])
         # First response
         client.post(
             f"{BASE_URL}/{n['id']}/respond",
             json={"response": "Done"},
         )
-        # Second response attempt
+        # Second attempt with a different response — legitimate conflict.
         resp = client.post(
             f"{BASE_URL}/{n['id']}/respond",
-            json={"response": "Done"},
+            json={"response": "Skip"},
         )
         assert resp.status_code == 409
         assert "already been responded to" in resp.json()["detail"]
@@ -339,3 +342,115 @@ class TestRespondErrors:
             json={"response": "Done", "response_note": "x" * 1001},
         )
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — (notification_id, response, response_note) tuple
+# ---------------------------------------------------------------------------
+
+class TestRespondIdempotency:
+    """POST /api/notifications/{id}/respond — idempotency contract per [2C-03].
+
+    The response endpoint is idempotent on the (response, response_note)
+    tuple: a repeat with identical values returns 200 with the existing
+    row unchanged. Any divergence (different response, or same response
+    with different note) is a legitimate conflict and returns 409.
+    """
+
+    def test_duplicate_identical_response_is_idempotent(self, client):
+        """Same response + same note twice → 200 both times, identical body,
+        responded_at unchanged on the second call.
+        """
+        n = make_notification(client, canned_responses=["Done"])
+        deliver(client, n["id"])
+
+        first = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Done", "response_note": "Got it"},
+        )
+        assert first.status_code == 200
+        first_body = first.json()
+        assert first_body["status"] == "responded"
+        assert first_body["response"] == "Done"
+        assert first_body["response_note"] == "Got it"
+        first_responded_at = first_body["responded_at"]
+        assert first_responded_at is not None
+
+        second = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Done", "response_note": "Got it"},
+        )
+        assert second.status_code == 200
+        second_body = second.json()
+        # responded_at must NOT be bumped on idempotent retry.
+        assert second_body["responded_at"] == first_responded_at
+        # Whole body matches the first call.
+        assert second_body == first_body
+
+    def test_duplicate_identical_response_no_note(self, client):
+        """Idempotency also holds when response_note is null on both calls."""
+        n = make_notification(client, canned_responses=["Done"])
+        deliver(client, n["id"])
+
+        first = client.post(
+            f"{BASE_URL}/{n['id']}/respond", json={"response": "Done"},
+        )
+        assert first.status_code == 200
+        first_responded_at = first.json()["responded_at"]
+
+        second = client.post(
+            f"{BASE_URL}/{n['id']}/respond", json={"response": "Done"},
+        )
+        assert second.status_code == 200
+        assert second.json()["responded_at"] == first_responded_at
+        assert second.json()["response_note"] is None
+
+    def test_duplicate_with_different_response_is_409(self, client):
+        """Different response on retry → 409, existing row unchanged."""
+        n = make_notification(client, canned_responses=["Done", "Skip"])
+        deliver(client, n["id"])
+
+        first = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Done", "response_note": "Got it"},
+        )
+        assert first.status_code == 200
+        first_body = first.json()
+
+        conflict = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Skip", "response_note": "Got it"},
+        )
+        assert conflict.status_code == 409
+
+        # Existing row unchanged: response, note, and responded_at all preserved.
+        current = client.get(f"{BASE_URL}/{n['id']}").json()
+        assert current["response"] == "Done"
+        assert current["response_note"] == "Got it"
+        assert current["responded_at"] == first_body["responded_at"]
+
+    def test_duplicate_same_response_different_note_is_409(self, client):
+        """Same response but different response_note on retry → 409,
+        existing row unchanged.
+        """
+        n = make_notification(client, canned_responses=["Done"])
+        deliver(client, n["id"])
+
+        first = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Done", "response_note": "Got it"},
+        )
+        assert first.status_code == 200
+        first_body = first.json()
+
+        conflict = client.post(
+            f"{BASE_URL}/{n['id']}/respond",
+            json={"response": "Done", "response_note": "Different note"},
+        )
+        assert conflict.status_code == 409
+
+        # Existing row unchanged.
+        current = client.get(f"{BASE_URL}/{n['id']}").json()
+        assert current["response"] == "Done"
+        assert current["response_note"] == "Got it"
+        assert current["responded_at"] == first_body["responded_at"]


### PR DESCRIPTION
Closes #202

## Verification

- `ruff check .` — ✅ Pass (All checks passed!)
- `pytest -v` — ✅ Pass (1362 passed)
- Migration applied locally on brain3-dev: ✅ N/A (no schema change — idempotency computed from existing columns)
- Postgres-backed test confirmed: ✅ N/A (in-memory SQLite suite, no Postgres-specific behavior touched)

Ran locally against develop HEAD at `2ec8521` immediately before opening this PR.

## Summary

`POST /api/notifications/{id}/respond` is now idempotent on the
`(notification_id, response, response_note)` tuple. A retry that
matches the recorded response and note returns 200 with the existing
row (no DB write, `responded_at` unchanged). A retry with a different
response, or the same response with a different note, returns 409 —
that's a legitimate conflict (the user tapped a different action a
second time). The `pending` (409), `expired` (410), and `not-found`
(404) branches are unchanged.

## Changes

- `app/routers/notification.py` — `respond_to_notification` now
  short-circuits the `responded` branch when the new payload's
  `response` and `response_note` match the recorded values, returning
  the existing notification with no write. Docstring documents the
  idempotency contract and the client-facing implication that 200
  means "applied" regardless of first-vs-retry.
- `tests/test_notification_respond.py` — adds `TestRespondIdempotency`
  with the three acceptance-criteria cases plus a no-note variant
  (covers idempotency when `response_note` is null on both sides).
  Renames and updates the previous `test_409_already_responded` (see
  Deviations).

## How to Verify

1. Boot brain3 locally against `develop` HEAD `2ec8521`.
2. Create + deliver a notification, then `POST /respond` with
   `{"response": "Done", "response_note": "Got it"}`. Observe 200 and
   capture the `responded_at` timestamp.
3. POST the same body again. Observe 200, identical body, identical
   `responded_at` (no bump).
4. POST with `{"response": "Skip", "response_note": "Got it"}`.
   Observe 409 with detail `"Notification has already been responded
   to"`. GET the notification — `response`, `response_note`, and
   `responded_at` are unchanged from step 2.
5. Repeat step 4 with `{"response": "Done", "response_note": "different"}`.
   Observe 409, row unchanged.
6. Run `pytest tests/test_notification_respond.py -v` — 27 tests pass.

## Deviations

**D-10 — `test_409_already_responded` was renamed and modified.**
The pre-existing test posted `{"response": "Done"}` twice and asserted
409. Under the new contract that case is the canonical idempotent
success path (200), so the test cannot survive unchanged. Renamed to
`test_409_already_responded_with_different_response` and changed the
second call to `{"response": "Skip"}` so it still represents a 409
conflict path under the new semantics. The spec's acceptance line
"Existing 409/410/404 tests continue to pass" is otherwise honored —
all the *other* 409 (`pending`), 410 (`expired`), and 404 (`not
found`) tests pass without change. Flagging because the spec's
acceptance language read as if no test changes were needed in the
existing block; in practice this one case is the exact behavior being
flipped, so a test edit was unavoidable. Net test count: +4 (three
acceptance cases + a no-note idempotency variant).

## Test Results

```
$ python -m pytest -v
============================ 1362 passed in 21.68s ============================

$ python -m ruff check .
All checks passed!
```

Targeted run on the changed file:

```
$ python -m pytest tests/test_notification_respond.py -v
============================ 27 passed in 0.54s ============================
```

## Acceptance Checklist

- [x] `respond_to_notification` returns 200 + existing row when
      `(response, response_note)` match the recorded values; no DB
      write, `responded_at` not bumped.
- [x] `respond_to_notification` returns 409 when `response` differs
      from the recorded value.
- [x] `respond_to_notification` returns 409 when `response` matches
      but `response_note` differs.
- [x] `pending` → 409, `expired` → 410, `not found` → 404 unchanged.
- [x] No schema change.
- [x] `tests/test_notification_respond.py` covers the three
      acceptance-criteria cases.
- [x] Existing 409/410/404 tests pass (with one rename + one input
      change documented in Deviations).