### PR TITLE
[2C-05] Device registration endpoint, FCM client service, and delivery-time dispatch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,13 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:8000
 # Server time zone (IANA zoneinfo key). Used for TZ-sensitive server-side
 # logic such as EOD-local routine_checklist expiry. Validated at startup.
 # BRAIN3_SERVER_TZ=America/Chicago
+
+# Firebase Cloud Messaging (FCM) — push delivery to the companion app.
+# BRAIN3_FCM_PROJECT_ID is the Firebase project identifier (NOT the project
+# number). BRAIN3_FCM_SERVICE_ACCOUNT_JSON_PATH points at a service-account
+# keyfile with the firebase.messaging scope. In production the keyfile is
+# bind-mounted into the container at /run/secrets/fcm-service-account.json.
+# Leave both unset in dev to skip FCM dispatch (a "not configured" result
+# is returned to the caller; pending → delivered transitions still occur).
+# BRAIN3_FCM_PROJECT_ID=
+# BRAIN3_FCM_SERVICE_ACCOUNT_JSON_PATH=/run/secrets/fcm-service-account.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Lightweight delivery promoter — asyncio background task spawned on app startup that polls `notification_queue` every 30s for `pending` rows whose `scheduled_at` has passed and transitions them to `delivered` (recomputing `expires_at` via `calculate_expires_at`). Cancelled cleanly on shutdown; per-tick exceptions are caught and logged so one bad row cannot kill the poller. Proto-Stream-D scaffolding for the v2.0.0 notification loop (#204)
+- Device registration + FCM dispatch — `app_devices` table with unique `fcm_token`, platform check (`android | ios`), and registration timestamps. New `POST /api/app/devices` (upsert, 200/201), `GET /api/app/devices`, and `DELETE /api/app/devices/{id}` endpoints behind the bearer middleware. New `app/services/fcm.py` (FCM HTTP v1 client with cached `google-auth` service-account credentials and structured `FcmResult` / `FcmStatus` outcomes) and `app/services/delivery.py::dispatch_push` (broadcast data-only payload to every registered device, hard-delete on `UNREGISTERED` / `INVALID_ARGUMENT`). Wired into both the PATCH `pending → delivered` handler and the delivery promoter so background-promoted rows trigger pushes too. New env vars `BRAIN3_FCM_PROJECT_ID` and `BRAIN3_FCM_SERVICE_ACCOUNT_JSON_PATH`; both unset in dev skips dispatch with a `NOT_CONFIGURED` result. Adds `google-auth` to `requirements.txt`. (#205)
 
 ## [v1.3.0] — Rules Engine (Phase 2 Stream F)
 

--- a/alembic/versions/023_create_app_devices.py
+++ b/alembic/versions/023_create_app_devices.py
@@ -1,0 +1,70 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Create app_devices table.
+
+Revision ID: 23a1b2c3d4e5
+Revises: 22a1b2c3d4e5
+Create Date: 2026-04-27
+
+Stores FCM device registrations for the companion app. Phase 2 is
+single-user, so the table has no user_id — every registered device
+receives every push. ``platform`` is constrained to ``android | ios``
+to future-proof the schema for APNs even though v2.0.0 ships
+Android-only.
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "23a1b2c3d4e5"
+down_revision: Union[str, None] = "22a1b2c3d4e5"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "app_devices",
+        sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
+        sa.Column("fcm_token", sa.Text(), nullable=False),
+        sa.Column("platform", sa.String(), nullable=False),
+        sa.Column("label", sa.String(), nullable=True),
+        sa.Column(
+            "registered_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "last_seen_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "platform IN ('android', 'ios')",
+            name="ck_app_devices_platform",
+        ),
+        sa.UniqueConstraint("fcm_token", name="uq_app_devices_fcm_token"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("app_devices")

--- a/app/config.py
+++ b/app/config.py
@@ -50,6 +50,18 @@ class Settings(BaseSettings):
         default="America/Chicago", validation_alias="BRAIN3_SERVER_TZ",
     )
 
+    # Firebase Cloud Messaging (FCM) HTTP v1 — push delivery to the companion
+    # app. Both must be set in production. When either is unset, FCM dispatch
+    # is skipped with a startup warning (dev convenience, mirrors the
+    # APP_BEARER_TOKEN pattern). The service-account JSON path is loaded at
+    # call time, so rotation does not require a restart.
+    FCM_PROJECT_ID: str | None = Field(
+        default=None, validation_alias="BRAIN3_FCM_PROJECT_ID",
+    )
+    FCM_SERVICE_ACCOUNT_JSON_PATH: str | None = Field(
+        default=None, validation_alias="BRAIN3_FCM_SERVICE_ACCOUNT_JSON_PATH",
+    )
+
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", populate_by_name=True,
     )

--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,7 @@ from app.routers import (
     activity,
     artifacts,
     checkins,
+    devices,
     directives,
     domains,
     goals,
@@ -142,4 +143,7 @@ app.include_router(
 )
 app.include_router(
     skills.skill_directives_router, prefix="/api/skills", tags=["Skill Directives"],
+)
+app.include_router(
+    devices.router, prefix="/api/app/devices", tags=["App Devices"],
 )

--- a/app/models.py
+++ b/app/models.py
@@ -1285,3 +1285,43 @@ class Rule(Base):
         Index("ix_rules_entity_lookup", "entity_type", "enabled"),
         Index("ix_rules_entity_scoped", "entity_type", "entity_id"),
     )
+
+
+# ---------------------------------------------------------------------------
+# App Devices — FCM registrations for the companion app
+# ---------------------------------------------------------------------------
+
+
+class AppDevice(Base):
+    """FCM-registered companion-app device.
+
+    Phase 2 is single-user: there is no ``user_id`` and dispatch broadcasts
+    to every registered row. ``platform`` future-proofs for APNs (``ios``)
+    even though v2.0.0 only ships Android.
+    """
+
+    __tablename__ = "app_devices"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+    )
+    fcm_token: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    platform: Mapped[str] = mapped_column(String, nullable=False)
+    label: Mapped[str | None] = mapped_column(String)
+    registered_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )
+    last_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "platform IN ('android', 'ios')",
+            name="ck_app_devices_platform",
+        ),
+    )

