### PR TITLE
[2C-05a] Lightweight delivery promoter (asyncio background task)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to BRAIN 3.0 will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- Lightweight delivery promoter — asyncio background task spawned on app startup that polls `notification_queue` every 30s for `pending` rows whose `scheduled_at` has passed and transitions them to `delivered` (recomputing `expires_at` via `calculate_expires_at`). Cancelled cleanly on shutdown; per-tick exceptions are caught and logged so one bad row cannot kill the poller. Proto-Stream-D scaffolding for the v2.0.0 notification loop (#204)
+
 ## [v1.3.0] — Rules Engine (Phase 2 Stream F)
 
 ### Added

--- a/app/main.py
+++ b/app/main.py
@@ -43,6 +43,7 @@ from app.routers import (
     tags,
     tasks,
 )
+from app.services.delivery_promoter import install_delivery_promoter
 
 app = FastAPI(
     title="BRAIN 3.0",
@@ -61,6 +62,11 @@ app.add_middleware(
 # Bearer auth on /api/app/*. Skipped with a warning when the token is unset
 # (dev convenience) — production must set BRAIN3_APP_BEARER_TOKEN.
 install_app_bearer_auth(app, settings.APP_BEARER_TOKEN)
+
+# Delivery promoter ([2C-05a]) — asyncio task that polls notification_queue
+# and transitions due rows from pending → delivered. Stream D will expand
+# this into full scheduler infrastructure.
+install_delivery_promoter(app)
 
 
 @app.get("/health")

--- a/app/services/delivery_promoter.py
+++ b/app/services/delivery_promoter.py
@@ -1,0 +1,148 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Lightweight delivery promoter background task ([2C-05a]).
+
+Polls ``notification_queue`` every ``DELIVERY_POLLER_INTERVAL_SECONDS`` for
+rows in ``status='pending'`` whose ``scheduled_at`` is in the past, and
+transitions each such row to ``status='delivered'``. ``expires_at`` is
+recomputed at the transition via ``calculate_expires_at``, mirroring the
+side-effect on the PATCH ``status='delivered'`` path.
+
+This is the proto-Stream-D scaffolding shipped under [2C-05a]: the smallest
+asyncio task that satisfies the v2.0.0 notification loop. Stream D, when it
+runs, expands this module into full scheduler infrastructure (advance batch
+scheduling, time-block triggers, drift-tolerant execution).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import Callable
+
+from fastapi import FastAPI
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.models import NotificationQueue
+from app.services.notification_defaults import calculate_expires_at
+
+logger = logging.getLogger(__name__)
+
+# 30s is the Pass 2 recommended default — worst-case 30s delivery latency at
+# Phase 2 single-user scale. Module-level so tests can monkey-patch it.
+DELIVERY_POLLER_INTERVAL_SECONDS: float = 30.0
+
+SessionFactory = Callable[[], Session]
+
+_promoter_task: asyncio.Task[None] | None = None
+
+
+def promote_due_notifications(db: Session) -> int:
+    """Promote all pending notifications whose ``scheduled_at`` is in the past.
+
+    Transitions each eligible row to ``delivered`` and recomputes
+    ``expires_at`` via ``calculate_expires_at``. The expires_at logic
+    matches the PATCH handler's ``status='delivered'`` side-effect — kept
+    inline rather than extracted into a shared helper because [2C-05] FCM
+    dispatch is the natural moment to refactor this seam (see PR body).
+
+    Returns the number of rows promoted.
+    """
+    now = datetime.now(tz=UTC)
+    due = (
+        db.query(NotificationQueue)
+        .filter(
+            NotificationQueue.status == "pending",
+            NotificationQueue.scheduled_at <= now,
+        )
+        .all()
+    )
+    for row in due:
+        row.status = "delivered"
+        row.expires_at = calculate_expires_at(
+            row.notification_type,
+            now,
+            row.expires_at,
+            scheduled_date=row.scheduled_date,
+        )
+    if due:
+        db.commit()
+    return len(due)
+
+
+def _tick(session_factory: SessionFactory = SessionLocal) -> None:
+    """One promoter tick. Catches and logs any exception so the loop survives.
+
+    The exception swallow is deliberate — one bad row (or a transient DB
+    blip) must not kill the poller. Hardening (retry, backoff, dead-letter)
+    is a Stream D concern, explicitly out of scope here.
+    """
+    db: Session | None = None
+    try:
+        db = session_factory()
+        count = promote_due_notifications(db)
+        logger.info("delivery promoter: promoted %d notification(s)", count)
+    except Exception as exc:  # noqa: BLE001 — see docstring
+        logger.warning("delivery promoter: tick failed: %s", exc)
+    finally:
+        if db is not None:
+            db.close()
+
+
+async def _run_poller(session_factory: SessionFactory = SessionLocal) -> None:
+    """Run the promoter loop until cancelled.
+
+    Cancellation propagates from ``asyncio.sleep``; ``_tick`` is a quick
+    sync call between sleeps, so a clean cancel-on-shutdown is reliable.
+    """
+    while True:
+        _tick(session_factory)
+        await asyncio.sleep(DELIVERY_POLLER_INTERVAL_SECONDS)
+
+
+def install_delivery_promoter(
+    app: FastAPI, session_factory: SessionFactory = SessionLocal,
+) -> None:
+    """Register startup/shutdown hooks that run the delivery promoter.
+
+    ``session_factory`` is injectable for tests; production wiring uses the
+    default ``SessionLocal``.
+    """
+
+    @app.on_event("startup")
+    async def _start_promoter() -> None:
+        global _promoter_task
+        _promoter_task = asyncio.create_task(_run_poller(session_factory))
+        logger.info(
+            "delivery promoter started (interval=%ss)",
+            DELIVERY_POLLER_INTERVAL_SECONDS,
+        )
+
+    @app.on_event("shutdown")
+    async def _stop_promoter() -> None:
+        global _promoter_task
+        if _promoter_task is None:
+            return
+        _promoter_task.cancel()
+        try:
+            await _promoter_task
+        except asyncio.CancelledError:
+            pass
+        _promoter_task = None
+        logger.info("delivery promoter stopped")

--- a/tests/test_delivery_promoter.py
+++ b/tests/test_delivery_promoter.py
@@ -1,0 +1,298 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for the [2C-05a] lightweight delivery promoter."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.models import NotificationQueue
+from app.services import delivery_promoter
+from app.services.delivery_promoter import (
+    _run_poller,
+    _tick,
+    install_delivery_promoter,
+    promote_due_notifications,
+)
+from tests.conftest import TestingSessionLocal
+
+
+def _make_pending(
+    db,
+    *,
+    scheduled_at: datetime,
+    notification_type: str = "habit_nudge",
+) -> NotificationQueue:
+    """Insert a notification_queue row directly via the ORM and return it."""
+    row = NotificationQueue(
+        notification_type=notification_type,
+        delivery_type="notification",
+        status="pending",
+        scheduled_at=scheduled_at,
+        scheduled_date=scheduled_at.date(),
+        target_entity_type="habit",
+        target_entity_id=uuid.uuid4(),
+        message="Time to stretch!",
+        scheduled_by="system",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# promote_due_notifications — happy paths and skips
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteDueNotifications:
+    """Direct tests of the per-tick promotion function."""
+
+    def test_promotes_past_pending(self, db):
+        """A pending row with past scheduled_at is promoted to delivered."""
+        past = datetime.now(tz=UTC) - timedelta(minutes=5)
+        row = _make_pending(db, scheduled_at=past)
+
+        promoted = promote_due_notifications(db)
+
+        assert promoted == 1
+        db.refresh(row)
+        assert row.status == "delivered"
+
+    def test_sets_expires_at_at_promotion(self, db):
+        """expires_at is computed via calculate_expires_at on transition.
+
+        For habit_nudge with no override, the default window is 4h —
+        assert expires_at lands within a reasonable bound of now+4h.
+        """
+        past = datetime.now(tz=UTC) - timedelta(minutes=5)
+        row = _make_pending(db, scheduled_at=past, notification_type="habit_nudge")
+        assert row.expires_at is None
+
+        promote_due_notifications(db)
+
+        db.refresh(row)
+        assert row.expires_at is not None
+        # SQLite strips tz info on roundtrip even with DateTime(timezone=True);
+        # normalize to UTC-aware before comparison.
+        expires_at = row.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        delta = expires_at - datetime.now(tz=UTC)
+        # Allow a generous bound — the test should not be flaky on slow runs.
+        assert timedelta(hours=3, minutes=55) < delta < timedelta(hours=4, minutes=5)
+
+    def test_skips_future_pending(self, db):
+        """A pending row with future scheduled_at is NOT promoted."""
+        future = datetime.now(tz=UTC) + timedelta(hours=1)
+        row = _make_pending(db, scheduled_at=future)
+
+        promoted = promote_due_notifications(db)
+
+        assert promoted == 0
+        db.refresh(row)
+        assert row.status == "pending"
+        assert row.expires_at is None
+
+    def test_skips_already_delivered(self, db):
+        """A row already in 'delivered' is not touched by the promoter."""
+        past = datetime.now(tz=UTC) - timedelta(minutes=5)
+        row = _make_pending(db, scheduled_at=past)
+        row.status = "delivered"
+        existing_expires = datetime.now(tz=UTC) + timedelta(hours=2)
+        row.expires_at = existing_expires
+        db.commit()
+        db.refresh(row)
+
+        promoted = promote_due_notifications(db)
+
+        assert promoted == 0
+        db.refresh(row)
+        assert row.status == "delivered"
+        # expires_at must not be re-computed on a row the promoter ignored.
+        # SQLite strips tz info on roundtrip — compare timestamp values only.
+        assert row.expires_at.replace(tzinfo=None) == existing_expires.replace(
+            tzinfo=None,
+        )
+
+    def test_promotes_only_due_rows_in_mixed_set(self, db):
+        """With a mix of past, future, delivered rows, only past+pending promote."""
+        past = datetime.now(tz=UTC) - timedelta(minutes=5)
+        future = datetime.now(tz=UTC) + timedelta(hours=1)
+        due = _make_pending(db, scheduled_at=past)
+        not_due = _make_pending(db, scheduled_at=future)
+        already = _make_pending(db, scheduled_at=past)
+        already.status = "delivered"
+        db.commit()
+
+        promoted = promote_due_notifications(db)
+
+        assert promoted == 1
+        db.refresh(due)
+        db.refresh(not_due)
+        db.refresh(already)
+        assert due.status == "delivered"
+        assert not_due.status == "pending"
+        assert already.status == "delivered"
+
+
+# ---------------------------------------------------------------------------
+# _tick — exception handling
+# ---------------------------------------------------------------------------
+
+
+class TestTickExceptionHandling:
+    """The poller must survive a tick that raises."""
+
+    def test_tick_swallows_db_exception_and_logs_warning(self, caplog):
+        """A session_factory that raises is caught — the poller does not bubble."""
+
+        def boom_factory():
+            raise RuntimeError("database is on fire")
+
+        # _tick's finally calls db.close(); since boom_factory raises before
+        # returning, there is no db to close — the bare except in _tick
+        # catches the factory error too.
+        with caplog.at_level(logging.WARNING, logger=delivery_promoter.logger.name):
+            _tick(session_factory=boom_factory)
+
+        assert any(
+            "tick failed" in rec.message and "database is on fire" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_tick_continues_after_query_exception(self, caplog, monkeypatch):
+        """When the query raises mid-tick, the exception is caught and logged."""
+
+        class ExplodingSession:
+            def query(self, *_args, **_kwargs):
+                raise RuntimeError("query exploded")
+
+            def close(self) -> None:
+                pass
+
+        with caplog.at_level(logging.WARNING, logger=delivery_promoter.logger.name):
+            _tick(session_factory=ExplodingSession)
+
+        assert any("query exploded" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Loop lifecycle — the asyncio task starts and cancels cleanly
+# ---------------------------------------------------------------------------
+
+
+class TestPromoterLifecycle:
+    """End-to-end: start the loop, observe a tick, cancel cleanly.
+
+    Uses ``asyncio.run`` directly — pytest-asyncio is not in the dev deps and
+    adding it for two tests would be a scope expansion not warranted by the
+    spec.
+    """
+
+    def test_loop_promotes_within_one_interval(self, db, monkeypatch):
+        """Insert a due row, run the loop with a tiny interval, observe promotion."""
+        monkeypatch.setattr(
+            delivery_promoter, "DELIVERY_POLLER_INTERVAL_SECONDS", 0.01,
+        )
+        past = datetime.now(tz=UTC) - timedelta(minutes=5)
+        row = _make_pending(db, scheduled_at=past)
+        row_id = row.id
+
+        async def _run():
+            task = asyncio.create_task(
+                _run_poller(session_factory=TestingSessionLocal),
+            )
+            try:
+                # Give the loop time for at least one full tick + sleep cycle.
+                await asyncio.sleep(0.1)
+            finally:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        asyncio.run(_run())
+
+        # Re-query the row in a fresh session to see the committed state.
+        verify_session = TestingSessionLocal()
+        try:
+            updated = (
+                verify_session.query(NotificationQueue)
+                .filter(NotificationQueue.id == row_id)
+                .one()
+            )
+            assert updated.status == "delivered"
+        finally:
+            verify_session.close()
+
+    def test_cancel_terminates_task_without_leak(self, monkeypatch):
+        """Cancelling the loop ends the task cleanly with no pending state."""
+        monkeypatch.setattr(
+            delivery_promoter, "DELIVERY_POLLER_INTERVAL_SECONDS", 0.01,
+        )
+
+        async def _run():
+            task = asyncio.create_task(
+                _run_poller(session_factory=TestingSessionLocal),
+            )
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            return task
+
+        task = asyncio.run(_run())
+        assert task.done()
+
+
+# ---------------------------------------------------------------------------
+# FastAPI integration — startup/shutdown wiring fires without leaking
+# ---------------------------------------------------------------------------
+
+
+class TestFastAPIWiring:
+    """install_delivery_promoter wires startup/shutdown without leaking tasks."""
+
+    def test_startup_and_shutdown_run_clean(self, monkeypatch):
+        """Entering and exiting a TestClient context starts and stops the loop."""
+        monkeypatch.setattr(
+            delivery_promoter, "DELIVERY_POLLER_INTERVAL_SECONDS", 0.01,
+        )
+        # Reset module-level task state so the assertions below are
+        # deterministic regardless of test ordering.
+        monkeypatch.setattr(delivery_promoter, "_promoter_task", None)
+
+        scratch_app = FastAPI()
+        install_delivery_promoter(scratch_app, session_factory=TestingSessionLocal)
+
+        with TestClient(scratch_app):
+            # Inside the context the loop is running.
+            assert delivery_promoter._promoter_task is not None
+
+        # On exit, the shutdown hook cancels the task and clears the handle.
+        assert delivery_promoter._promoter_task is None


### PR DESCRIPTION
## Verification

- `ruff check .` — ✅ Pass (All checks passed!)
- `pytest -v` — ✅ Pass (1381 passed, 8 warnings in 2595.46s)

Ran locally against develop HEAD at `d091b5d` immediately before opening this PR.

## Summary

Adds a lightweight asyncio polling task that promotes due `notification_queue` rows from `pending` to `delivered`, recomputing `expires_at` at the transition. This is the proto-Stream-D scaffolding called out in the spec — the smallest module that satisfies the v2.0.0 notification loop, deliberately single-purpose so Stream D can expand it without rework. Once `[2C-05]` lands the FCM dispatch path on the `delivered` transition, the loop end-to-end is closed.

## Changes

- **`app/services/delivery_promoter.py`** — new module. Exposes `promote_due_notifications(db)` (one tick, returns count promoted), `_tick(session_factory)` (the swallow-and-log wrapper), `_run_poller(session_factory)` (the loop), and `install_delivery_promoter(app, session_factory)` (registers FastAPI startup/shutdown hooks). The 30s polling interval lives at module level (`DELIVERY_POLLER_INTERVAL_SECONDS`) so tests can monkey-patch it.
- **`app/main.py`** — calls `install_delivery_promoter(app)` once after the existing bearer-auth wiring.
- **`tests/test_delivery_promoter.py`** — new test module covering all five spec ACs across four test classes (per-tick promotion logic, exception handling, asyncio loop lifecycle, FastAPI startup/shutdown wiring). Uses `asyncio.run` rather than introducing pytest-asyncio.
- **`CHANGELOG.md`** — Unreleased section added with the `[2C-05a]` line item.

## How to Verify

1. `git checkout feat/2C-05a-delivery-promoter && pip install -r requirements-dev.txt`
2. `ruff check .` → all checks pass
3. `pytest -v tests/test_delivery_promoter.py` → 10 passed
4. `pytest -v` (full suite) → all green, no regressions in the existing notification or rules tests

To watch it work end-to-end against a running app:
1. `uvicorn app.main:app --reload`
2. Insert a `notification_queue` row with `status='pending'` and `scheduled_at` set to a few seconds in the past.
3. Within ~30 seconds, observe the row's `status` flip to `delivered` and `expires_at` populated. The startup log line `delivery promoter started (interval=30.0s)` confirms the task spawned; each tick logs `delivery promoter: promoted N notification(s)` at INFO.

## Deviations

The spec prescribes `app.on_event("startup") via asyncio.create_task(poller())`. I followed that literally. **Heads-up:** FastAPI 0.135 emits a `DeprecationWarning` for `on_event` and recommends the lifespan context-manager pattern; the codebase doesn't use either today, so this is the first instance. Functionally equivalent for our needs and matches the spec letter-for-letter — happy to swap to lifespan in a follow-up if you'd prefer the modern shape going forward.

The spec's first AC mentions verifying that **FCM dispatch (mocked per [2C-05] test infrastructure)** has been invoked. `[2C-05]` hasn't merged yet, so no FCM dispatch path or mock infrastructure exists on `develop`. This PR satisfies the testable half of the AC (the status transition + `expires_at` side-effect) and leaves the FCM-invocation assertion to land alongside `[2C-05]` itself. The forward-looking framing in the spec (`That status change wires into the dispatch path landed in [2C-05]`) is consistent with this read — the promoter's only contract is the status transition; FCM is `[2C-05]`'s contract.

The spec leaves open whether the promoter calls the PATCH handler function or invokes the side-effects inline. **I chose inline** — the per-row work is three lines (`status = "delivered"`, `expires_at = calculate_expires_at(...)`, commit), and `[2C-05]` will need to reshape this seam regardless when FCM dispatch lands. Extracting a shared helper now would be one consumer's worth of indirection on a path about to change. Documented in the module docstring and `promote_due_notifications` docstring.

The repo `CLAUDE.md` is missing on `develop`, while BRAIN canonical (`cf7fc00c` v2) exists. Per org `CLAUDE.md` v5 inheritance section, BRAIN won for the session and I worked from the BRAIN-canonical copy. I'll file a `[2C-Gap]` issue separately to sync the working copy back into the repo (per "log it, don't fix it" — `4ea28266` says agents flag, PO updates).

The prior `[2C-01..04]` PRs didn't update `CHANGELOG.md`. Org `CLAUDE.md` says "update per ticket," so I added an `Unreleased` section here. If the policy has shifted to bulk CHANGELOG updates at release time, happy to drop this line.

## Test Results

```
pytest -v tests/test_delivery_promoter.py
======================= 10 passed, 8 warnings in 0.33s ========================
```

The 8 warnings are the FastAPI `on_event` deprecation noise covered in Deviations.

Full-suite `pytest` results land in this PR's commit chain via the verification block above; no regressions in pre-existing notification/rules/expiry tests.

## Acceptance Checklist

- [x] New module `app/services/delivery_promoter.py` exposing the asyncio background task
- [x] Spawned on `app.on_event("startup")` via `asyncio.create_task`
- [x] Polling interval ~30s, configurable constant (`DELIVERY_POLLER_INTERVAL_SECONDS`)
- [x] Each tick: SELECT pending rows where `scheduled_at <= now()`
- [x] Each eligible row: `pending` → `delivered`
- [x] Cancelled cleanly on `app.on_event("shutdown")`
- [x] No new schema, no new endpoints
- [x] INFO log per tick summarizing count promoted
- [x] WARN log on tick exception, swallowed so the poller continues
- [x] Integration test: past pending row promoted within one polling interval
- [x] Integration test: future pending row NOT touched
- [x] Integration test: already-delivered row NOT touched
- [x] Unit test: tick exception caught + logged + poller continues
- [x] App shutdown terminates the task without leaking

Closes #204
