### PR TITLE
[2C-04] Align EXPIRY_DEFAULTS to v0.9 Q4, add SERVER_TZ config, add Time Block duration floor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,7 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:8000
 # Distinct from any MCP token. Generate with: python -m scripts.generate_token
 # Leave unset in dev to skip auth (a startup warning will be logged).
 # BRAIN3_APP_BEARER_TOKEN=
+
+# Server time zone (IANA zoneinfo key). Used for TZ-sensitive server-side
+# logic such as EOD-local routine_checklist expiry. Validated at startup.
+# BRAIN3_SERVER_TZ=America/Chicago

--- a/app/config.py
+++ b/app/config.py
@@ -16,7 +16,9 @@
 
 """Application configuration via Pydantic Settings."""
 
-from pydantic import Field
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -41,9 +43,31 @@ class Settings(BaseSettings):
         default=None, validation_alias="BRAIN3_APP_BEARER_TOKEN",
     )
 
+    # IANA zoneinfo key used for TZ-sensitive server-side logic (e.g. EOD-local
+    # routine_checklist expiry). Validated at startup — a bad key fails fast
+    # rather than silently producing wrong expiries.
+    SERVER_TZ: str = Field(
+        default="America/Chicago", validation_alias="BRAIN3_SERVER_TZ",
+    )
+
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", populate_by_name=True,
     )
+
+    @field_validator("SERVER_TZ")
+    @classmethod
+    def _validate_server_tz(cls, v: str) -> str:
+        try:
+            ZoneInfo(v)
+        except ZoneInfoNotFoundError as exc:
+            msg = f"SERVER_TZ {v!r} is not a valid IANA zoneinfo key"
+            raise ValueError(msg) from exc
+        return v
+
+    @property
+    def server_tz(self) -> ZoneInfo:
+        """Return SERVER_TZ as a resolved ZoneInfo."""
+        return ZoneInfo(self.SERVER_TZ)
 
     @property
     def database_url(self) -> str:

--- a/app/routers/notification.py
+++ b/app/routers/notification.py
@@ -292,6 +292,7 @@ async def update_notification(
             notification.notification_type,
             delivered_at,
             notification.expires_at,
+            scheduled_date=notification.scheduled_date,
         )
 
     db.commit()

--- a/app/services/notification_defaults.py
+++ b/app/services/notification_defaults.py
@@ -18,9 +18,11 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 
 from sqlalchemy.orm import Session