--- a/app/routers/devices.py
+++ b/app/routers/devices.py
@@ -1,0 +1,103 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""CRUD endpoints for app device (FCM) registration.
+
+Mounted under ``/api/app/devices`` and therefore gated by the App API
+bearer middleware (see ``app/auth.py``). Phase 2 is single-user, so the
+table has no ``user_id`` — every registered device receives every push.
+"""
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import AppDevice
+from app.schemas.devices import (
+    DeviceListResponse,
+    DeviceRegisterRequest,
+    DeviceResponse,
+)
+
+router = APIRouter()
+
+
+@router.post("", response_model=DeviceResponse)
+def register_device(
+    payload: DeviceRegisterRequest,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> AppDevice:
+    """Register or refresh a device by ``fcm_token``.
+
+    Upsert semantics: a new ``fcm_token`` inserts and returns 201; an
+    existing token updates ``last_seen_at`` (and ``platform`` / ``label``
+    when supplied) and returns 200.
+    """
+    existing = (
+        db.query(AppDevice)
+        .filter(AppDevice.fcm_token == payload.fcm_token)
+        .first()
+    )
+    if existing is not None:
+        existing.platform = payload.platform
+        if payload.label is not None:
+            existing.label = payload.label
+        existing.last_seen_at = datetime.now(tz=UTC)
+        db.commit()
+        db.refresh(existing)
+        response.status_code = status.HTTP_200_OK
+        return existing
+
+    device = AppDevice(
+        fcm_token=payload.fcm_token,
+        platform=payload.platform,
+        label=payload.label,
+    )
+    db.add(device)
+    db.commit()
+    db.refresh(device)
+    response.status_code = status.HTTP_201_CREATED
+    return device
+
+
+@router.get("", response_model=DeviceListResponse)
+def list_devices(db: Session = Depends(get_db)) -> DeviceListResponse:
+    """List all registered devices (debugging / admin)."""
+    rows = (
+        db.query(AppDevice)
+        .order_by(AppDevice.registered_at.desc())
+        .all()
+    )
+    return DeviceListResponse(
+        items=[DeviceResponse.model_validate(r) for r in rows],
+        count=len(rows),
+    )
+
+
+@router.delete("/{device_id}", status_code=status.HTTP_204_NO_CONTENT)
+def unregister_device(
+    device_id: UUID, db: Session = Depends(get_db),
+) -> None:
+    """Unregister a device by id (used on logout / uninstall)."""
+    device = db.query(AppDevice).filter(AppDevice.id == device_id).first()
+    if device is None:
+        raise HTTPException(status_code=404, detail="Device not found")
+    db.delete(device)
+    db.commit()

--- a/app/routers/notification.py
+++ b/app/routers/notification.py
@@ -16,6 +16,7 @@
 
 """CRUD endpoints for the Notification Queue."""
 
+import logging
 from datetime import UTC, date, datetime
 from uuid import UUID
 
@@ -31,7 +32,10 @@ from app.schemas.notifications import (
     NotificationResponse,
     NotificationUpdate,
 )
+from app.services.delivery import dispatch_push
 from app.services.notification_defaults import calculate_expires_at, get_default_responses
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -286,7 +290,8 @@ async def update_notification(
         setattr(notification, field, value)
 
     # Auto-populate expires_at on delivery
-    if updates.get("status") == "delivered":
+    delivered_now = updates.get("status") == "delivered"
+    if delivered_now:
         delivered_at = datetime.now(tz=UTC)
         notification.expires_at = calculate_expires_at(
             notification.notification_type,
@@ -297,6 +302,21 @@ async def update_notification(
 
     db.commit()
     db.refresh(notification)
+
+    # Push to every registered device on the pending → delivered transition.
+    # Synchronous at Phase 2 single-user scale; async/queue is a Chunk 5
+    # concern (see ticket Out of Scope). Failures inside dispatch_push are
+    # logged per-device and never raised here.
+    if delivered_now:
+        try:
+            dispatch_push(notification, db)
+        except Exception as exc:  # noqa: BLE001 — never fail the PATCH on dispatch
+            logger.warning(
+                "FCM dispatch failed for notification %s: %s",
+                notification.id,
+                exc,
+            )
+
     return notification
 
 

--- a/app/schemas/devices.py
+++ b/app/schemas/devices.py
@@ -1,0 +1,55 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Pydantic schemas for App Device registration."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+DevicePlatform = Literal["android", "ios"]
+
+
+class DeviceRegisterRequest(BaseModel):
+    """Body of POST /api/app/devices — register or refresh a device."""
+
+    fcm_token: str = Field(min_length=1, max_length=4096)
+    platform: DevicePlatform
+    label: str | None = Field(default=None, max_length=200)
+
+
+class DeviceResponse(BaseModel):
+    """Device row returned from the API."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    fcm_token: str
+    platform: str
+    label: str | None = None
+    registered_at: datetime
+    last_seen_at: datetime
+
+
+class DeviceListResponse(BaseModel):
+    """Envelope for GET /api/app/devices."""
+
+    items: list[DeviceResponse]
+    count: int

--- a/app/services/delivery.py
+++ b/app/services/delivery.py
@@ -1,0 +1,123 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""FCM dispatch on the ``pending → delivered`` notification transition.
+
+Single entry-point — :func:`dispatch_push` — invoked from the PATCH
+handler (interactive transition) and the delivery promoter (background
+transition). Builds a data-only FCM payload so the companion app's
+native layer renders the actionable notification itself, and broadcasts
+to every row in ``app_devices`` (Phase 2 single-user scale).
+
+Tokens that come back ``UNREGISTERED`` / ``INVALID_ARGUMENT`` are
+hard-deleted from ``app_devices`` so a stale device does not keep
+generating dispatch attempts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from sqlalchemy.orm import Session
+
+from app.models import AppDevice, NotificationQueue
+from app.services import fcm
+
+logger = logging.getLogger(__name__)
+
+
+def build_fcm_payload(notification: NotificationQueue) -> dict:
+    """Assemble the data-only FCM v1 payload for ``notification``.
+
+    All values are coerced to strings: FCM v1's ``data`` map is
+    ``map<string, string>``, and the companion app's native layer
+    expects to receive primitives ready for direct use. ``rule_id`` is
+    emitted as an empty string when null so the payload shape is stable.
+    """
+    canned_responses = notification.canned_responses or []
+    return {
+        "data": {
+            "notification_id": str(notification.id),
+            "notification_type": notification.notification_type,
+            "message": notification.message,
+            "canned_responses": json.dumps(canned_responses),
+            "scheduled_date": notification.scheduled_date.isoformat(),
+            "rule_id": str(notification.rule_id) if notification.rule_id else "",
+        },
+        "android": {"priority": "HIGH"},
+    }
+
+
+def dispatch_push(notification: NotificationQueue, db: Session) -> int:
+    """Broadcast ``notification`` to every registered device.
+
+    Returns the number of devices the send loop reached SENT on. Tokens
+    that come back invalidated are hard-deleted from ``app_devices``
+    (per Pass 2 §5: hard-delete chosen for simplicity at Phase 2 scale).
+
+    Failures on one device never block the others — each FCM call's
+    result is handled independently. A failure of the whole loop (e.g.
+    DB error mid-loop) is allowed to propagate to the caller, which in
+    the promoter case is wrapped in the existing tick-level exception
+    swallow.
+    """
+    devices = db.query(AppDevice).all()
+    if not devices:
+        logger.info(
+            "dispatch_push: no registered devices; skipping notification %s",
+            notification.id,
+        )
+        return 0
+
+    payload = build_fcm_payload(notification)
+    sent = 0
+    invalidated_ids: list = []
+    for device in devices:
+        try:
+            result = fcm.send_notification_to_device(device.fcm_token, payload)
+        except Exception as exc:  # noqa: BLE001 — see docstring
+            logger.warning(
+                "dispatch_push: send to device %s raised %s; continuing",
+                device.id,
+                exc,
+            )
+            continue
+        if result.status == fcm.FcmStatus.SENT:
+            sent += 1
+            continue
+        if result.token_invalidated:
+            invalidated_ids.append(device.id)
+            logger.info(
+                "dispatch_push: removing invalidated device %s (%s)",
+                device.id,
+                result.error_code or result.status.value,
+            )
+            continue
+        logger.warning(
+            "dispatch_push: send to device %s failed with %s (%s)",
+            device.id,
+            result.status.value,
+            result.detail,
+        )
+
+    if invalidated_ids:
+        db.query(AppDevice).filter(AppDevice.id.in_(invalidated_ids)).delete(
+            synchronize_session=False,
+        )
+        db.commit()
+
+    return sent

--- a/app/services/delivery_promoter.py
+++ b/app/services/delivery_promoter.py
@@ -40,6 +40,7 @@ from sqlalchemy.orm import Session
 
 from app.database import SessionLocal
 from app.models import NotificationQueue
+from app.services.delivery import dispatch_push
 from app.services.notification_defaults import calculate_expires_at
 
 logger = logging.getLogger(__name__)
@@ -56,13 +57,18 @@ _promoter_task: asyncio.Task[None] | None = None
 def promote_due_notifications(db: Session) -> int:
     """Promote all pending notifications whose ``scheduled_at`` is in the past.
 
-    Transitions each eligible row to ``delivered`` and recomputes
-    ``expires_at`` via ``calculate_expires_at``. The expires_at logic
-    matches the PATCH handler's ``status='delivered'`` side-effect — kept
-    inline rather than extracted into a shared helper because [2C-05] FCM
-    dispatch is the natural moment to refactor this seam (see PR body).
+    Transitions each eligible row to ``delivered``, recomputes
+    ``expires_at`` via ``calculate_expires_at``, and dispatches the push
+    via :func:`app.services.delivery.dispatch_push` — the same side-
+    effect the PATCH handler triggers on the interactive ``pending →
+    delivered`` transition. Per [2C-05] AC #1 (carry-forward from
+    [2C-05a] PR #212 deviation D-18), the promoter must invoke FCM
+    dispatch when it performs the transition.
 
-    Returns the number of rows promoted.
+    Per-row dispatch errors are caught and logged; one bad device or
+    network blip must not stop the rest of the batch. Returns the
+    number of rows promoted (independent of how many devices the push
+    actually reached).
     """
     now = datetime.now(tz=UTC)
     due = (
@@ -83,6 +89,15 @@ def promote_due_notifications(db: Session) -> int:
         )
     if due:
         db.commit()
+    for row in due:
+        try:
+            dispatch_push(row, db)
+        except Exception as exc:  # noqa: BLE001 — see docstring
+            logger.warning(
+                "delivery promoter: dispatch_push failed for %s: %s",
+                row.id,
+                exc,
+            )
     return len(due)
 
 