+
+from app.config import settings
 
 CANNED_RESPONSE_DEFAULTS: dict[str, list[str]] = {
     "habit_nudge": [
@@ -110,12 +112,16 @@ def validate_canned_responses(responses: list[str]) -> None:
 # ---------------------------------------------------------------------------
 
 EXPIRY_DEFAULTS: dict[str, timedelta] = {
-    "habit_nudge": timedelta(hours=2),
+    "habit_nudge": timedelta(hours=4),
+    # routine_checklist resolves to EOD-local at calc time; the timedelta
+    # here is a fallback used only when scheduled_date is missing.
     "routine_checklist": timedelta(hours=4),
-    "checkin_prompt": timedelta(hours=12),
-    "time_block_reminder": timedelta(hours=1),
+    "checkin_prompt": timedelta(hours=2),
+    # time_block_reminder is floored by block_duration when supplied; default
+    # 30m applies when block_duration is unknown at delivery time.
+    "time_block_reminder": timedelta(minutes=30),
     "deadline_event_alert": timedelta(hours=0),  # special: expires at target deadline
-    "pattern_observation": timedelta(hours=24),
+    "pattern_observation": timedelta(hours=48),
     "stale_work_nudge": timedelta(hours=24),
 }
 
@@ -135,6 +141,9 @@ def calculate_expires_at(
     notification_type: str,
     delivered_at: datetime,
     existing_expires_at: datetime | None = None,
+    *,
+    scheduled_date: date | None = None,
+    block_duration: timedelta | None = None,
 ) -> datetime | None:
     """Calculate the expiry timestamp for a notification at delivery time.
 
@@ -143,6 +152,11 @@ def calculate_expires_at(
 
     - ``deadline_event_alert`` with no override falls back to 24h from delivery
       (the creator *should* have set an explicit ``expires_at``).
+    - ``time_block_reminder``: ``delivered_at + min(30m, block_duration)`` when
+      *block_duration* is supplied; otherwise the 30m default.
+    - ``routine_checklist``: midnight at the start of the day after
+      *scheduled_date*, in ``settings.SERVER_TZ`` (EOD-local). Falls back to
+      the 4h default if *scheduled_date* is not supplied.
     - All other types: ``delivered_at + EXPIRY_DEFAULTS[type]``.
     """
     if existing_expires_at is not None:
@@ -150,6 +164,16 @@ def calculate_expires_at(
 
     if notification_type == "deadline_event_alert":
         return delivered_at + timedelta(hours=24)
+
+    if notification_type == "time_block_reminder":
+        floor = EXPIRY_DEFAULTS["time_block_reminder"]
+        if block_duration is not None:
+            floor = min(floor, block_duration)
+        return delivered_at + floor
+
+    if notification_type == "routine_checklist" and scheduled_date is not None:
+        next_day = scheduled_date + timedelta(days=1)
+        return datetime.combine(next_day, time(0, 0), tzinfo=settings.server_tz)
 
     default_delta = EXPIRY_DEFAULTS.get(notification_type)
     if default_delta is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pydantic==2.12.5
 pydantic-settings==2.13.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
+tzdata==2026.2

--- a/tests/test_notification_expiry.py
+++ b/tests/test_notification_expiry.py
@@ -14,13 +14,20 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-"""Tests for [2B-05] response expiry windows and notification retention."""
+"""Tests for [2B-05] response expiry windows and notification retention.
+
+Updated by [2C-04] to assert v0.9 §Q4 EXPIRY_DEFAULTS values, the
+``time_block_reminder`` block_duration floor, and the ``routine_checklist``
+EOD-local boundary.
+"""
 
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 
+from app.config import settings
 from app.models import NotificationQueue
 from app.services.notification_defaults import (
     EXPIRY_DEFAULTS,
@@ -112,22 +119,26 @@ class TestExpiryDefaults:
         assert set(EXPIRY_DEFAULTS.keys()) == set(NOTIFICATION_TYPES)
 
     def test_habit_nudge(self):
-        assert EXPIRY_DEFAULTS["habit_nudge"] == timedelta(hours=2)
+        assert EXPIRY_DEFAULTS["habit_nudge"] == timedelta(hours=4)
 
-    def test_routine_checklist(self):
+    def test_routine_checklist_fallback(self):
+        # Fallback when scheduled_date is missing; the live path resolves
+        # to EOD-local — see TestRoutineChecklistEOD.
         assert EXPIRY_DEFAULTS["routine_checklist"] == timedelta(hours=4)
 
     def test_checkin_prompt(self):
-        assert EXPIRY_DEFAULTS["checkin_prompt"] == timedelta(hours=12)
+        assert EXPIRY_DEFAULTS["checkin_prompt"] == timedelta(hours=2)
 
     def test_time_block_reminder(self):
-        assert EXPIRY_DEFAULTS["time_block_reminder"] == timedelta(hours=1)
+        # 30m default; floored further by block_duration when supplied —
+        # see TestTimeBlockFloor.
+        assert EXPIRY_DEFAULTS["time_block_reminder"] == timedelta(minutes=30)
 
     def test_deadline_event_alert(self):
         assert EXPIRY_DEFAULTS["deadline_event_alert"] == timedelta(hours=0)
 
     def test_pattern_observation(self):
-        assert EXPIRY_DEFAULTS["pattern_observation"] == timedelta(hours=24)
+        assert EXPIRY_DEFAULTS["pattern_observation"] == timedelta(hours=48)
 
     def test_stale_work_nudge(self):
         assert EXPIRY_DEFAULTS["stale_work_nudge"] == timedelta(hours=24)
@@ -193,11 +204,12 @@ class TestCalculateExpiresAt:
 
     def test_habit_nudge_exact_calculation(self):
         result = calculate_expires_at("habit_nudge", self.DELIVERED_AT)
-        assert result == datetime(2026, 4, 15, 12, 0, tzinfo=UTC)
+        assert result == datetime(2026, 4, 15, 14, 0, tzinfo=UTC)
 
     def test_time_block_reminder_exact_calculation(self):
+        # No block_duration supplied → 30m default.
         result = calculate_expires_at("time_block_reminder", self.DELIVERED_AT)
-        assert result == datetime(2026, 4, 15, 11, 0, tzinfo=UTC)
+        assert result == datetime(2026, 4, 15, 10, 30, tzinfo=UTC)
 
     def test_override_in_past_still_preserved(self):
         """Even a past override is preserved — the caller decides validity."""
@@ -206,6 +218,119 @@ class TestCalculateExpiresAt:
             "habit_nudge", self.DELIVERED_AT, existing_expires_at=past,
         )
         assert result == past
+
+
+# ===========================================================================
+# Unit tests — time_block_reminder block_duration floor
+# ===========================================================================
+
+
+class TestTimeBlockFloor:
+    """time_block_reminder is floored by block_duration when supplied."""
+
+    DELIVERED_AT = datetime(2026, 4, 15, 10, 0, tzinfo=UTC)
+
+    def test_block_duration_under_floor_wins(self):
+        """block_duration < 30m → expiry is delivered_at + block_duration."""
+        result = calculate_expires_at(
+            "time_block_reminder",
+            self.DELIVERED_AT,
+            block_duration=timedelta(minutes=10),
+        )
+        assert result == self.DELIVERED_AT + timedelta(minutes=10)
+
+    def test_block_duration_over_floor_uses_floor(self):
+        """block_duration > 30m → expiry is delivered_at + 30m."""
+        result = calculate_expires_at(
+            "time_block_reminder",
+            self.DELIVERED_AT,
+            block_duration=timedelta(hours=2),
+        )
+        assert result == self.DELIVERED_AT + timedelta(minutes=30)
+
+    def test_block_duration_equal_floor(self):
+        """block_duration == 30m → expiry is delivered_at + 30m."""
+        result = calculate_expires_at(
+            "time_block_reminder",
+            self.DELIVERED_AT,
+            block_duration=timedelta(minutes=30),
+        )
+        assert result == self.DELIVERED_AT + timedelta(minutes=30)
+
+    def test_no_block_duration_uses_default(self):
+        """block_duration omitted → expiry is delivered_at + 30m."""
+        result = calculate_expires_at("time_block_reminder", self.DELIVERED_AT)
+        assert result == self.DELIVERED_AT + timedelta(minutes=30)
+
+    def test_block_duration_ignored_for_other_types(self):
+        """block_duration only floors time_block_reminder; other types ignore it."""
+        result = calculate_expires_at(
+            "habit_nudge",
+            self.DELIVERED_AT,
+            block_duration=timedelta(minutes=10),
+        )
+        assert result == self.DELIVERED_AT + timedelta(hours=4)
+
+
+# ===========================================================================
+# Unit tests — routine_checklist EOD-local
+# ===========================================================================
+
+
+class TestRoutineChecklistEOD:
+    """routine_checklist resolves to midnight at start of next day in SERVER_TZ."""
+
+    SCHEDULED_DATE = date(2026, 4, 20)
+
+    def test_eod_local_late_evening(self):
+        """Spec example (adapted to SERVER_TZ=America/Chicago): scheduled
+        2026-04-20, delivered 22:15 local → expires 2026-04-21T00:00 local.
+        Confirms expiry does NOT cross into the next day via delivered_at + 4h.
+        """
+        tz = ZoneInfo("America/Chicago")
+        # Pre-condition for the test's intent: SERVER_TZ is Chicago.
+        assert settings.SERVER_TZ == "America/Chicago"
+
+        delivered_at = datetime(2026, 4, 20, 22, 15, tzinfo=tz)
+        result = calculate_expires_at(
+            "routine_checklist",
+            delivered_at,
+            scheduled_date=self.SCHEDULED_DATE,
+        )
+        expected = datetime(2026, 4, 21, 0, 0, tzinfo=tz)
+        assert result == expected
+        # Sanity: NOT the old delivered_at + 4h behavior (which would be
+        # 2026-04-21T02:15 local — well past midnight).
+        assert result != delivered_at + timedelta(hours=4)
+
+    def test_eod_local_early_morning(self):
+        """Delivered early on scheduled day → expires at next day's midnight."""
+        tz = ZoneInfo("America/Chicago")
+        delivered_at = datetime(2026, 4, 20, 6, 0, tzinfo=tz)
+        result = calculate_expires_at(
+            "routine_checklist",
+            delivered_at,
+            scheduled_date=self.SCHEDULED_DATE,
+        )
+        assert result == datetime(2026, 4, 21, 0, 0, tzinfo=tz)
+
+    def test_eod_local_uses_server_tz_setting(self, monkeypatch):
+        """The boundary is computed in settings.SERVER_TZ, not UTC."""
+        monkeypatch.setattr(settings, "SERVER_TZ", "America/New_York")
+        tz = ZoneInfo("America/New_York")
+        delivered_at = datetime(2026, 4, 20, 22, 15, tzinfo=tz)
+        result = calculate_expires_at(
+            "routine_checklist",
+            delivered_at,
+            scheduled_date=self.SCHEDULED_DATE,
+        )
+        assert result == datetime(2026, 4, 21, 0, 0, tzinfo=tz)
+
+    def test_falls_back_to_default_when_scheduled_date_missing(self):
+        """Without scheduled_date, falls back to delivered_at + 4h default."""
+        delivered_at = datetime(2026, 4, 20, 22, 15, tzinfo=UTC)
+        result = calculate_expires_at("routine_checklist", delivered_at)
+        assert result == delivered_at + timedelta(hours=4)
 
 
 # ===========================================================================
@@ -411,13 +536,13 @@ class TestDeliveryExpiryIntegration:
         expires = datetime.fromisoformat(delivered["expires_at"]).replace(tzinfo=UTC)
         assert expires == datetime(2026, 4, 16, 23, 59, tzinfo=UTC)
 
-    def test_habit_nudge_expires_approx_2h(self, client):
+    def test_habit_nudge_expires_approx_4h(self, client):
         notif = make_notification(client, notification_type="habit_nudge")
         before = datetime.now(tz=UTC)
         delivered = deliver(client, notif["id"])
         expires = datetime.fromisoformat(delivered["expires_at"]).replace(tzinfo=UTC)
         delta = expires - before
-        assert timedelta(hours=1, minutes=59) < delta < timedelta(hours=2, seconds=5)
+        assert timedelta(hours=3, minutes=59) < delta < timedelta(hours=4, seconds=5)
 
     def test_expires_at_not_set_on_patch_without_delivery(self, client):
         """PATCH that doesn't transition to delivered doesn't touch expires_at."""


### PR DESCRIPTION
## Summary

Realigns the seven `EXPIRY_DEFAULTS` to the v0.9 §Q4 authoritative table, introduces a `block_duration` floor for `time_block_reminder` (`min(30m, block_duration)`), and switches `routine_checklist` from a flat `+4h` to EOD-local — midnight at the start of the day after the notification's `scheduled_date`, computed in a new `SERVER_TZ` config setting. The PATCH-to-delivered handler now threads `scheduled_date` into `calculate_expires_at` so the EOD path is exercised in production.

`SERVER_TZ` is a Pydantic Settings field validated at startup via `zoneinfo.ZoneInfo` — a bad IANA key fails fast rather than silently producing wrong expiries. Added `tzdata` to `requirements.txt` because Windows hosts have no system tzdata and `zoneinfo` falls back to the PyPI package.

Closes #203

## Changes

- `app/config.py` — Added `SERVER_TZ: str` field (env var `BRAIN3_SERVER_TZ`, default `America/Chicago`), `_validate_server_tz` field validator, and `server_tz` property returning the resolved `ZoneInfo`.
- `.env.example` — Documented the new `BRAIN3_SERVER_TZ` env var alongside the existing `BRAIN3_APP_BEARER_TOKEN`.
- `requirements.txt` — Added `tzdata==2026.2` as a runtime dep.
- `app/services/notification_defaults.py` — Updated `EXPIRY_DEFAULTS` to v0.9 §Q4 values; added keyword-only `scheduled_date` and `block_duration` parameters to `calculate_expires_at`; new branches for the time-block floor and routine_checklist EOD-local logic; both fall back gracefully when their respective inputs are missing.
- `app/routers/notification.py` — PATCH-to-delivered handler now passes `scheduled_date=notification.scheduled_date` so `routine_checklist` hits the EOD path. (`block_duration` is not threaded — see Deviations.)
- `tests/test_notification_expiry.py` — Constants and per-type calculation tests rewritten to assert v0.9 values. New `TestTimeBlockFloor` (5 tests) and `TestRoutineChecklistEOD` (4 tests) classes cover the new branches. `test_habit_nudge_expires_approx_2h` integration test renamed/rebanded to `_approx_4h`.

## How to Verify

1. `git checkout feat/2C-04-expiry-defaults && pip install -r requirements-dev.txt`
2. `pytest -v tests/test_notification_expiry.py` — 58 tests pass; the `TestTimeBlockFloor` and `TestRoutineChecklistEOD` classes are the new behavior.
3. `pytest -v` — full suite (1371 tests) passes.
4. `ruff check .` — clean.
5. Manual sanity: `python -c \"from app.config import settings; print(settings.SERVER_TZ, settings.server_tz)\"` → `America/Chicago zoneinfo.ZoneInfo(key='America/Chicago')`.
6. Negative sanity: `BRAIN3_SERVER_TZ=Bogus/Zone python -c \"from app.config import settings\"` raises `ValueError: SERVER_TZ 'Bogus/Zone' is not a valid IANA zoneinfo key` at startup.

## Deviations

- **`SERVER_TZ` default is `America/Chicago`, not `America/New_York` as the issue body suggested.** L confirmed during the ticket's open question: BRAIN is self-hosted single-user out of Springfield MO, which is Central. The NY suggestion in the issue body was a Stellan oversight. Spec amendment to follow at the next reconciliation pass.
- **EOD-local acceptance-criteria test uses Chicago offset (`-05:00` CDT), not the spec's example `-04:00` Eastern.** Same reason — the test is faithful to the *intent* (delivered 22:15 local on scheduled day → expires next-day 00:00 local in `SERVER_TZ`), adapted to the actual `SERVER_TZ` value. The spec's `-04` example would only make sense if `SERVER_TZ` were Eastern. A separate test `test_eod_local_uses_server_tz_setting` monkeypatches `SERVER_TZ` to `America/New_York` and asserts the same shape, proving the calculation respects the setting.
- **Added `tzdata` to `requirements.txt` (out-of-spec but functionally required).** Windows hosts have no system tzdata. Without `tzdata`, `ZoneInfo('America/Chicago')` raises `ZoneInfoNotFoundError` and `app.config.settings = Settings()` blows up at module load. Pinning `tzdata==2026.2` matches the rest of the file's pinning style and gives deterministic TZ data across dev / CI / container.
- **`block_duration` is not threaded into the PATCH-to-delivered handler.** No `TimeBlock` entity exists in the repo today; there is nothing to look up at delivery time. The parameter is wired into `calculate_expires_at` for the future time-block scheduler — when that scheduler lands, *its* creation path is the natural place to resolve and pass `block_duration`. Current `time_block_reminder` notifications get the 30m default. **This is the second 'first consumer instantiates' instance** flagged in the Group 2 brief (Group 1 PR #35 was the first). L confirmed BRAIN will roll the codification into a brain3 CLAUDE.md v3 amendment at Group 2 close — no action required from this PR beyond the flag.

## Test Results

```
$ pytest -v
============================ 1371 passed in 21.14s ============================

$ ruff check .
All checks passed!
```

Touched-file detail (58/58):

```
$ pytest -v tests/test_notification_expiry.py
============================ 58 passed in 0.58s ===============================
```

The new behavior coverage:
- `TestTimeBlockFloor::test_block_duration_under_floor_wins` — `block_duration=10m` → `+10m`.
- `TestTimeBlockFloor::test_block_duration_over_floor_uses_floor` — `block_duration=2h` → `+30m`.
- `TestTimeBlockFloor::test_block_duration_equal_floor` — `block_duration=30m` → `+30m`.
- `TestTimeBlockFloor::test_no_block_duration_uses_default` — omitted → `+30m`.
- `TestTimeBlockFloor::test_block_duration_ignored_for_other_types` — `habit_nudge` ignores it.
- `TestRoutineChecklistEOD::test_eod_local_late_evening` — scheduled 2026-04-20, delivered 22:15 CDT → 2026-04-21T00:00 CDT (the spec example, adapted to Chicago).
- `TestRoutineChecklistEOD::test_eod_local_early_morning` — same shape, early delivery.
- `TestRoutineChecklistEOD::test_eod_local_uses_server_tz_setting` — monkeypatches `SERVER_TZ` to NY, asserts the calc honors it.
- `TestRoutineChecklistEOD::test_falls_back_to_default_when_scheduled_date_missing` — defensive fallback.

## Acceptance Checklist

- [x] `tests/test_notification_expiry.py` updated to assert v0.9 values.
- [x] New test: `time_block_reminder` with `block_duration=10min` yields expiry of `delivered_at + 10min`, not `delivered_at + 30min`.
- [x] New test: `routine_checklist` scheduled for `2026-04-20` and delivered at `22:15` local expires at `2026-04-21T00:00` local (not `delivered_at + 4h` which would cross into the next day). _Adapted to `SERVER_TZ=America/Chicago` per L._
- [x] All existing expiry tests rewritten — deliberate behavior change.
- [x] `SERVER_TZ` setting accessible via `settings.SERVER_TZ` and consumed by `calculate_expires_at`.