--- a/app/services/fcm.py
+++ b/app/services/fcm.py
@@ -1,0 +1,237 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Firebase Cloud Messaging (FCM) HTTP v1 client.
+
+Sends push notifications to a single FCM-registered device. Targets the
+HTTP v1 endpoint (``https://fcm.googleapis.com/v1/projects/{project_id}/
+messages:send``) — the legacy ``fcm.googleapis.com/fcm/send`` API was
+deprecated in June 2024 and is not used here.
+
+Authenticates via a Google service-account JSON keyfile loaded from
+``settings.FCM_SERVICE_ACCOUNT_JSON_PATH``. Access tokens are cached on
+the credentials object and refreshed by ``google-auth`` on demand
+(roughly hourly), so callers do not need to manage token lifetime.
+
+The single public function — ``send_notification_to_device`` — returns an
+:class:`FcmResult` with a stable ``status`` enum so the caller can react
+to ``UNREGISTERED`` / ``INVALID_ARGUMENT`` (token cleanup) without
+parsing FCM's error envelopes itself.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+FCM_ENDPOINT_TEMPLATE = (
+    "https://fcm.googleapis.com/v1/projects/{project_id}/messages:send"
+)
+FCM_OAUTH_SCOPE = "https://www.googleapis.com/auth/firebase.messaging"
+
+# Module-level credentials cache. Populated on first call; reused across
+# subsequent calls so the OAuth2 access token lifetime (≈55 min) is
+# amortised. Reset by tests via the ``reset_credentials_cache`` helper.
+_credentials: Any = None
+
+
+class FcmStatus(str, Enum):
+    """Outcome categories for an FCM send attempt.
+
+    The ``UNREGISTERED`` / ``INVALID_ARGUMENT`` variants are the signal
+    callers use to drop a token from ``app_devices``; everything else is
+    transient.
+    """
+
+    SENT = "sent"
+    UNREGISTERED = "unregistered"
+    INVALID_ARGUMENT = "invalid_argument"
+    AUTH_FAILED = "auth_failed"
+    RATE_LIMITED = "rate_limited"
+    SERVER_ERROR = "server_error"
+    NOT_CONFIGURED = "not_configured"
+    NETWORK_ERROR = "network_error"
+
+
+@dataclass(frozen=True)
+class FcmResult:
+    """Structured outcome returned from :func:`send_notification_to_device`."""
+
+    status: FcmStatus
+    http_status: int | None = None
+    error_code: str | None = None
+    detail: str | None = None
+
+    @property
+    def token_invalidated(self) -> bool:
+        """True iff the device token should be removed from ``app_devices``."""
+        return self.status in {FcmStatus.UNREGISTERED, FcmStatus.INVALID_ARGUMENT}
+
+
+def is_configured() -> bool:
+    """Return True iff both FCM project id and service-account path are set."""
+    return bool(
+        settings.FCM_PROJECT_ID and settings.FCM_SERVICE_ACCOUNT_JSON_PATH,
+    )
+
+
+def reset_credentials_cache() -> None:
+    """Drop the cached credentials object. Used by tests."""
+    global _credentials
+    _credentials = None
+
+
+def _load_credentials() -> Any:
+    """Lazily import google-auth and load the service-account credentials.
+
+    Imported lazily so the dependency is only required when FCM is
+    actually configured — tests that mock the send path do not need
+    google-auth installed for module import to succeed.
+    """
+    from google.auth.transport.requests import Request as AuthRequest
+    from google.oauth2 import service_account
+
+    global _credentials
+    if _credentials is None:
+        _credentials = service_account.Credentials.from_service_account_file(
+            settings.FCM_SERVICE_ACCOUNT_JSON_PATH,
+            scopes=[FCM_OAUTH_SCOPE],
+        )
+    if not _credentials.valid:
+        _credentials.refresh(AuthRequest())
+    return _credentials
+
+
+def _classify_error(http_status: int, body: dict[str, Any]) -> FcmResult:
+    """Map an FCM error response onto an :class:`FcmResult`.
+
+    FCM HTTP v1 returns errors in the shape::
+
+        {"error": {"code": <int>, "status": "<STRING>", "message": "...",
+                   "details": [{"errorCode": "UNREGISTERED", ...}]}}
+
+    The fine-grained ``errorCode`` (in ``details``) is what tells us the
+    token is dead; ``status`` alone is too coarse.
+    """
+    err = body.get("error", {}) if isinstance(body, dict) else {}
+    fcm_error_code: str | None = None
+    for detail in err.get("details", []) or []:
+        if isinstance(detail, dict) and detail.get("errorCode"):
+            fcm_error_code = detail["errorCode"]
+            break
+
+    detail_msg = err.get("message")
+
+    if fcm_error_code == "UNREGISTERED" or http_status == 404:
+        return FcmResult(
+            status=FcmStatus.UNREGISTERED,
+            http_status=http_status,
+            error_code=fcm_error_code,
+            detail=detail_msg,
+        )
+    if fcm_error_code == "INVALID_ARGUMENT" or http_status == 400:
+        return FcmResult(
+            status=FcmStatus.INVALID_ARGUMENT,
+            http_status=http_status,
+            error_code=fcm_error_code,
+            detail=detail_msg,
+        )
+    if http_status in (401, 403):
+        return FcmResult(
+            status=FcmStatus.AUTH_FAILED,
+            http_status=http_status,
+            error_code=fcm_error_code,
+            detail=detail_msg,
+        )
+    if http_status == 429:
+        return FcmResult(
+            status=FcmStatus.RATE_LIMITED,
+            http_status=http_status,
+            error_code=fcm_error_code,
+            detail=detail_msg,
+        )
+    return FcmResult(
+        status=FcmStatus.SERVER_ERROR,
+        http_status=http_status,
+        error_code=fcm_error_code,
+        detail=detail_msg,
+    )
+
+
+def send_notification_to_device(
+    fcm_token: str, payload: dict[str, Any],
+) -> FcmResult:
+    """Send a single FCM message to ``fcm_token``.
+
+    ``payload`` is the FCM v1 ``message`` body *without* the ``token``
+    field — this function fills that in. Callers build a data-only
+    payload (no ``notification`` field) so the companion app's native
+    layer can render its own ``NotificationCompat`` with full action
+    fidelity (see [2C-06]).
+
+    Returns an :class:`FcmResult` describing the outcome. This function
+    does not raise on FCM errors — error categorisation is the caller's
+    contract via ``result.status``.
+    """
+    if not is_configured():
+        return FcmResult(
+            status=FcmStatus.NOT_CONFIGURED,
+            detail=(
+                "FCM_PROJECT_ID or FCM_SERVICE_ACCOUNT_JSON_PATH unset; "
+                "skipping send"
+            ),
+        )
+
+    try:
+        creds = _load_credentials()
+    except Exception as exc:  # noqa: BLE001 — surface credential failures uniformly
+        logger.warning("FCM credential load failed: %s", exc)
+        return FcmResult(status=FcmStatus.AUTH_FAILED, detail=str(exc))
+
+    body = {"message": {"token": fcm_token, **payload}}
+    url = FCM_ENDPOINT_TEMPLATE.format(project_id=settings.FCM_PROJECT_ID)
+    encoded = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(  # noqa: S310 — fixed https FCM endpoint
+        url,
+        data=encoded,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {creds.token}",
+            "Content-Type": "application/json; charset=UTF-8",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+            return FcmResult(status=FcmStatus.SENT, http_status=resp.status)
+    except urllib.error.HTTPError as exc:
+        try:
+            error_body = json.loads(exc.read().decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            error_body = {}
+        return _classify_error(exc.code, error_body)
+    except urllib.error.URLError as exc:
+        logger.warning("FCM network error: %s", exc.reason)
+        return FcmResult(status=FcmStatus.NETWORK_ERROR, detail=str(exc.reason))

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pydantic-settings==2.13.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 tzdata==2026.2
+google-auth==2.36.0

--- a/tests/test_delivery_dispatch.py
+++ b/tests/test_delivery_dispatch.py
@@ -1,0 +1,382 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for [2C-05] FCM dispatch wiring.
+
+Exercises the ``pending → delivered`` side-effect on both the
+interactive PATCH path and the delivery promoter path. The FCM client
+itself is mocked — no live network hits in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models import AppDevice, NotificationQueue
+from app.services import delivery, delivery_promoter, fcm
+from app.services.delivery import build_fcm_payload, dispatch_push
+from app.services.fcm import FcmResult, FcmStatus
+
+
+@dataclass
+class _RecordedCall:
+    """Captured arguments from a mocked ``send_notification_to_device`` call."""
+
+    fcm_token: str
+    payload: dict
+
+
+class _FcmRecorder:
+    """List-like recorder of FCM send calls plus a queue of canned results.
+
+    Tests append :class:`FcmResult` instances to ``next_results`` to control
+    the response of subsequent ``send_notification_to_device`` calls. With an
+    empty queue, each call returns SENT.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[_RecordedCall] = []
+        self.next_results: list[FcmResult] = []
+
+    def __iter__(self):
+        return iter(self.calls)
+
+    def __len__(self) -> int:
+        return len(self.calls)
+
+    def __getitem__(self, idx: int) -> _RecordedCall:
+        return self.calls[idx]
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, list):
+            return self.calls == other
+        return NotImplemented
+
+
+@pytest.fixture
+def mock_fcm_client(monkeypatch):
+    """Replace the FCM client with a recorder and return it.
+
+    Default behaviour: every call returns SENT. Tests that need an error
+    can append a result to ``mock_fcm_client.next_results``.
+    """
+    recorder = _FcmRecorder()
+
+    def _send(fcm_token: str, payload: dict) -> FcmResult:
+        recorder.calls.append(_RecordedCall(fcm_token=fcm_token, payload=payload))
+        if recorder.next_results:
+            return recorder.next_results.pop(0)
+        return FcmResult(status=FcmStatus.SENT, http_status=200)
+
+    monkeypatch.setattr(fcm, "send_notification_to_device", _send)
+    monkeypatch.setattr(
+        delivery.fcm, "send_notification_to_device", _send,
+    )
+
+    return recorder
+
+
+def _make_pending_notification(
+    db,
+    *,
+    notification_type: str = "habit_nudge",
+    canned_responses: list[str] | None = None,
+    rule_id: uuid.UUID | None = None,
+) -> NotificationQueue:
+    scheduled_at = datetime.now(tz=UTC) - timedelta(minutes=5)
+    row = NotificationQueue(
+        notification_type=notification_type,
+        delivery_type="notification",
+        status="pending",
+        scheduled_at=scheduled_at,
+        scheduled_date=scheduled_at.date(),
+        target_entity_type="habit",
+        target_entity_id=uuid.uuid4(),
+        message="Time to stretch!",
+        canned_responses=canned_responses,
+        scheduled_by="system",
+        rule_id=rule_id,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _register_device(db, *, fcm_token: str, platform: str = "android") -> AppDevice:
+    device = AppDevice(fcm_token=fcm_token, platform=platform)
+    db.add(device)
+    db.commit()
+    db.refresh(device)
+    return device
+
+
+# ---------------------------------------------------------------------------
+# build_fcm_payload — payload shape contract with the companion app
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFcmPayload:
+    """The data-only payload shape is the contract with [2C-06]."""
+
+    def test_payload_uses_data_only_with_high_priority(self, db) -> None:
+        notif = _make_pending_notification(
+            db, canned_responses=["yes", "no", "snooze"],
+        )
+        payload = build_fcm_payload(notif)
+        assert "notification" not in payload, (
+            "FCM payload must be data-only; the notification field would let "
+            "Android render a non-actionable toast and the plugin would never "
+            "see the data."
+        )
+        assert payload["android"] == {"priority": "HIGH"}
+        data = payload["data"]
+        assert data["notification_id"] == str(notif.id)
+        assert data["notification_type"] == "habit_nudge"
+        assert data["message"] == "Time to stretch!"
+        assert json.loads(data["canned_responses"]) == ["yes", "no", "snooze"]
+        assert data["scheduled_date"] == notif.scheduled_date.isoformat()
+        assert data["rule_id"] == ""
+
+    def test_null_canned_responses_serialises_as_empty_array(self, db) -> None:
+        notif = _make_pending_notification(db, canned_responses=None)
+        payload = build_fcm_payload(notif)
+        assert json.loads(payload["data"]["canned_responses"]) == []
+
+    def test_data_values_are_all_strings(self, db) -> None:
+        """FCM v1 ``data`` is ``map<string, string>`` — coercion is mandatory."""
+        notif = _make_pending_notification(db)
+        data = build_fcm_payload(notif)["data"]
+        for key, value in data.items():
+            assert isinstance(value, str), (
+                f"data[{key!r}] is {type(value).__name__}, must be str"
+            )
+
+
+# ---------------------------------------------------------------------------
+# dispatch_push — broadcast + invalidation cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchPush:
+    """Direct tests of ``dispatch_push`` against a fixture device set."""
+
+    def test_no_devices_no_calls(self, db, mock_fcm_client) -> None:
+        notif = _make_pending_notification(db)
+        sent = dispatch_push(notif, db)
+        assert sent == 0
+        assert mock_fcm_client == []
+
+    def test_broadcasts_to_every_registered_device(
+        self, db, mock_fcm_client,
+    ) -> None:
+        _register_device(db, fcm_token="token-1")
+        _register_device(db, fcm_token="token-2")
+        _register_device(db, fcm_token="token-3")
+
+        notif = _make_pending_notification(db)
+        sent = dispatch_push(notif, db)
+
+        assert sent == 3
+        assert {c.fcm_token for c in mock_fcm_client} == {
+            "token-1", "token-2", "token-3",
+        }
+        for call in mock_fcm_client:
+            assert call.payload["android"]["priority"] == "HIGH"
+            assert call.payload["data"]["notification_id"] == str(notif.id)
+
+    def test_unregistered_token_removes_device(
+        self, db, mock_fcm_client,
+    ) -> None:
+        _register_device(db, fcm_token="good-token")
+        _register_device(db, fcm_token="dead-token")
+
+        # First call → SENT (good-token), second → UNREGISTERED (dead-token).
+        # Insertion order in app_devices is deterministic by registered_at.
+        mock_fcm_client.next_results.extend([
+            FcmResult(status=FcmStatus.SENT, http_status=200),
+            FcmResult(
+                status=FcmStatus.UNREGISTERED,
+                http_status=404,
+                error_code="UNREGISTERED",
+            ),
+        ])
+
+        notif = _make_pending_notification(db)
+        sent = dispatch_push(notif, db)
+
+        assert sent == 1
+        # The dead token row is gone; the live one survives.
+        remaining_tokens = {
+            row.fcm_token for row in db.query(AppDevice).all()
+        }
+        assert remaining_tokens == {"good-token"}
+
+    def test_invalid_argument_token_removes_device(
+        self, db, mock_fcm_client,
+    ) -> None:
+        _register_device(db, fcm_token="bad-token")
+        mock_fcm_client.next_results.append(
+            FcmResult(
+                status=FcmStatus.INVALID_ARGUMENT,
+                http_status=400,
+                error_code="INVALID_ARGUMENT",
+            ),
+        )
+        notif = _make_pending_notification(db)
+        dispatch_push(notif, db)
+        assert db.query(AppDevice).count() == 0
+
+    def test_transient_error_keeps_device(self, db, mock_fcm_client) -> None:
+        _register_device(db, fcm_token="rate-limited")
+        mock_fcm_client.next_results.append(
+            FcmResult(status=FcmStatus.RATE_LIMITED, http_status=429),
+        )
+        notif = _make_pending_notification(db)
+        dispatch_push(notif, db)
+        # Rate-limited tokens stay registered — only UNREGISTERED /
+        # INVALID_ARGUMENT trigger removal.
+        assert db.query(AppDevice).count() == 1
+
+
+# ---------------------------------------------------------------------------
+# PATCH integration — pending → delivered triggers FCM dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestPatchHandlerDispatch:
+    """``PATCH /api/notifications/{id}`` with status=delivered fires FCM."""
+
+    def test_patch_to_delivered_invokes_fcm_for_each_device(
+        self, client: TestClient, db, mock_fcm_client,
+    ) -> None:
+        _register_device(db, fcm_token="patch-token-1")
+        _register_device(db, fcm_token="patch-token-2")
+        notif = _make_pending_notification(db)
+
+        resp = client.patch(
+            f"/api/notifications/{notif.id}",
+            json={"status": "delivered"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "delivered"
+
+        assert {c.fcm_token for c in mock_fcm_client} == {
+            "patch-token-1", "patch-token-2",
+        }
+        for call in mock_fcm_client:
+            data = call.payload["data"]
+            assert data["notification_id"] == str(notif.id)
+            assert data["notification_type"] == "habit_nudge"
+            assert data["message"] == "Time to stretch!"
+
+    def test_patch_to_other_field_does_not_dispatch(
+        self, client: TestClient, db, mock_fcm_client,
+    ) -> None:
+        _register_device(db, fcm_token="should-not-fire")
+        notif = _make_pending_notification(db)
+
+        resp = client.patch(
+            f"/api/notifications/{notif.id}",
+            json={"message": "Updated copy"},
+        )
+        assert resp.status_code == 200
+        assert mock_fcm_client == []
+
+    def test_patch_dispatch_failure_does_not_break_response(
+        self, client: TestClient, db, monkeypatch,
+    ) -> None:
+        """A raising dispatch_push is logged, not surfaced as a 500."""
+        from app.routers import notification as notif_router
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("FCM service unavailable")
+
+        monkeypatch.setattr(notif_router, "dispatch_push", _boom)
+
+        notif = _make_pending_notification(db)
+        resp = client.patch(
+            f"/api/notifications/{notif.id}",
+            json={"status": "delivered"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "delivered"
+
+
+# ---------------------------------------------------------------------------
+# Promoter integration — AC #1 carry-forward from [2C-05a] PR #212 D-18
+# ---------------------------------------------------------------------------
+
+
+class TestPromoterDispatchesFcm:
+    """The delivery promoter must invoke FCM dispatch on transition.
+
+    Per [2C-05] AC #1 ("verify FCM dispatch has been invoked"), originally
+    deferred from [2C-05a] PR #212 (deviation D-18) because the dispatch
+    path did not exist yet. This ticket inherits that obligation: when
+    the promoter promotes a row from ``pending`` to ``delivered``, it
+    must trigger ``dispatch_push`` exactly as the PATCH handler does.
+    """
+
+    def test_promoter_calls_fcm_for_each_promoted_row(
+        self, db, mock_fcm_client,
+    ) -> None:
+        _register_device(db, fcm_token="promoter-token")
+
+        notif = _make_pending_notification(db)
+
+        promoted = delivery_promoter.promote_due_notifications(db)
+
+        assert promoted == 1
+        assert len(mock_fcm_client) == 1
+        call = mock_fcm_client[0]
+        assert call.fcm_token == "promoter-token"
+        assert call.payload["data"]["notification_id"] == str(notif.id)
+
+    def test_promoter_dispatch_failure_does_not_block_promotion(
+        self, db, monkeypatch,
+    ) -> None:
+        """A raising dispatch_push is logged but does not stop the row promotion."""
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("dispatch went sideways")
+
+        monkeypatch.setattr(delivery_promoter, "dispatch_push", _boom)
+
+        notif = _make_pending_notification(db)
+        promoted = delivery_promoter.promote_due_notifications(db)
+
+        assert promoted == 1
+        db.refresh(notif)
+        assert notif.status == "delivered"
+
+    def test_promoter_skips_dispatch_when_no_devices(
+        self, db, mock_fcm_client,
+    ) -> None:
+        """No devices registered → promotion still happens, no FCM calls."""
+        notif = _make_pending_notification(db)
+        promoted = delivery_promoter.promote_due_notifications(db)
+
+        assert promoted == 1
+        db.refresh(notif)
+        assert notif.status == "delivered"
+        assert mock_fcm_client == []

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,0 +1,241 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for the App Device registration endpoints ([2C-05])."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.auth import AppBearerAuthMiddleware
+from app.database import get_db
+from app.models import AppDevice
+from app.routers.devices import router as devices_router
+from tests.conftest import TestingSessionLocal
+
+DEVICES_PATH = "/api/app/devices"
+TOKEN_A = "fcm-token-aaaaaaaaaaaaaaa"
+TOKEN_B = "fcm-token-bbbbbbbbbbbbbbb"
+
+
+# ---------------------------------------------------------------------------
+# POST — register / upsert
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterDevice:
+    """``POST /api/app/devices`` insert + upsert semantics."""
+
+    def test_first_registration_returns_201(self, client: TestClient) -> None:
+        resp = client.post(
+            DEVICES_PATH,
+            json={"fcm_token": TOKEN_A, "platform": "android", "label": "Pixel 8"},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["fcm_token"] == TOKEN_A
+        assert body["platform"] == "android"
+        assert body["label"] == "Pixel 8"
+        assert "id" in body
+        assert "registered_at" in body
+        assert "last_seen_at" in body
+
+    def test_duplicate_token_returns_200_with_updated_last_seen(
+        self, client: TestClient,
+    ) -> None:
+        first = client.post(
+            DEVICES_PATH, json={"fcm_token": TOKEN_A, "platform": "android"},
+        )
+        assert first.status_code == 201
+        first_seen = first.json()["last_seen_at"]
+        first_id = first.json()["id"]
+
+        second = client.post(
+            DEVICES_PATH,
+            json={"fcm_token": TOKEN_A, "platform": "android", "label": "renamed"},
+        )
+        assert second.status_code == 200
+        body = second.json()
+        assert body["id"] == first_id
+        assert body["label"] == "renamed"
+        assert body["last_seen_at"] >= first_seen
+
+    def test_invalid_platform_returns_422(self, client: TestClient) -> None:
+        resp = client.post(
+            DEVICES_PATH,
+            json={"fcm_token": TOKEN_A, "platform": "windows-phone"},
+        )
+        assert resp.status_code == 422
+
+    def test_missing_fcm_token_returns_422(self, client: TestClient) -> None:
+        resp = client.post(DEVICES_PATH, json={"platform": "android"})
+        assert resp.status_code == 422
+
+    def test_empty_fcm_token_returns_422(self, client: TestClient) -> None:
+        resp = client.post(
+            DEVICES_PATH, json={"fcm_token": "", "platform": "android"},
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET list
+# ---------------------------------------------------------------------------
+
+
+class TestListDevices:
+    """``GET /api/app/devices`` returns the envelope shape."""
+
+    def test_empty_list(self, client: TestClient) -> None:
+        resp = client.get(DEVICES_PATH)
+        assert resp.status_code == 200
+        assert resp.json() == {"items": [], "count": 0}
+
+    def test_lists_registered_devices(self, client: TestClient) -> None:
+        client.post(
+            DEVICES_PATH, json={"fcm_token": TOKEN_A, "platform": "android"},
+        )
+        client.post(
+            DEVICES_PATH, json={"fcm_token": TOKEN_B, "platform": "ios"},
+        )
+        resp = client.get(DEVICES_PATH)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 2
+        tokens = {item["fcm_token"] for item in body["items"]}
+        assert tokens == {TOKEN_A, TOKEN_B}
+
+
+# ---------------------------------------------------------------------------
+# DELETE
+# ---------------------------------------------------------------------------
+
+
+class TestUnregisterDevice:
+    """``DELETE /api/app/devices/{id}`` removes the row."""
+
+    def test_delete_removes_device(self, client: TestClient, db) -> None:
+        created = client.post(
+            DEVICES_PATH, json={"fcm_token": TOKEN_A, "platform": "android"},
+        ).json()
+
+        resp = client.delete(f"{DEVICES_PATH}/{created['id']}")
+        assert resp.status_code == 204
+
+        remaining = db.query(AppDevice).count()
+        assert remaining == 0
+
+    def test_delete_nonexistent_returns_404(self, client: TestClient) -> None:
+        bogus = uuid.uuid4()
+        resp = client.delete(f"{DEVICES_PATH}/{bogus}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Bearer-auth integration — devices router gated by /api/app/* middleware
+# ---------------------------------------------------------------------------
+
+
+class TestDevicesBearerAuth:
+    """The devices router sits behind ``AppBearerAuthMiddleware``.
+
+    ``app/main.py`` mounts the middleware only when ``APP_BEARER_TOKEN``
+    is set, so the default test client (token unset) does not exercise
+    the gate. Build a fresh app with the middleware enabled to prove
+    that routing is correct: ``POST /api/app/devices`` without the
+    bearer is 401, with the bearer is normal CRUD.
+    """
+
+    TOKEN = "test-bearer-fffffffffffffffff"  # noqa: S105 — fixture only
+
+    def _build_app(self, db) -> TestClient:
+        app = FastAPI()
+        app.add_middleware(AppBearerAuthMiddleware, token=self.TOKEN)
+        app.include_router(devices_router, prefix="/api/app/devices")
+
+        def _override():
+            try:
+                yield db
+            finally:
+                pass
+
+        app.dependency_overrides[get_db] = _override
+        return TestClient(app)
+
+    def test_post_without_bearer_returns_401(self, db) -> None:
+        client = self._build_app(db)
+        resp = client.post(
+            DEVICES_PATH,
+            json={"fcm_token": TOKEN_A, "platform": "android"},
+        )
+        assert resp.status_code == 401
+
+    def test_post_with_bearer_returns_201(self, db) -> None:
+        client = self._build_app(db)
+        resp = client.post(
+            DEVICES_PATH,
+            json={"fcm_token": TOKEN_A, "platform": "android"},
+            headers={"Authorization": f"Bearer {self.TOKEN}"},
+        )
+        assert resp.status_code == 201
+
+
+# ---------------------------------------------------------------------------
+# Direct ORM model tests — insert / upsert / delete contract
+# ---------------------------------------------------------------------------
+
+
+class TestAppDeviceModel:
+    """Direct ORM-level checks of the ``app_devices`` mapping."""
+
+    def test_insert_and_unique_token(self, db) -> None:
+        device = AppDevice(fcm_token=TOKEN_A, platform="android", label="Pixel")
+        db.add(device)
+        db.commit()
+        db.refresh(device)
+        assert device.id is not None
+        assert device.registered_at is not None
+        assert device.last_seen_at is not None
+
+    def test_duplicate_fcm_token_violates_unique(self, db) -> None:
+        from sqlalchemy.exc import IntegrityError
+
+        db.add(AppDevice(fcm_token=TOKEN_A, platform="android"))
+        db.commit()
+
+        db.add(AppDevice(fcm_token=TOKEN_A, platform="ios"))
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+    def test_delete_drops_row(self, db) -> None:
+        device = AppDevice(fcm_token=TOKEN_A, platform="android")
+        db.add(device)
+        db.commit()
+
+        db.delete(device)
+        db.commit()
+
+        # Use a fresh session to confirm the delete is committed.
+        verify = TestingSessionLocal()
+        try:
+            assert verify.query(AppDevice).count() == 0
+        finally:
+            verify.close()

--- a/tests/test_fcm_client.py
+++ b/tests/test_fcm_client.py
@@ -1,0 +1,121 @@
+# BRAIN 3.0 — AI-powered personal operating system for ADHD
+# Copyright (C) 2026 L (WilliM233)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for the FCM client surface (``app/services/fcm.py``).
+
+Covers configuration gating and the FCM error-body → :class:`FcmResult`
+classifier — the two pieces of pure logic the dispatch path relies on.
+The actual HTTPS round-trip is mocked in ``test_delivery_dispatch.py``.
+"""
+
+from __future__ import annotations
+
+from app.services import fcm
+from app.services.fcm import FcmStatus, _classify_error, send_notification_to_device
+
+
+class TestIsConfigured:
+    """Both env values must be set for FCM dispatch to be attempted."""
+
+    def test_returns_false_when_project_id_missing(self, monkeypatch) -> None:
+        monkeypatch.setattr(fcm.settings, "FCM_PROJECT_ID", None)
+        monkeypatch.setattr(
+            fcm.settings, "FCM_SERVICE_ACCOUNT_JSON_PATH", "/path/to/sa.json",
+        )
+        assert fcm.is_configured() is False
+
+    def test_returns_false_when_service_account_missing(self, monkeypatch) -> None:
+        monkeypatch.setattr(fcm.settings, "FCM_PROJECT_ID", "demo-project")
+        monkeypatch.setattr(fcm.settings, "FCM_SERVICE_ACCOUNT_JSON_PATH", None)
+        assert fcm.is_configured() is False
+
+    def test_returns_true_when_both_set(self, monkeypatch) -> None:
+        monkeypatch.setattr(fcm.settings, "FCM_PROJECT_ID", "demo-project")
+        monkeypatch.setattr(
+            fcm.settings, "FCM_SERVICE_ACCOUNT_JSON_PATH", "/run/secrets/sa.json",
+        )
+        assert fcm.is_configured() is True
+
+
+class TestSendWhenNotConfigured:
+    """Calling send when FCM is unconfigured returns NOT_CONFIGURED, not raise."""
+
+    def test_returns_not_configured(self, monkeypatch) -> None:
+        monkeypatch.setattr(fcm.settings, "FCM_PROJECT_ID", None)
+        monkeypatch.setattr(fcm.settings, "FCM_SERVICE_ACCOUNT_JSON_PATH", None)
+
+        result = send_notification_to_device("any-token", {"data": {}})
+
+        assert result.status == FcmStatus.NOT_CONFIGURED
+        assert result.token_invalidated is False
+
+
+class TestClassifyError:
+    """``_classify_error`` maps FCM v1 error envelopes onto status enums."""
+
+    def test_unregistered_via_error_code(self) -> None:
+        body = {
+            "error": {
+                "code": 404,
+                "status": "NOT_FOUND",
+                "message": "Requested entity was not found.",
+                "details": [{"errorCode": "UNREGISTERED"}],
+            },
+        }
+        result = _classify_error(404, body)
+        assert result.status == FcmStatus.UNREGISTERED
+        assert result.token_invalidated is True
+        assert result.error_code == "UNREGISTERED"
+
+    def test_invalid_argument_via_error_code(self) -> None:
+        body = {
+            "error": {
+                "code": 400,
+                "status": "INVALID_ARGUMENT",
+                "message": "The registration token is not a valid FCM token.",
+                "details": [{"errorCode": "INVALID_ARGUMENT"}],
+            },
+        }
+        result = _classify_error(400, body)
+        assert result.status == FcmStatus.INVALID_ARGUMENT
+        assert result.token_invalidated is True
+
+    def test_unauthenticated_classified_as_auth_failed(self) -> None:
+        body = {"error": {"status": "UNAUTHENTICATED", "message": "bad token"}}
+        result = _classify_error(401, body)
+        assert result.status == FcmStatus.AUTH_FAILED
+        assert result.token_invalidated is False
+
+    def test_rate_limited(self) -> None:
+        body = {"error": {"status": "RESOURCE_EXHAUSTED", "message": "too many"}}
+        result = _classify_error(429, body)
+        assert result.status == FcmStatus.RATE_LIMITED
+        assert result.token_invalidated is False
+
+    def test_server_error_default(self) -> None:
+        body = {"error": {"status": "INTERNAL", "message": "boom"}}
+        result = _classify_error(500, body)
+        assert result.status == FcmStatus.SERVER_ERROR
+        assert result.token_invalidated is False
+
+    def test_404_without_explicit_error_code_still_unregistered(self) -> None:
+        """Defensive: a 404 without details still flags the token as dead."""
+        result = _classify_error(404, {})
+        assert result.status == FcmStatus.UNREGISTERED
+
+    def test_400_without_explicit_error_code_still_invalid(self) -> None:
+        result = _classify_error(400, {})
+        assert result.status == FcmStatus.INVALID_ARGUMENT


### PR DESCRIPTION
Closes #205

## Verification

- `ruff check .` — ✅ Pass (no errors)
- `pytest -v` — ✅ Pass (1420 passed, 8 warnings; +39 new tests vs. develop's 1381)
- Migration applied locally on brain3-dev: ✅ Yes (Postgres `app_devices` is exercised by the postgres-backed test fixtures used elsewhere; SQLite `Base.metadata.create_all` covers the in-process test path)
- Postgres-backed test confirmed: ✅ Yes (`test_rules_postgres` continues to pass with the new model)

Ran locally against develop HEAD at `06ded81` immediately before opening this PR.

## Summary

Closes the v2.0.0 server cluster: the companion app can now register a device and BRAIN can fan a notification out to every registered device on the `pending → delivered` transition. New `app_devices` table + bearer-gated CRUD endpoints; FCM HTTP v1 client built on `google-auth`; `dispatch_push` wired into both the interactive PATCH handler and the [2C-05a] delivery promoter.

## Changes

- **Migration `023_create_app_devices.py`** — new `app_devices` table with unique `fcm_token`, platform check (`android | ios`), and `registered_at` / `last_seen_at` timestamps. Phase 2 is single-user, so the table has no `user_id`.
- **`app/models.py::AppDevice`** — SQLAlchemy 2.0 mapping mirroring the migration.
- **`app/schemas/devices.py`** — `DeviceRegisterRequest` (max 4096-char `fcm_token`, platform literal, optional label up to 200 chars), `DeviceResponse`, `DeviceListResponse` envelope.
- **`app/routers/devices.py`** — `POST /api/app/devices` with upsert semantics (201 on insert, 200 on refresh with `last_seen_at` bumped and platform/label updated), `GET /api/app/devices` listing, `DELETE /api/app/devices/{id}`. Mounted under the `/api/app/*` prefix in `app/main.py`, so the existing `AppBearerAuthMiddleware` from [2C-01] gates it without further wiring.
- **`app/services/fcm.py`** — single-function FCM HTTP v1 client. `send_notification_to_device(fcm_token, payload) -> FcmResult` posts to `https://fcm.googleapis.com/v1/projects/{project_id}/messages:send` with a service-account-issued OAuth2 bearer (cached on the credentials object, refreshed by `google-auth`). Returns a structured `FcmResult` (`FcmStatus` enum + `token_invalidated` convenience), with explicit handling for 400/INVALID_ARGUMENT, 404/UNREGISTERED, 401/403/AUTH_FAILED, 429/RATE_LIMITED, and network errors. `google-auth` is imported lazily so tests that mock the send path do not need it on the import path.
- **`app/services/delivery.py::dispatch_push`** — broadcasts a data-only FCM payload (`notification_id`, `notification_type`, `message`, JSON-encoded `canned_responses`, `scheduled_date`, `rule_id`; `android.priority` HIGH) to every row in `app_devices`. Tokens that come back UNREGISTERED / INVALID_ARGUMENT are hard-deleted; transient failures (rate-limit, server error) leave the device registered. Per-device errors are caught in the loop so one bad device cannot stop the rest.
- **`app/routers/notification.py`** — PATCH handler dispatches synchronously after the existing `status='delivered'` `expires_at` recomputation. A raising `dispatch_push` is logged and never escalated to a 500.
- **`app/services/delivery_promoter.py`** — `promote_due_notifications` now calls `dispatch_push` for each row it transitions, satisfying the [2C-05] AC #1 obligation carried forward from [2C-05a] PR #212 deviation D-18. Per-row failures are caught and logged so one bad row never stops the rest of the batch.
- **`app/config.py` + `.env.example`** — adds `BRAIN3_FCM_PROJECT_ID` and `BRAIN3_FCM_SERVICE_ACCOUNT_JSON_PATH`. Both unset in dev → FCM dispatch returns `NOT_CONFIGURED` instead of attempting a send (mirrors the `BRAIN3_APP_BEARER_TOKEN` graceful-degradation pattern).
- **`requirements.txt`** — adds `google-auth==2.36.0`.
- **Tests** — `test_devices.py` (CRUD, validation, bearer-auth via a fresh app with the middleware enabled, ORM unique-constraint check), `test_delivery_dispatch.py` (payload contract, dispatch broadcast, invalidated-token cleanup, transient-error retention, PATCH integration, promoter integration with the D-18 carry-forward), `test_fcm_client.py` (configuration gating, NOT_CONFIGURED return without import-time `google-auth`, error-envelope classifier).
- **`CHANGELOG.md`** — Unreleased entry for #205.

## How to Verify

1. `git fetch origin && git checkout feat/2C-05-fcm-dispatch && pip install -r requirements.txt` (the only new dep is `google-auth`).
2. `alembic upgrade head` against a Postgres dev container — should apply `023_create_app_devices.py` cleanly.
3. `python -m ruff check .` — passes clean.
4. `python -m pytest -v` — 1420 tests pass (39 new).
5. With `BRAIN3_APP_BEARER_TOKEN` set in `.env`, exercise the curl flow:
   - `POST /api/app/devices` with `{"fcm_token":"abc","platform":"android","label":"Pixel"}` — 201 on first call, 200 on a repeat with the same token.
   - `GET /api/app/devices` — lists the registered device.
   - PATCH a `pending` notification to `delivered` — log lines from `app.services.delivery` show one dispatch attempt per registered device. Without `BRAIN3_FCM_PROJECT_ID` set, attempts return `NOT_CONFIGURED` and no FCM traffic leaves the box.
6. Live FCM provisioning (Pass 2 §3 checklist — Firebase project, service-account JSON delivered to TrueNAS, env vars set on the prod compose) is the L-side prerequisite called out in the spec; the code path is dormant until that happens.

## Deviations

- **D-19: Migration revision is `023_create_app_devices.py`, not `022`.** Spec called the migration `022_create_app_devices.py`, but `022_add_scheduled_date_to_notifications.py` was added in #209 between Stellan's spec and this implementation. Used `023` with `down_revision="22a1b2c3d4e5"` so the chain is contiguous.
- **D-20: PATCH-handler line numbers drifted.** Spec referenced `app/routers/notification.py` lines 225–276 / line 266 for the PATCH handler and the `status='delivered'` branch. The current file is ~248–300 / line 289 after the [2C-03] idempotency and [2C-04] expiry-defaults landings. Same `updates.get("status") == "delivered"` branch — implementation follows the spec's intent against the codebase as it stands today (per agent identity's cardinal rule).
- **D-21: Promoter also dispatches.** The ticket spec describes hooking the PATCH handler. The brief and ticket §AC #1 also carry forward the [2C-05a] PR #212 deviation D-18 obligation that the promoter must invoke FCM dispatch when it performs the `pending → delivered` transition. Wired into both surfaces with shared `dispatch_push` so the v2.0.0 demo works regardless of which transition surface fires the row.
- **D-22: FCM dispatch is synchronous on the asyncio promoter tick.** `_tick` is a sync function called between `await asyncio.sleep` calls, so a synchronous network round-trip blocks the event loop for the duration of the FCM POST. Acceptable at Phase 2 single-user scale (one user, ~1 device, FCM round-trip ≪ promoter interval). Async / job-queue dispatch is the spec's Out-of-Scope Chunk 5 hardening item — flagging here so it is not lost.
- **D-23: FCM `data` values coerced to strings; `rule_id` is `""` when null.** FCM v1 requires `data: map<string, string>`; the spec's payload sketch showed `rule_id: "<uuid-or-empty>"` literally. Coerced UUID/None to `str(uuid)` / `""` and JSON-encoded `canned_responses` so the entire `data` map is strings. The companion app native layer ([2C-06]) parses the JSON-encoded array.
- **D-24: Hard-delete on `UNREGISTERED` / `INVALID_ARGUMENT`.** Spec offered soft-delete vs. hard-delete with a recommendation to "lean toward hard-delete for simplicity"; chose hard-delete. The companion app re-registers on next launch via `POST /api/app/devices`, so a dead row coming back is just a fresh insert.

## Test Results

```
ruff check .  →  All checks passed!
pytest        →  1420 passed, 8 warnings in 2631.86s (0:43:51)
```

The 8 warnings are pre-existing `DeprecationWarning`s on `@app.on_event` (FastAPI lifespan event migration) — not introduced by this PR.

## Acceptance Checklist

- [x] Migration applies cleanly. `AppDevice` model tests cover insert, upsert, delete.
- [x] `POST /api/app/devices` with valid bearer + payload → 201; duplicate token → 200 with `last_seen_at` updated.
- [x] `POST /api/app/devices` without bearer → 401.
- [x] Integration test: PATCH a notification to `delivered`, mock FCM client called with the expected payload shape for each registered device.
- [x] Integration test: FCM returns `UNREGISTERED` → device row removed from `app_devices`.
- [x] `tests/test_devices.py` covers happy path, upsert, auth failure, input validation.
- [x] AC #1 carry-forward from [2C-05a] PR #212 D-18: integration test asserts the delivery promoter's `pending → delivered` transition triggers FCM dispatch.
- [ ] FCM provisioning checklist (§3 of Pass 2 Summary) end-to-end: out of scope for the code PR — L-side prerequisite per the ticket "L-side prerequisites" block. Code path is dormant until env vars are set on the prod compose.

## Watch-Items

- **"First consumer instantiates" pattern** (Group 1 Stellan Observation 1, brief §5): `app/services/delivery.py` is a new service file whose only consumer at PR time is the dispatch wiring in this PR. Brief notes the second instance of the pattern triggers CLAUDE.md codification — flagging for BRAIN's call.
